### PR TITLE
[10.0][FIX] Fix group on wizard to bind shopinvader.category

### DIFF
--- a/shopinvader/wizards/shopinvader_category_binding_wizard.xml
+++ b/shopinvader/wizards/shopinvader_category_binding_wizard.xml
@@ -27,7 +27,7 @@
         <field name="context">{}</field>
         <field name="target">new</field>
         <field name="view_id" ref="shopinvader_category_binding_wizard_form_view"/>
-         <field name="groups_id" eval="[(4, ref('connector.group_connector_manager'))]"/>
+         <field name="groups_id" eval="[(4, ref('shopinvader.group_shopinvader_manager'))]"/>
     </record>
 
 </odoo>

--- a/shopinvader/wizards/shopinvader_category_unbinding_wizard.xml
+++ b/shopinvader/wizards/shopinvader_category_unbinding_wizard.xml
@@ -24,7 +24,7 @@
         <field name="context">{}</field>
         <field name="target">new</field>
         <field name="view_id" ref="shopinvader_category_unbinding_wizard_form_view"/>
-        <field name="groups_id" eval="[(4, ref('connector.group_connector_manager'))]"/>
+        <field name="groups_id" eval="[(4, ref('shopinvader.group_shopinvader_manager'))]"/>
     </record>
 
     <record model="ir.values" id="shopinvader_category_unbinding_wizard_act_multi">


### PR DESCRIPTION
The connector module is not into requirements of the module so the shopinvader module raise an exception during installation.
Fix: update the group of these 2 wizards