### PR TITLE
[10.0][FIX] Fix function name for computed field

### DIFF
--- a/base_url/models/abstract_url.py
+++ b/base_url/models/abstract_url.py
@@ -33,7 +33,7 @@ class AbstractUrl(models.AbstractModel):
         store=True,
     )
     url_url_ids = fields.One2many(
-        compute='_compute_url_url_id',
+        compute='_compute_url_url_ids',
         comodel_name='url.url')
     redirect_url_key_ids = fields.One2many(
         compute='_compute_redirect_url',


### PR DESCRIPTION
The compute name was invalid and an errors occurs during computation.
This build failed due to module Payment Stripe.