### PR TITLE
10.0 auth_api_key fixes method name, auth method and user_id in view

### DIFF
--- a/auth_api_key/models/auth_api_key.py
+++ b/auth_api_key/models/auth_api_key.py
@@ -43,6 +43,6 @@ class AuthApiKey(models.Model):
         res = {}
         for key in keychain_accounts:
             _id = int(key.technical_name.split(',')[1])
-            api_key = key.get_password()
+            api_key = key._get_password()
             res[api_key] = _id
         return res

--- a/auth_api_key/models/ir_http.py
+++ b/auth_api_key/models/ir_http.py
@@ -26,7 +26,7 @@ class IrHttp(models.AbstractModel):
             auth_api_key = request.env['auth.api.key'].retrieve_from_api_key(
                 api_key
             )
-            if api_key:
+            if auth_api_key:
                 # reset _env on the request since we change the uid...
                 # the next call to env will instantiate an new
                 # odoo.api.Environment with the user defined on the

--- a/auth_api_key/views/auth_api_key.xml
+++ b/auth_api_key/views/auth_api_key.xml
@@ -15,6 +15,7 @@
                         <field name="name" class="oe_inline"/>
                     </h1>
                      <group name="config" colspan="4" col="4">
+                         <field name="user_id" colspan="4"/>
                          <field name="password" colspan="4"/>
                      </group>
                 </sheet>


### PR DESCRIPTION
Fix the method name get_password (changed from keychain 10.0.1 to 10.0.2),
Fix the auth method (If the user set the Api-Key in the header, it was always authenticated)
Imp Show the user_id in the form view
