### PR TITLE
[10.0] partner conditional binding

### DIFF
--- a/shopinvader/__manifest__.py
+++ b/shopinvader/__manifest__.py
@@ -55,6 +55,7 @@
         'views/partner_view.xml',
         'views/product_category_view.xml',
         'views/sale_view.xml',
+        'views/shopinvader_config_settings.xml',
         "data/res_partner.xml",
         "data/ir_export_product.xml",
         "data/ir_export_category.xml",

--- a/shopinvader/models/__init__.py
+++ b/shopinvader/models/__init__.py
@@ -17,3 +17,5 @@ from . import shopinvader_notification
 from . import shopinvader_category
 from . import shopinvader_product
 from . import shopinvader_variant
+from . import shopinvader_config_settings
+from . import res_partner

--- a/shopinvader/models/res_partner.py
+++ b/shopinvader/models/res_partner.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Akretion (http://www.akretion.com)
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    shopinvader_bind_ids = fields.One2many(
+        'shopinvader.partner',
+        'record_id',
+        string='Shopinvader Binding')
+    address_type = fields.Selection(
+        selection=[('profile', 'Profile'), ('address', 'Address')],
+        string='Address Type',
+        compute='_compute_address_type',
+        store=True)
+    # In europe we use more the opt_in
+    opt_in = fields.Boolean(
+        compute='_compute_opt_in',
+        inverse='_inverse_opt_in')
+
+    @api.multi
+    @api.constrains('email')
+    def _check_unique_email(self):
+        config = self.env['shopinvader.config.settings']
+        if config.is_partner_duplication_allowed():
+            return True
+        self.env.cr.execute("""
+            SELECT
+                email
+            FROM (
+                SELECT
+                    id,
+                    email,
+                    ROW_NUMBER() OVER (PARTITION BY email) AS Row
+                FROM
+                    res_partner
+                WHERE email is not null
+                ) dups
+            WHERE dups.Row > 1;
+        """)
+        duplicate_emails = set([r[0] for r in self.env.cr.fetchall()])
+        invalid_emails = [
+            e for e in self.mapped('email') if e in duplicate_emails]
+        if invalid_emails:
+            raise ValidationError(_('Email must be unique: The following '
+                                    'mails are not unique: %s') %
+                                  ', '.join(invalid_emails))
+
+    @api.depends('opt_out')
+    def _compute_opt_in(self):
+        for record in self:
+            record.opt_in = not record.opt_out
+
+    def _inverse_opt_in(self):
+        for record in self:
+            record.opt_out = not record.opt_in
+
+    @api.depends('parent_id')
+    def _compute_address_type(self):
+        for partner in self:
+            if partner.parent_id:
+                partner.address_type = 'address'
+            else:
+                partner.address_type = 'profile'
+
+    @api.multi
+    def write(self, vals):
+        super(ResPartner, self).write(vals)
+        if 'country_id' in vals:
+            carts = self.env['sale.order'].search([
+                ('typology', '=', 'cart'),
+                ('partner_shipping_id', 'in', self.ids)])
+            for cart in carts:
+                # Trigger a write on cart to recompute the
+                # fiscal position if needed
+                cart.write_with_onchange({
+                    'partner_shipping_id': cart.partner_shipping_id.id,
+                    })
+        return True

--- a/shopinvader/models/shopinvader_config_settings.py
+++ b/shopinvader/models/shopinvader_config_settings.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+PARAMS = [
+    ("no_partner_duplicate",
+     "shopinvader.no_partner_duplicate"),
+]
+
+
+class ShopinvaderConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+    _name = 'shopinvader.config.settings'
+
+    no_partner_duplicate = fields.Boolean(
+        default=True,
+        help="If checked, when a binding is created for a backend, we first "
+             "try to find a partner with the same email and if found we link "
+             "the new binding to the first partner found. Otherwise we always "
+             "create a new partner"
+    )
+
+    @api.multi
+    def set_params(self):
+        self.ensure_one()
+        for field_name, key_name in PARAMS:
+            value = getattr(self, field_name, '')
+            self.env['ir.config_parameter'].set_param(key_name, value)
+
+    @api.model
+    def get_default_params(self, fields):
+        res = {}
+        for field_name, key_name in PARAMS:
+            res[field_name] = self.env['ir.config_parameter'].get_param(
+                key_name, '').strip()
+        return res
+
+    # external methods
+    @api.model
+    def is_partner_duplication_allowed(self):
+        param = self.env['ir.config_parameter'].get_param(
+            'shopinvader.no_partner_duplicate')
+        if not param:
+            return self._fields['no_partner_duplicate'].default
+        return param == 'False'

--- a/shopinvader/models/shopinvader_partner.py
+++ b/shopinvader/models/shopinvader_partner.py
@@ -3,6 +3,7 @@
 # Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+
 from odoo import api, fields, models
 
 
@@ -31,6 +32,11 @@ class ShopinvaderPartner(models.Model):
 
     @api.model
     def create(self, vals):
+        vals = self._prepare_create_params(vals)
+        return super(ShopinvaderPartner, self).create(vals)
+
+    @api.model
+    def _prepare_create_params(self, vals):
         # As we want to have a SQL contraint on customer email
         # we have to set it manually to avoid to raise the constraint
         # at the creation of the element
@@ -39,54 +45,56 @@ class ShopinvaderPartner(models.Model):
         if not vals.get('partner_email') and vals.get('record_id'):
             vals['partner_email'] = self.env['res.partner'].browse(
                 vals['record_id']).email
-        return super(ShopinvaderPartner, self).create(vals)
+        if not vals.get('record_id'):
+            vals['record_id'] = self._get_or_create_partner(vals).id
+        return vals
 
+    @api.model
+    def _get_or_create_partner(self, vals):
+        config = self.env['shopinvader.config.settings']
+        partner = self.env['res.partner'].browse()
+        if not config.is_partner_duplication_allowed():
+            domain = self._get_unique_partner_domain(vals)
+            partner = partner.search(domain)
+        if partner:
+            # here we check if one of the given value is different than those
+            # on partner. If true, we create a child partner to keep the
+            # given informations
+            partner = partner[0]
+            if not self._is_same_partner_value(partner, vals):
+                self._create_child_partner(partner, vals)
+            return partner
+        return partner.create(vals.copy())
 
-class ResPartner(models.Model):
-    _inherit = 'res.partner'
+    @api.model
+    def _get_unique_partner_domain(self, vals):
+        """ """
+        email = vals['email']
+        return [('email', '=', email)]
 
-    shopinvader_bind_ids = fields.One2many(
-        'shopinvader.partner',
-        'record_id',
-        string='Shopinvader Binding')
-    address_type = fields.Selection(
-        selection=[('profile', 'Profile'), ('address', 'Address')],
-        string='Address Type',
-        compute='_compute_address_type',
-        store=True)
-    # In europe we use more the opt_in
-    opt_in = fields.Boolean(
-        compute='_compute_opt_in',
-        inverse='_inverse_opt_in')
-
-    @api.depends('opt_out')
-    def _compute_opt_in(self):
-        for record in self:
-            record.opt_in = not record.opt_out
-
-    def _inverse_opt_in(self):
-        for record in self:
-            record.opt_out = not record.opt_in
-
-    @api.depends('parent_id')
-    def _compute_address_type(self):
-        for partner in self:
-            if partner.parent_id:
-                partner.address_type = 'address'
-            else:
-                partner.address_type = 'profile'
-
-    @api.multi
-    def write(self, vals):
-        super(ResPartner, self).write(vals)
-        if 'country_id' in vals:
-            carts = self.env['sale.order'].search([
-                ('typology', '=', 'cart'),
-                ('partner_shipping_id', 'in', self.ids)])
-            for cart in carts:
-                # Trigger a write on cart to recompute the
-                # fiscal position if needed
-                cart.write_with_onchange({
-                    'partner_shipping_id': cart.partner_shipping_id.id,
-                    })
+    @api.model
+    def _is_same_partner_value(self, partner, vals):
+        """ we check if one of the given value is different than values
+            of the given partner
+        """
+        data = partner._convert_to_write(partner._cache)
+        for key in data:
+            if key not in vals:
+                continue
+            if data[key] != vals[key]:
+                return False
         return True
+
+    @api.model
+    def _create_child_partner(self, parent, vals):
+        vals = self._prepare_create_child_params(parent, vals)
+        return self.env['res.partner'].create(vals)
+
+    @api.model
+    def _prepare_create_child_params(self, parent, vals):
+        v = vals.copy()
+        v['parent_id'] = parent.id
+        if not v.get('type'):
+            v['type'] = 'other'
+        v.pop('email')
+        return v

--- a/shopinvader/models/shopinvader_partner.py
+++ b/shopinvader/models/shopinvader_partner.py
@@ -34,8 +34,11 @@ class ShopinvaderPartner(models.Model):
         # As we want to have a SQL contraint on customer email
         # we have to set it manually to avoid to raise the constraint
         # at the creation of the element
-        vals['partner_email'] = self.env['res.partner'].browse(
-            vals['record_id']).email
+        if not vals.get('partner_email'):
+            vals['partner_email'] = vals.get('email')
+        if not vals.get('partner_email') and vals.get('record_id'):
+            vals['partner_email'] = self.env['res.partner'].browse(
+                vals['record_id']).email
         return super(ShopinvaderPartner, self).create(vals)
 
 

--- a/shopinvader/services/address.py
+++ b/shopinvader/services/address.py
@@ -35,7 +35,7 @@ class AddressService(Component):
 
     def update(self, _id, **params):
         address = self._get(_id)
-        address.write(self._prepare_params(params, update=True))
+        address.write(self._prepare_params(params))
         res = self.search()
         if address.address_type == 'profile':
             res['store_cache'] = {'customer': self._to_json(address)[0]}
@@ -132,7 +132,7 @@ class AddressService(Component):
     def _to_json(self, address):
         return address.jsonify(self._json_parser())
 
-    def _prepare_params(self, params, update=False):
+    def _prepare_params(self, params):
         for key in ['country', 'state']:
             if key in params:
                 val = params.pop(key)

--- a/shopinvader/services/customer.py
+++ b/shopinvader/services/customer.py
@@ -61,11 +61,8 @@ class CustomerService(Component):
         return schema
 
     def _prepare_params(self, params):
-        for key in ['country', 'state']:
-            if key in params:
-                val = params.pop(key)
-                if val.get('id'):
-                    params["%s_id" % key] = val['id']
+        address = self.component(usage='addresses')
+        params = address._prepare_params(params)
         params['backend_id'] = self.shopinvader_backend.id,
         return params
 

--- a/shopinvader/tests/__init__.py
+++ b/shopinvader/tests/__init__.py
@@ -11,3 +11,5 @@ from . import test_sale
 from . import test_shopinvader_variant_binding_wizard
 from . import test_shopinvader_category_binding_wizard
 from . import test_customer
+from . import test_shopinvader_partner
+from . import test_res_partner

--- a/shopinvader/tests/test_controller.py
+++ b/shopinvader/tests/test_controller.py
@@ -6,6 +6,8 @@
 from .common import ShopinvaderRestCase
 import requests
 
+from odoo.tools import mute_logger
+
 
 class ShopinvaderControllerCase(ShopinvaderRestCase):
 
@@ -43,6 +45,8 @@ class ShopinvaderControllerCase(ShopinvaderRestCase):
         expected_ids = set([self.address_1.id, self.address_2.id])
         self.assertEqual(ids, expected_ids)
 
+    @mute_logger('odoo.addons.auth_api_key.models.ir_http',
+                 'odoo.addons.base_rest.http')
     def test_get_addresses_with_wrong_api_key(self):
         result = requests.get(self.url, headers={
             'API_KEY': 'WRONG',

--- a/shopinvader/tests/test_res_partner.py
+++ b/shopinvader/tests/test_res_partner.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import datetime
+
+from odoo.addons.component.tests.common import SavepointComponentCase
+from odoo.exceptions import ValidationError
+
+
+class TestResPartner(SavepointComponentCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestResPartner, cls).setUpClass()
+        cls.shopinvader_config = cls.env['shopinvader.config.settings']
+        cls.unique_email = datetime.now().isoformat() + '@test.com'
+
+    def test_unique_email_partner(self):
+        self.assertTrue(
+            self.shopinvader_config.is_partner_duplication_allowed())
+        self.env['res.partner'].create({
+            'email': self.unique_email,
+            'name': 'test partner',
+        })
+        # by default we can create partner with same email
+        self.env['res.partner'].create({
+            'email': self.unique_email,
+            'name': 'test partner 2',
+        })
+        self.shopinvader_config.create({
+            "no_partner_duplicate": True,
+        }).execute()
+        self.assertFalse(
+            self.shopinvader_config.is_partner_duplication_allowed())
+        # once you've changed the config to dispable duplicate partner
+        # it's no more possible to create a partner with the same email
+        with self.assertRaises(ValidationError), self.cr.savepoint():
+            self.env['res.partner'].create({
+                'email': self.unique_email,
+                'name': 'test partner 3',
+            })

--- a/shopinvader/tests/test_shopinvader_partner.py
+++ b/shopinvader/tests/test_shopinvader_partner.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import datetime
+from psycopg2 import IntegrityError
+
+from odoo.addons.component.tests.common import SavepointComponentCase
+
+
+class TestShopinvaderPartner(SavepointComponentCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestShopinvaderPartner, cls).setUpClass()
+        cls.backend = cls.env.ref('shopinvader.backend_1')
+        cls.shopinvader_config = cls.env['shopinvader.config.settings']
+        cls.unique_email = datetime.now().isoformat() + '@test.com'
+
+    def test_unique_binding(self):
+        self.env['shopinvader.partner'].create({
+            'email': self.unique_email,
+            'name': 'test  partner',
+            'backend_id': self.backend.id,
+        })
+        with self.assertRaises(IntegrityError), self.cr.savepoint():
+            self.env['shopinvader.partner'].create({
+                'email': self.unique_email,
+                'name': 'test  partner',
+                'backend_id': self.backend.id,
+            })
+
+    def test_partner_duplicate(self):
+        """
+        Test that the partner are duplicated if we create 2 binding with the
+        email (after having removed the first binding)
+        :return:
+        """
+        self.assertTrue(
+            self.shopinvader_config.is_partner_duplication_allowed())
+        # we create a first binding
+        binding = self.env['shopinvader.partner'].create({
+            'email': self.unique_email,
+            'name': 'test  partner',
+            'backend_id': self.backend.id,
+        })
+        # a partner has been created for this binding
+        res = self.env['res.partner'].search(
+            [('email', '=', self.unique_email)])
+        self.assertEqual(
+            binding.record_id, res
+        )
+        # if we remove the partner and create a new binding with the same email
+        # a new partner will be created
+        binding.unlink()
+        self.env['shopinvader.partner'].create({
+            'email': self.unique_email,
+            'name': 'test  partner 2',
+            'backend_id': self.backend.id,
+        })
+        res = self.env['res.partner'].search(
+            [('email', '=', self.unique_email)])
+        self.assertEqual(len(res), 2)
+
+    def test_partner_no_duplicate(self):
+        """
+        Test that if a partner already exists with the same email, the binding
+        will not create a new partner
+        """
+        self.shopinvader_config.create({
+            "no_partner_duplicate": True,
+        }).execute()
+        self.assertFalse(
+            self.shopinvader_config.is_partner_duplication_allowed())
+        vals = {
+            'email': self.unique_email,
+            'name': 'test  partner',
+        }
+        # create a partner...
+        partner = self.env['res.partner'].create(vals)
+        # create a binding
+        binding = self.env['shopinvader.partner'].create({
+            'email': self.unique_email,
+            'name': 'test  partner',
+            'backend_id': self.backend.id,
+        })
+        # the binding must be linked to the partner
+        self.assertEqual(partner, binding.record_id)
+        # no child should exists since all the values are the same on the
+        # partner
+        self.assertFalse(partner.child_ids)
+
+    def test_partner_no_duplicate_child(self):
+        """
+        In this test we check that if a partner already exists for the binding
+        but with different values, the binding is linked to the partner and a
+        new child partner or partner is created to keep the information
+        provided when creating the binding
+        """
+        self.shopinvader_config.create({
+            "no_partner_duplicate": True,
+        }).execute()
+        self.assertFalse(
+            self.shopinvader_config.is_partner_duplication_allowed())
+        vals = {
+            'email': self.unique_email,
+            'name': 'test  partner',
+        }
+        # create a partner...
+        partner = self.env['res.partner'].create(vals)
+        self.assertFalse(partner.child_ids)
+        # create a binding with the same email but an other name
+        binding = self.env['shopinvader.partner'].create({
+            'email': self.unique_email,
+            'name': 'test other partner',
+            'street': 'my street',
+            'backend_id': self.backend.id,
+        })
+        self.assertEqual(partner, binding.record_id)
+        partner.refresh()
+        self.assertTrue(partner.child_ids)
+        self.assertEqual(1, len(partner.child_ids))
+        child = partner.child_ids
+        self.assertEqual(child.name, 'test other partner')
+        self.assertEqual(child.street, 'my street')
+
+        # only one partner should exists with this email
+        res = self.env['res.partner'].search(
+            [('email', '=', self.unique_email)])
+        self.assertEqual(len(res), 1)

--- a/shopinvader/views/shopinvader_config_settings.xml
+++ b/shopinvader/views/shopinvader_config_settings.xml
@@ -34,7 +34,7 @@
         <field name="name">Shopinvader Config Settings</field>
         <field name="parent_id" ref="menu_shopinvader_config"/>
         <field name="action" ref="shopinvader_config_settings_act_window"/>
-        <field name="sequence" eval="16"/>
+        <field name="sequence" eval="-1"/>
     </record>
 
 </odoo>

--- a/shopinvader/views/shopinvader_config_settings.xml
+++ b/shopinvader/views/shopinvader_config_settings.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="shopinvader_config_settings_form_view">
+        <field name="name">shopinvader.config.settings.form (in shopinvader)</field>
+        <field name="model">shopinvader.config.settings</field>
+        <field name="arch" type="xml">
+            <form string="Configure Warehouse" class="oe_form_configuration">
+                <header>
+                    <button string="Apply" type="object" name="execute" class="oe_highlight"/>
+                    <button string="Cancel" type="object" name="cancel" class="oe_link" special="cancel"/>
+                </header>
+                <group string="General" name="general">
+                    <field name="no_partner_duplicate"/>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="shopinvader_config_settings_act_window">
+        <field name="name">Configure Shopinvader</field>
+        <field name="res_model">shopinvader.config.settings</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[]</field>
+        <field name="context">{}</field>
+        <field name="view_mode">form</field>
+        <field name="target">inline</field>
+    </record>
+
+    <record model="ir.ui.menu" id="shopinvader_config_settings_menu">
+        <field name="name">Shopinvader Config Settings</field>
+        <field name="parent_id" ref="menu_shopinvader_config"/>
+        <field name="action" ref="shopinvader_config_settings_act_window"/>
+        <field name="sequence" eval="16"/>
+    </record>
+
+</odoo>

--- a/shopinvader/views/shopinvader_menu.xml
+++ b/shopinvader/views/shopinvader_menu.xml
@@ -9,5 +9,9 @@
               sequence="10"
               web_icon="shopinvader,static/description/icon.png"
               groups="group_shopinvader_manager"/>
-
+    <menuitem id="menu_shopinvader_config"
+              name="Configuration"
+              sequence="100"
+              parent="menu_shopinvader_root"
+              groups="group_shopinvader_manager"/>
 </odoo>

--- a/shopinvader/views/shopinvader_menu.xml
+++ b/shopinvader/views/shopinvader_menu.xml
@@ -14,4 +14,18 @@
               sequence="100"
               parent="menu_shopinvader_root"
               groups="group_shopinvader_manager"/>
+
+    <record model="ir.ui.menu" id="auth_api_key_menu">
+        <field name="name">Auth Api Key</field>
+        <field name="parent_id" ref="menu_shopinvader_config"/>
+        <field name="action" ref="auth_api_key.auth_api_key_act_window"/>
+        <field name="sequence" eval="10"/>
+    </record>
+    <record model="ir.ui.menu" id="keychain_menu">
+        <field name="name">Keychain</field>
+        <field name="parent_id" ref="menu_shopinvader_config"/>
+        <field name="action" ref="keychain.keychain_list_action"/>
+        <field name="sequence" eval="11"/>
+    </record>
+
 </odoo>

--- a/shopinvader_contact_company/services/address.py
+++ b/shopinvader_contact_company/services/address.py
@@ -23,9 +23,8 @@ class AddressService(Component):
             ]
         return res
 
-    def _prepare_params(self, params, update=False):
-        params = super(AddressService, self)._prepare_params(
-            params, update=update)
+    def _prepare_params(self, params):
+        params = super(AddressService, self)._prepare_params(params)
         if 'name' in params:
             params['contact_name'] = params.pop('name')
         return params

--- a/shopinvader_payment/__manifest__.py
+++ b/shopinvader_payment/__manifest__.py
@@ -24,6 +24,7 @@
         "sale_automatic_workflow_payment_mode",
     ],
     "data": [
+        "views/shopinvader_menu.xml",
         "views/shopinvader_payment_view.xml",
         "views/backend_view.xml",
         "security/ir.model.access.csv",

--- a/shopinvader_payment/views/shopinvader_menu.xml
+++ b/shopinvader_payment/views/shopinvader_menu.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Akretion
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.menu" id="account_payment_mode_menu">
+        <field name="name">Payment Modes</field>
+        <field name="parent_id" ref="shopinvader.menu_shopinvader_config"/>
+        <field name="action" ref="account_payment_mode.account_payment_mode_action"/>
+        <field name="sequence" eval="20"/>
+    </record>
+
+</odoo>

--- a/shopinvader_sale_profile/services/shopinvader_customer_service.py
+++ b/shopinvader_sale_profile/services/shopinvader_customer_service.py
@@ -9,23 +9,17 @@ from odoo.addons.component.core import Component
 class ShopInvaderCustomerService(Component):
     _inherit = 'shopinvader.customer.service'
 
-    def _create_shopinvader_binding(self, external_id):
+    def _prepare_create_response(self, binding):
         """
-        Inherit the creation of shopinvader binding to add the sale profile
+        Inherit the creation of create responseto add the sale profile
         code of the shopinvader partner
-        :param external_id: int
+        :param binding: instance of shopinvader.binding
         :return: dict
         """
         response = super(ShopInvaderCustomerService, self)\
-            ._create_shopinvader_binding(external_id=external_id)
+            ._prepare_create_response(binding=binding)
         data = response.get('data', {})
-        # Get the shopinvader partner created into the super
-        shop_partner = self.env['shopinvader.partner'].search([
-            ('backend_id', '=', self.shopinvader_backend.id),
-            ('external_id', '=', external_id),
-            ('record_id', '=', self.partner.id),
-        ], order="create_date desc", limit=1)
         data.update({
-            'sale_profile': shop_partner.sale_profile_id.code,
+            'sale_profile': binding.sale_profile_id.code,
         })
         return response


### PR DESCRIPTION
In this PR we declare a new global config option to allow(default)/disallow the creation of a new partner each time a new binding is created.  If you disallow the duplication of partner, when a binding is created we search first for a partner with the same email. If found we link the partner to the binding, otherwise we create a new one.
When a partner is created from within odoo, a new constrains also checks if the email is unique. The constrains is checked by a python method since it's active depending of the configuration.

This PR also add a configuration menu.