### PR TITLE
[FIX] Fix issue about cache/env who doesn't recompute correctly

### DIFF
--- a/shopinvader/models/locomotive_backend.py
+++ b/shopinvader/models/locomotive_backend.py
@@ -121,11 +121,10 @@ class LocomotiveBackend(models.Model):
 
     @api.multi
     def bind_all_category(self):
-        self.with_context(recompute=False)._bind_all_content(
+        self._bind_all_content(
             'product.category',
             'shopinvader.category',
             [])
-        self.recompute()
 
     def _send_notification(self, notification, record):
         self.ensure_one()


### PR DESCRIPTION
Fix issue about cache/env who doesn't recompute correctly shopinvader.category after binding

Original code:
```
@api.multi
    def bind_all_category(self):
        self.with_context(recompute=False)._bind_all_content(
            'product.category',
            'shopinvader.category',
            [])
        self.recompute()
```
Due to the with_context(...), binded shopinvader.category doesn't have any computed fields filled.
Even when doing this:
```
@api.multi
    def bind_all_category(self):
        self_ctx = self.with_context(recompute=False)
        self_ctx._bind_all_content(
            'product.category',
            'shopinvader.category',
            [])
        self_ctx.recompute()
```
The issue still there.
So we decide to remove the with_context(...) who is probably not useful.
The issue doesn't appears everytime, approximately 10% and we appears during unit test, randomly.