### PR TITLE
[10.0][ADD] Add the automatic binding of shopinvader.product and variants

### DIFF
--- a/shopinvader/__init__.py
+++ b/shopinvader/__init__.py
@@ -3,6 +3,7 @@
 # Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from . import components
 from . import controllers
 from . import models
 from . import services

--- a/shopinvader/__manifest__.py
+++ b/shopinvader/__manifest__.py
@@ -28,6 +28,7 @@
         "base_sparse_field_list_support",
         "base_url",
         "base_vat",
+        "component_event",
         "sale",
         "onchange_helper",
         'queue_job',

--- a/shopinvader/components/__init__.py
+++ b/shopinvader/components/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com).
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import product_product_event_listener

--- a/shopinvader/components/product_product_event_listener.py
+++ b/shopinvader/components/product_product_event_listener.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com).
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.addons.component.core import Component
+from odoo.addons.component_event import skip_if
+
+
+class ProductProductEventListener(Component):
+    _name = 'product.product.event.listener'
+    _inherit = 'base.connector.listener'
+
+    _apply_on = [
+        'product.product',
+    ]
+
+    @skip_if(lambda self, record, **kwargs:
+             not record.product_tmpl_id.shopinvader_bind_ids or
+             self.no_connector_export(record))
+    def on_record_create(self, record, fields=None):
+        """
+        Event listener on the create of product.product.
+        In case of the related product.template has been binded, we have to
+        bind every new product.product (checked with the skip_if(...).
+        By default, they shouldn't be binded (force active = False)
+        :param record: product.template recordset
+        :param fields: list of str
+        :return:
+        """
+        shopinv_products = record.mapped(
+            "product_tmpl_id.shopinvader_bind_ids")
+        shopinv_variants = self._launch_shopinvader_variant_creation(
+            shopinv_products)
+        # If at least 1 is True, force False
+        if any(shopinv_variants.mapped("active")):
+            shopinv_variants.write({
+                'active': False,
+            })
+
+    def _launch_shopinvader_variant_creation(self, shopinvader_products):
+        """
+        Launch the creation of the shopinvader.variant based on the (given)
+        shopinvader.product
+        :param shopinvader_products: shopinvader.product recordset
+        :return: shopinvader.variant recordset
+        """
+        shopinv_variants = self.env['shopinvader.variant'].browse()
+        for shopinv_product in shopinvader_products:
+            shopinv_variants |= shopinv_product._create_shopinvader_variant()
+        return shopinv_variants

--- a/shopinvader/models/product_product.py
+++ b/shopinvader/models/product_product.py
@@ -20,7 +20,11 @@ class ProductProduct(models.Model):
     shopinvader_bind_ids = fields.One2many(
         'shopinvader.variant',
         'record_id',
-        string='Shopinvader Binding')
+        string='Shopinvader Binding',
+        context={
+            'active_test': False,
+        },
+    )
 
     shopinvader_backend_ids = fields.Many2many(
         string='ShopInvader Backends',

--- a/shopinvader/models/product_template.py
+++ b/shopinvader/models/product_template.py
@@ -20,7 +20,12 @@ class ProductTemplate(models.Model):
     shopinvader_bind_ids = fields.One2many(
         'shopinvader.product',
         'record_id',
-        string='Shopinvader Binding')
+        string='Shopinvader Binding',
+        context={
+            'active_test': False,
+            'map_children': True,
+        },
+    )
 
     shopinvader_backend_ids = fields.Many2many(
         string='ShopInvader Backends',

--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -66,10 +66,10 @@ class ShopinvaderBackend(models.Model):
 
     @api.model
     def _default_last_step_id(self):
-        last_step = self.env['shopinvader.cart.step']
+        last_step = self.env['shopinvader.cart.step'].browse()
         try:
             last_step = self.env.ref('shopinvader.cart_end')
-        except Exception:
+        except ValueError:
             pass
         return last_step
 

--- a/shopinvader/models/shopinvader_variant.py
+++ b/shopinvader/models/shopinvader_variant.py
@@ -154,3 +154,23 @@ class ShopinvaderVariant(models.Model):
                 record.main = True
             else:
                 record.main = False
+
+    @api.multi
+    def toggle_published(self):
+        """
+        Toggle the active field
+        :return: dict
+        """
+        actual_active = self.filtered(
+            lambda s: s.active).with_prefetch(self._prefetch)
+        actual_inactive = self - actual_active
+        actual_inactive = actual_inactive.with_prefetch(self._prefetch)
+        if actual_inactive:
+            actual_inactive.write({
+                'active': True,
+            })
+        if actual_active:
+            actual_active.write({
+                'active': False,
+            })
+        return {}

--- a/shopinvader/tests/test_product.py
+++ b/shopinvader/tests/test_product.py
@@ -89,12 +89,13 @@ class ProductCase(ProductCommonCase):
 
     def test_product_category_with_one_lang(self):
         self.backend.bind_all_product()
+        self.backend.bind_all_category()
         product = self.env.ref('product.product_product_4')
         self.assertEqual(len(product.shopinvader_bind_ids), 1)
         shopinvader_product = product.shopinvader_bind_ids
         self.assertEqual(len(shopinvader_product.shopinvader_categ_ids), 3)
 
-    def test_product_category_with_one_lang(self):
+    def test_product_category_with_two_lang(self):
         lang = self.install_lang('base.lang_fr')
         self.backend.lang_ids |= lang
         self.backend.bind_all_category()
@@ -108,3 +109,148 @@ class ProductCase(ProductCommonCase):
                 self.assertEqual(binding.url_key, u'ipad-avec-ecran-retina')
             elif binding.lang_id.code == 'en_US':
                 self.assertEqual(binding.url_key, u'ipad-retina-display')
+
+    def test_create_product_binding1(self):
+        """
+        Test the creation of a product.template.
+        During the creation of a new product.template, Odoo create
+        automatically a new product.product.
+        If the product.template doesn't have a shopinvader.product, we should
+        create a new shopinvader.variant (because the product is not published)
+        But if it's published, we should create a shopinvader.variant for each
+        product.product related to this product.template.
+        So each time a product.product is created, we should check if we need
+        to create a shopinvader.variant.
+        For this test, we create a product.template not published (so no
+        shopinvader.variant should be created)
+        :return: bool
+        """
+        product_tmpl_obj = self.env['product.template'].with_context(
+            active_test=False)
+        product_values = {
+            'name': 'Shopinvader t-shirt',
+        }
+        product_tmpl = product_tmpl_obj.create(product_values)
+        self.assertFalse(product_tmpl.shopinvader_bind_ids)
+        product_product = product_tmpl.product_variant_ids
+        self.assertFalse(product_product.shopinvader_bind_ids)
+        return True
+
+    def test_create_product_binding2(self):
+        """
+        Test the creation of a product.template.
+        During the creation of a new product.template, Odoo create
+        automatically a new product.product.
+        If the product.template doesn't have a shopinvader.product, we should
+        create a new shopinvader.variant (because the product is not published)
+        But if it's published, we should create a shopinvader.variant for each
+        product.product related to this product.template.
+        So each time a product.product is created, we should check if we need
+        to create a shopinvader.variant.
+        For this test, we create a product.template who is not published
+        (but with a shopinvader.product related) so the related
+        product.product should have a shopinvader.variant.
+        :return: bool
+        """
+        backend = self.backend
+        product_tmpl_obj = self.env['product.template'].with_context(
+            active_test=False)
+        lang = self.env['res.lang']._lang_get(self.env.user.lang)
+        product_values = {
+            'name': 'Shopinvader t-shirt',
+            'shopinvader_bind_ids': [(0, False, {
+                'backend_id': backend.id,
+                'lang_id': lang.id,
+                'active': False,
+            })],
+        }
+        product_tmpl = product_tmpl_obj.create(product_values)
+        self.assertTrue(product_tmpl.shopinvader_bind_ids)
+        product_product = product_tmpl.product_variant_ids
+        self.assertEqual(len(product_product.shopinvader_bind_ids), 1)
+        self.assertFalse(product_product.shopinvader_bind_ids.active)
+        return True
+
+    def test_create_product_binding3(self):
+        """
+        Test the creation of a product.template.
+        During the creation of a new product.template, Odoo create
+        automatically a new product.product.
+        If the product.template doesn't have a shopinvader.product, we should
+        create a new shopinvader.variant (because the product is not published)
+        But if it's published, we should create a shopinvader.variant for each
+        product.product related to this product.template.
+        So each time a product.product is created, we should check if we need
+        to create a shopinvader.variant.
+        For this test, we create a product.template who is published
+        (with a shopinvader.product related and active = True) so the related
+        product.product should have a shopinvader.variant.
+        :return: bool
+        """
+        backend = self.backend
+        product_tmpl_obj = self.env['product.template'].with_context(
+            active_test=False)
+        lang = self.env['res.lang']._lang_get(self.env.user.lang)
+        product_values = {
+            'name': 'Shopinvader t-shirt',
+            'shopinvader_bind_ids': [(0, False, {
+                'backend_id': backend.id,
+                'lang_id': lang.id,
+                'active': True,
+            })],
+        }
+        product_tmpl = product_tmpl_obj.create(product_values)
+        self.assertTrue(product_tmpl.shopinvader_bind_ids)
+        product_product = product_tmpl.product_variant_ids
+        self.assertEqual(len(product_product.shopinvader_bind_ids), 1)
+        self.assertFalse(product_product.shopinvader_bind_ids.active)
+        return True
+
+    def test_create_product_binding4(self):
+        """
+        Test the creation of a product.template.
+        During the creation of a new product.template, Odoo create
+        automatically a new product.product.
+        If the product.template doesn't have a shopinvader.product, we should
+        create a new shopinvader.variant (because the product is not published)
+        But if it's published, we should create a shopinvader.variant for each
+        product.product related to this product.template.
+        So each time a product.product is created, we should check if we need
+        to create a shopinvader.variant.
+        For this test, we create a product.template who is published
+        (with a shopinvader.product related and active = True) so the related
+        product.product should have a shopinvader.variant.
+        :return: bool
+        """
+        backend = self.backend
+        color_attribute = self.env.ref("product.product_attribute_2")
+        white_attr = self.env.ref("product.product_attribute_value_3")
+        black_attr = self.env.ref("product.product_attribute_value_4")
+        attr = white_attr | black_attr
+        product_tmpl_obj = self.env['product.template'].with_context(
+            active_test=False)
+        lang = self.env['res.lang']._lang_get(self.env.user.lang)
+        product_values = {
+            'name': 'Shopinvader t-shirt',
+            'shopinvader_bind_ids': [(0, False, {
+                'backend_id': backend.id,
+                'lang_id': lang.id,
+                'active': True,
+            })],
+        }
+        product_tmpl = product_tmpl_obj.create(product_values)
+        self.assertTrue(product_tmpl.shopinvader_bind_ids)
+        product_product = product_tmpl.product_variant_ids
+        self.assertEqual(len(product_product.shopinvader_bind_ids), 1)
+        self.assertFalse(product_product.shopinvader_bind_ids.active)
+        # Then we add some products attributes (to create some variants)
+        product_tmpl.write({
+            'attribute_line_ids': [(0, False, {
+                'attribute_id': color_attribute.id,
+                'value_ids': [(6, False, attr.ids)],
+            })],
+        })
+        self.assertEqual(len(attr), len(product_tmpl.product_variant_ids))
+        self.assertEqual(len(attr), len(
+            product_tmpl.shopinvader_bind_ids.shopinvader_variant_ids))
+        return True

--- a/shopinvader/views/product_view.xml
+++ b/shopinvader/views/product_view.xml
@@ -8,15 +8,19 @@
             <xpath expr="/form/sheet/notebook" position="inside">
                 <page name="shopinvader" string="ShopInvader">
                     <field name="shopinvader_bind_ids">
-                        <tree>
+                        <tree decoration-danger="active != True" decoration-success="active == True">
                             <field name="backend_id"/>
                             <field name="lang_id"/>
                             <field name="sync_date"/>
+                            <field name="active" invisible="True"/>
+                            <button name="toggle_published" type="object" help="Click to unpublish" color="green" icon="fa-close" attrs="{'invisible': [('active', '=', True)]}"/>
+                            <button name="toggle_published" type="object" help="Click to publish" color="red" icon="fa-check" attrs="{'invisible': [('active', '!=', True)]}"/>
                         </tree>
                         <form>
                             <group name="backend">
                                 <field name="backend_id" widget="selection"/>
                                 <field name="lang_id" widget="selection"/>
+                                <field name="active"/>
                             </group>
                             <notebook>
                                 <page name="description_and_seo" string="Description and Seo">

--- a/shopinvader_algolia/tests/test_export.py
+++ b/shopinvader_algolia/tests/test_export.py
@@ -63,8 +63,7 @@ class TestExport(ConnectorAlgoliaCase):
         count = self.env['shopinvader.product'].search_count([])
         self.assertEqual(
             _("Export %d records of %d for index 'algolia-product'") % (
-                count, count),
-            job.description)
+                count, count), job.description)
         # the last job is the one performing the export
         job = Job.load(self.env, new_job.uuid)
         with mock_api(self.env) as mocked_api:


### PR DESCRIPTION
- Automatic binding of product.product if related product.template is binded
-- When add new variants on product.template, product.product are created (and maybe should be binded)
- Add unit test