### PR TITLE
[10.0] easy dev

### DIFF
--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -80,7 +80,6 @@
                                             type="object"/>
                                 </group>
                                 <group name="category" string="Category" col="10" colspan="4">
-                                    <field name="nbr_category"/>
                                     <button
                                             name="bind_all_category"
                                             string="Bind all category"

--- a/shopinvader_search_engine/models/shopinvader_backend.py
+++ b/shopinvader_search_engine/models/shopinvader_backend.py
@@ -3,7 +3,7 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ShopinvaderBackend(models.Model):
@@ -12,3 +12,20 @@ class ShopinvaderBackend(models.Model):
     se_backend_id = fields.Many2one(
         'se.backend',
         'Search Engine Backend')
+
+    @api.multi
+    def force_recompute_all_binding_index(self):
+        self.mapped('se_backend_id.index_ids').force_recompute_all_binding()
+        return True
+
+    @api.multi
+    def force_batch_export_index(self):
+        for index in self.mapped('se_backend_id.index_ids'):
+            index.force_batch_export()
+        return True
+
+    @api.multi
+    def clear_index(self):
+        for index in self.mapped('se_backend_id.index_ids'):
+            index.clear_index()
+        return True

--- a/shopinvader_search_engine/views/shopinvader_backend_view.xml
+++ b/shopinvader_search_engine/views/shopinvader_backend_view.xml
@@ -1,15 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
-<record id="shopinvader_backend_view_form" model="ir.ui.view">
-    <field name="model">shopinvader.backend</field>
-    <field name="inherit_id"
-           ref="shopinvader.shopinvader_backend_view_form" />
-    <field name="arch" type="xml">
-        <field name="auth_api_key_id" position="after">
-            <field name="se_backend_id"/>
+    <record id="shopinvader_backend_view_form" model="ir.ui.view">
+        <field name="model">shopinvader.backend</field>
+        <field name="inherit_id"
+               ref="shopinvader.shopinvader_backend_view_form"/>
+        <field name="arch" type="xml">
+            <field name="auth_api_key_id" position="after">
+                <field name="se_backend_id"/>
+            </field>
+            <group name="category" position="after">
+                <group name="indexes" string="Search engined indexes" col="10" colspan="4">
+                    <button
+                            name="force_recompute_all_binding_index"
+                            string="Recompute"
+                            type="object"/>
+                    <button
+                            name="force_batch_export_index"
+                            string="Export"
+                            type="object"/>
+                    <button
+                            name="clear_index"
+                            string="Clear"
+                            type="object"/>
+                </group>
+            </group>
         </field>
-    </field>
-</record>
+    </record>
 
 </odoo>


### PR DESCRIPTION
* Ease developper work by allowing to build, clear and export search engine indexes all at once from the shopinvader backend

* Remove duplicate field into the backend view