### PR TITLE
[CHG] check that field used by components has been loaded before usage

### DIFF
--- a/shopinvader/components/event_listeners.py
+++ b/shopinvader/components/event_listeners.py
@@ -43,11 +43,15 @@ class ShopinvaderRecordListener(Component):
     def on_record_write(self, record, fields=None):
         if fields == ['shopinvader_bind_ids']:
             return
+        if 'shopinvader_bind_ids' not in record._fields:
+            return
         for binding in record.shopinvader_bind_ids:
             binding.with_delay().export_record(_fields=fields)
 
     def on_record_unlink(self, record, fields=None):
         """ Unlink all binding before removing the record in order to
         trigger an event for deleting the record in locomotive"""
+        if 'shopinvader_bind_ids' not in record._fields:
+            return
         for binding in record.shopinvader_bind_ids:
             binding.unlink()


### PR DESCRIPTION
To avoid to upgrade everything (-u all) when deploying on a server, we use https://github.com/acsone/click-odoo-contrib coupled with https://github.com/OCA/server-tools/tree/10.0/module_auto_update. This addon uses checksum to compare which addons has been changed to make chirugical upgrades.

As it works just like a click on upgrade in the web interfaces, the components registry is loaded first because of this line https://github.com/OCA/connector/blob/10.0/component/builder.py#L66  but ,unfortunatly, before the odoo registry so that the field is not yet known on the model.

So an update fails with:
`2018-05-07 13:05:02,725 26755 INFO odoo-recette-10 odoo.modules.loading: loading stock/data/default_barcode_patterns.xml
2018-05-07 13:05:02,745 26755 INFO odoo-recette-10 odoo.modules.loading: loading stock/data/stock_data.xml
2018-05-07 13:05:49,515 26755 INFO odoo-recette-10 odoo.modules.loading: loading stock/data/stock_data.yml
2018-05-07 13:05:49,617 26755 ERROR odoo-recette-10 odoo.tools.yaml_import: 'res.partner' object has no attribute 'shopinvader_bind_ids'
Traceback (most recent call last):
  File "/home/odoo-recette10/instance/venv-27.0.6/local/lib/python2.7/site-packages/odoo/tools/yaml_import.py", line 880, in process
    self._process_node(node)
  File "/home/odoo-recette10/instance/venv-27.0.6/local/lib/python2.7/site-packages/odoo/tools/yaml_import.py", line 893, in _process_node
    self.process_python(node)
  File "/home/odoo-recette10/instance/venv-27.0.6/local/lib/python2.7/site-packages/odoo/tools/yaml_import.py", line 608, in process_python
    unsafe_eval(code_obj, {'ref': self.get_id}, code_context)
  File "/home/odoo-recette10/instance/venv-27.0.6/local/lib/python2.7/site-packages/odoo/addons/stock/data/stock_data.yml", line 4, in <module>
    self.write({'property_stock_customer':main_warehouse.lot_stock_id.id})
  File "/home/odoo-recette10/instance/venv-27.0.6/local/lib/python2.7/site-packages/odoo/addons/base_partner_sequence/models/partner.py", line 57, in write
    super(ResPartner, partner).write(vals)
  File "/home/odoo-recette10/instance/venv-27.0.6/local/lib/python2.7/site-packages/odoo/addons/base/res/res_partner.py", line 514, in write
    result = result and super(Partner, self).write(vals)
  File "/home/odoo-recette10/instance/venv-27.0.6/local/lib/python2.7/site-packages/odoo/addons/mail/models/mail_thread.py", line 274, in write
    result = super(MailThread, self).write(values)
  File "/home/odoo-recette10/instance/venv-27.0.6/local/lib/python2.7/site-packages/odoo/addons/connector/producer.py", line 37, in write
    result = super(Base, self).write(vals)
  File "/home/odoo-recette10/instance/venv-27.0.6/local/lib/python2.7/site-packages/odoo/addons/component_event/models/base.py", line 102, in write
    self._event('on_record_write').notify(record, fields=fields)
  File "/home/odoo-recette10/instance/venv-27.0.6/local/lib/python2.7/site-packages/odoo/addons/component_event/components/event.py", line 188, in notify
    event(*args, **kwargs)
  File "/home/odoo-recette10/instance/venv-27.0.6/local/lib/python2.7/site-packages/odoo/addons/component_event/components/event.py", line 158, in func_wrapper
    return func(*args, **kwargs)
  File "/home/odoo-recette10/instance/venv-27.0.6/local/lib/python2.7/site-packages/odoo/addons/shopinvader/components/event_listeners.py", line 46, in on_record_write
    for binding in record.shopinvader_bind_ids:
AttributeError: 'res.partner' object has no attribute 'shopinvader_bind_ids'
`