### PR TITLE
[10] [FIX] shopinvader: Don't change the type of an existing field

### DIFF
--- a/shopinvader/models/product_template.py
+++ b/shopinvader/models/product_template.py
@@ -29,7 +29,6 @@ class ProductTemplate(models.Model):
         store=False,
         search=_search_locomotive_backend_ids)
 
-    description = fields.Html(translate=True)
     active = fields.Boolean(inverse='_inverse_active')
 
     @api.multi


### PR DESCRIPTION
When you change the type of an existing field you introduce an incompatibility issue with others modules relying of the original type of the field