### PR TITLE
[10.0][FIX] shopinvader: HTTP Hearder names must not contain underscore

### DIFF
--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -301,7 +301,7 @@ class CartService(Component):
         defaults = super(
             CartService, self)._get_openapi_default_parameters()
         defaults.append({
-            "name": "SESS_CART_ID",
+            "name": "SESS-CART-ID",
             "in": "header",
             "description": "Session Cart Identifier",
             "required": False,

--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -88,7 +88,7 @@ class BaseShopinvaderService(AbstractComponent):
         defaults = super(
             BaseShopinvaderService, self)._get_openapi_default_parameters()
         defaults.append({
-            "name": "API_KEY",
+            "name": "API-KEY",
             "in": "header",
             "description": "Ath API key",
             "required": True,
@@ -98,7 +98,7 @@ class BaseShopinvaderService(AbstractComponent):
             "style": "simple"
         })
         defaults.append({
-            "name": "PARTNER_EMAIL",
+            "name": "PARTNER-EMAIL",
             "in": "header",
             "description": "Logged partner email",
             "required": False,


### PR DESCRIPTION
when parsed by werkzeug, '-' are replaced by '_' and the name is prefixed by 'HTTP_'

ping @sebastienbeau without this changes, services are not available when called by swagger if the server is behing a proxy like nginx