### PR TITLE
[FIX] product_stock: error message if a line contains a bom

### DIFF
--- a/shopinvader_product_stock/models/stock_move.py
+++ b/shopinvader_product_stock/models/stock_move.py
@@ -51,8 +51,10 @@ class StockMove(models.Model):
 
         :return: stock.move recordset
         """
+        # action_confirm on stock_move method can return a new recorset in
+        # case of BOM
         result = super(StockMove, self).action_confirm()
-        self._jobify_product_stock_update()
+        result._jobify_product_stock_update()
         return result
 
     @api.multi


### PR DESCRIPTION
Fix wrong recordset used in action_confirm on stock_move as original method can return a new recorset in case of BOM:
- the original move is deleted
- a move is generated per components

In this case we got the message `Record does not exist or has been deleted.`
