### PR TITLE
[10.0][ADD] Add shopinvader_backend_image_proxy module

### DIFF
--- a/setup/shopinvader_backend_image_proxy/odoo/__init__.py
+++ b/setup/shopinvader_backend_image_proxy/odoo/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/shopinvader_backend_image_proxy/odoo/addons/__init__.py
+++ b/setup/shopinvader_backend_image_proxy/odoo/addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/shopinvader_backend_image_proxy/odoo/addons/shopinvader_backend_image_proxy
+++ b/setup/shopinvader_backend_image_proxy/odoo/addons/shopinvader_backend_image_proxy
@@ -1,0 +1,1 @@
+../../../../shopinvader_backend_image_proxy

--- a/setup/shopinvader_backend_image_proxy/setup.py
+++ b/setup/shopinvader_backend_image_proxy/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopinvader_backend_image_proxy/__init__.py
+++ b/shopinvader_backend_image_proxy/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com).
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import models

--- a/shopinvader_backend_image_proxy/__manifest__.py
+++ b/shopinvader_backend_image_proxy/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com).
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Shopinvader backend image proxy",
+    "summary": "Add possibility to replace the image URL by the proxy url "
+               "set on the SE backend",
+    "version": "10.0.1.0.0",
+    "category": "e-commerce",
+    'author': 'Akretion,ACSONE SA/NV',
+    'website': 'http://www.akretion.com',
+    "license": "AGPL-3",
+    "depends": [
+        'shopinvader_image',
+    ],
+    "data": [
+        'views/shopinvader_backend.xml',
+    ],
+}

--- a/shopinvader_backend_image_proxy/models/__init__.py
+++ b/shopinvader_backend_image_proxy/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com).
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import shopinvader_backend
+from . import shopinvader_image_mixin

--- a/shopinvader_backend_image_proxy/models/shopinvader_backend.py
+++ b/shopinvader_backend_image_proxy/models/shopinvader_backend.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com).
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, fields, models
+
+
+class ShopinvaderBackend(models.Model):
+    _inherit = 'shopinvader.backend'
+
+    image_proxy_url = fields.Char(
+        help="Replace the original url (base part) by this proxy url during "
+             "export of images serialized field.\n"
+             "Fill without specify the protocol and anything else than the "
+             "complete website name (with subdomain if any).\n"
+             "Example: my.website.com",
+    )
+
+    @api.multi
+    def _replace_by_proxy(self, url):
+        """
+        This function is used to replace the website (into url parameter)
+        by the one set on the current recordset (image_proxy_url field).
+        Example:
+        url = "http://subdomain.example.com/abc/shopinvader.png?a=awesome"
+        self.image_proxy_url = "https://anonymous.shopinvader.com/test"
+        Expected result:
+        "https://anonymous.shopinvader.com/test/shopinvader.png?a=myself"
+        So we have to replace the protocol (http, https,...) and keep only
+        the final part (file name with arguments)
+        :param url: str
+        :return: str
+        """
+        self.ensure_one()
+        if self.image_proxy_url and url:
+            file_url = url.rsplit("/", 1)
+            base_url = self.image_proxy_url
+            if not base_url.endswith("/"):
+                base_url += "/"
+            return base_url + file_url[1]
+        return url

--- a/shopinvader_backend_image_proxy/models/shopinvader_backend.py
+++ b/shopinvader_backend_image_proxy/models/shopinvader_backend.py
@@ -2,6 +2,7 @@
 # Copyright 2018 Akretion (http://www.akretion.com).
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from urlparse import urlparse, urljoin, ParseResult
 from odoo import api, fields, models
 
 
@@ -11,7 +12,7 @@ class ShopinvaderBackend(models.Model):
     image_proxy_url = fields.Char(
         help="Replace the original url (base part) by this proxy url during "
              "export of images serialized field.\n"
-             "Fill without specify the protocol and anything else than the "
+             "Fill without specifying the protocol or anything else than the "
              "complete website name (with subdomain if any).\n"
              "Example: my.website.com",
     )
@@ -32,10 +33,12 @@ class ShopinvaderBackend(models.Model):
         :return: str
         """
         self.ensure_one()
-        if self.image_proxy_url and url:
-            file_url = url.rsplit("/", 1)
-            base_url = self.image_proxy_url
-            if not base_url.endswith("/"):
-                base_url += "/"
-            return base_url + file_url[1]
+        proxy_url = self.image_proxy_url
+        if proxy_url and url:
+            if not proxy_url.endswith('/'):
+                proxy_url = proxy_url + '/'
+            parts = urlparse(url)
+            path = parts.path.split('/')[-1]
+            path = ParseResult('', '', path, *parts[3:]).geturl()
+            return urljoin(proxy_url, path)
         return url

--- a/shopinvader_backend_image_proxy/models/shopinvader_image_mixin.py
+++ b/shopinvader_backend_image_proxy/models/shopinvader_image_mixin.py
@@ -22,9 +22,7 @@ class ShopinvaderImageMixin(models.AbstractModel):
         url_key = "src"
         url = values.get(url_key)
         if url and 'backend_id' in self._fields:
-            new_url = self.backend_id._replace_by_proxy(url)
-            if url != new_url:
-                values.update({
-                    url_key: new_url,
-                })
+            values.update({
+                url_key: self.backend_id._replace_by_proxy(url),
+            })
         return values

--- a/shopinvader_backend_image_proxy/models/shopinvader_image_mixin.py
+++ b/shopinvader_backend_image_proxy/models/shopinvader_image_mixin.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com).
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class ShopinvaderImageMixin(models.AbstractModel):
+    _inherit = 'shopinvader.image.mixin'
+
+    @api.multi
+    def _prepare_data_resize(self, thumbnail, image_relation):
+        """
+        Prepare data to fill images serialized field
+        :param thumbnail: storage.thumbnail recordset
+        :param image_relation: product.image.relation recordset
+        :return: dict
+        """
+        self.ensure_one()
+        values = super(ShopinvaderImageMixin, self)._prepare_data_resize(
+            thumbnail=thumbnail, image_relation=image_relation)
+        url_key = "src"
+        url = values.get(url_key)
+        if url and 'backend_id' in self._fields:
+            new_url = self.backend_id._replace_by_proxy(url)
+            if url != new_url:
+                values.update({
+                    url_key: new_url,
+                })
+        return values

--- a/shopinvader_backend_image_proxy/readme/CONFIGURE.rst
+++ b/shopinvader_backend_image_proxy/readme/CONFIGURE.rst
@@ -1,0 +1,4 @@
+* By interface:
+
+- Browse into your shopinvader backends
+- Fill the field "image_proxy_url" if necessary

--- a/shopinvader_backend_image_proxy/readme/CONTRIBUTORS.rst
+++ b/shopinvader_backend_image_proxy/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* François Honoré <francois.honore@acsone.eu>

--- a/shopinvader_backend_image_proxy/readme/DESCRIPTION.rst
+++ b/shopinvader_backend_image_proxy/readme/DESCRIPTION.rst
@@ -1,0 +1,11 @@
+This addon is used to replace the url (only the first part, without the
+file name) of images serialized field of the
+shopinvader.image.mixin abstract model.
+Only the related recordset (who inherit this abstract model) has a
+backend_id field (M2O to shopinvader.backend) and if image_proxy_url is filled.
+
+
+Features:
+
+* Add 'image_proxy_url' field into shopinvader.backend.
+* If the field is set, the url will be replaced.

--- a/shopinvader_backend_image_proxy/tests/__init__.py
+++ b/shopinvader_backend_image_proxy/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com).
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import test_shopinvader_backend
+from . import test_shopinvader_image_mixin

--- a/shopinvader_backend_image_proxy/tests/test_shopinvader_backend.py
+++ b/shopinvader_backend_image_proxy/tests/test_shopinvader_backend.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.addons.shopinvader.tests.common import ProductCommonCase
+from odoo.addons.storage_image_product.tests.common import (
+    ProductImageCommonCase)
+
+
+class TestShopinvaderBackendTest(ProductCommonCase, ProductImageCommonCase):
+    """
+    Tests for shopinvader.backend
+    """
+
+    def setUp(self):
+        super(TestShopinvaderBackendTest, self).setUp()
+        self.backend.write({
+            'image_proxy_url': 'https://custom.website.dev',
+        })
+        self.env.ref('base.user_demo').write({
+            'groups_id': [
+                (4, self.env.ref('shopinvader.group_shopinvader_manager').id)]
+        })
+        ProductImageCommonCase.setUp(self)
+        img_relation_obj = self.env['product.image.relation']
+        product_attr = self.env.ref('product.product_attribute_value_4')
+        self.logo = img_relation_obj.create({
+            'product_tmpl_id': self.template.id,
+            'image_id': self.logo_image.id,
+        })
+        self.image_bk = img_relation_obj.create({
+            'product_tmpl_id': self.template.id,
+            'image_id': self.black_image.id,
+            'attribute_value_ids': [(6, 0, product_attr.ids)]
+        })
+
+    def test_replace_url(self):
+        """
+        Test if the url is correctly replaced
+        :return:
+        """
+        # Test normal url
+        image_proxy_url = self.backend.image_proxy_url
+        # Normal url with final /
+        test_url = "https://aaaaaaaa.bbbbbbbb.dev/img.png"
+        expected_url = "%s/img.png" % image_proxy_url
+        result_url = self.backend._replace_by_proxy(test_url)
+        self.assertEqual(expected_url, result_url)
+        # Normal url without final /
+        test_url = "https://aaaaaaaa.bbbbbbbb.dev/titi/toto/dddd.png"
+        expected_url = "%s/dddd.png" % image_proxy_url
+        result_url = self.backend._replace_by_proxy(test_url)
+        self.assertEqual(expected_url, result_url)
+        # Test url with arguments
+        test_url = "https://aaaaaaaa.xxxx.dev/uu/tt.png?a=5698zzzz"
+        expected_url = "%s/tt.png?a=5698zzzz" % image_proxy_url
+        result_url = self.backend._replace_by_proxy(test_url)
+        self.assertEqual(expected_url, result_url)
+        # Test url without subdomain
+        test_url = "https://xxxx.dev/get?a=5698zzzzea"
+        expected_url = "%s/get?a=5698zzzzea" % image_proxy_url
+        result_url = self.backend._replace_by_proxy(test_url)
+        self.assertEqual(expected_url, result_url)
+        # image_proxy_url with another directory/url path
+        image_proxy_url = 'http://custom.website.dev/force_directory/titi'
+        self.backend.write({
+            'image_proxy_url': image_proxy_url,
+        })
+        test_url = "ftp://xxxx.dev/toto.png?a=5698zzzzqqq"
+        expected_url = "%s/toto.png?a=5698zzzzqqq" % image_proxy_url
+        # Test url with another protocol
+        image_proxy_url = 'ftp://custom.website.dev'
+        self.backend.write({
+            'image_proxy_url': image_proxy_url,
+        })
+        test_url = "ftp://xxxx.dev/get?a=5698zzzzqqq"
+        expected_url = "%s/get?a=5698zzzzqqq" % image_proxy_url
+        result_url = self.backend._replace_by_proxy(test_url)
+        self.assertEqual(expected_url, result_url)
+        # Now remove the image_proxy_url on the backend
+        # So the given url shouldn't be updated
+        self.backend.write({
+            'image_proxy_url': False,
+        })
+        test_url = "https://aaaaaaaa.bbbbbbbb.dev/"
+        result_url = self.backend._replace_by_proxy(test_url)
+        self.assertEqual(test_url, result_url)
+        test_url = "https://xxxx.dev/get?a=5698zzzzea"
+        result_url = self.backend._replace_by_proxy(test_url)
+        self.assertEqual(test_url, result_url)
+        test_url = "https://aaaa.xxxx.dev/get?a=5698zzzzea"
+        result_url = self.backend._replace_by_proxy(test_url)
+        self.assertEqual(test_url, result_url)

--- a/shopinvader_backend_image_proxy/tests/test_shopinvader_image_mixin.py
+++ b/shopinvader_backend_image_proxy/tests/test_shopinvader_image_mixin.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.addons.shopinvader.tests.common import ProductCommonCase
+from odoo.addons.storage_image_product.tests.common import (
+    ProductImageCommonCase)
+
+
+class TestShopinvaderImageMixin(ProductCommonCase, ProductImageCommonCase):
+    """
+    Tests for shopinvader.image.mixin
+    """
+
+    def setUp(self):
+        super(TestShopinvaderImageMixin, self).setUp()
+        self.backend.write({
+            'image_proxy_url': 'http://custom.website.dev',
+        })
+        self.env.ref('base.user_demo').write({
+            'groups_id': [
+                (4, self.env.ref('shopinvader.group_shopinvader_manager').id)]
+        })
+        ProductImageCommonCase.setUp(self)
+        img_relation_obj = self.env['product.image.relation']
+        product_attr = self.env.ref('product.product_attribute_value_4')
+        self.logo = img_relation_obj.create({
+            'product_tmpl_id': self.template.id,
+            'image_id': self.logo_image.id,
+        })
+        self.image_bk = img_relation_obj.create({
+            'product_tmpl_id': self.template.id,
+            'image_id': self.black_image.id,
+            'attribute_value_ids': [(6, 0, product_attr.ids)]
+        })
+
+    def test_image_url(self):
+        """
+        Ensure the url into images serialized field is correctly updated
+        :return:
+        """
+        image_proxy_url = self.backend.image_proxy_url
+        images = self.shopinvader_variant.images
+        # Ensure that we have some images for this test
+        self.assertTrue(bool(images))
+        for image_sizes in images:
+            for image_dict in image_sizes.values():
+                src = image_dict.get('src')
+                self.assertIn(image_proxy_url, src)

--- a/shopinvader_backend_image_proxy/views/shopinvader_backend.xml
+++ b/shopinvader_backend_image_proxy/views/shopinvader_backend.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record model="ir.ui.view" id="shopinvader_backend_form_view">
+        <field name="name">Shopinvader.backend.form (in shopinvader_backend_image_proxy)</field>
+        <field name="model">shopinvader.backend</field>
+        <field name="inherit_id" ref="shopinvader.shopinvader_backend_view_form"/>
+        <field name="priority" eval="90"/>
+        <field name="arch" type="xml">
+            <field name="location" position="after">
+                <field name="image_proxy_url"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/shopinvader_image/models/shopinvader_image_mixin.py
+++ b/shopinvader_image/models/shopinvader_image_mixin.py
@@ -3,7 +3,7 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ShopinvaderImageMixin(models.AbstractModel):
@@ -14,19 +14,23 @@ class ShopinvaderImageMixin(models.AbstractModel):
         compute='_compute_image',
         string='Shopinvader Image')
 
+    @api.multi
     def _compute_image(self):
         # Note: this computed field depend on the lang used in the context
         # as the name of the record is used for generating the thumbnail
         for record in self:
             record.images = record._get_image_data_for_record()
 
+    @api.multi
     def _get_image_url_key(self, image_relation):
         # You can inherit this method to change the name of the image of
         # your website. By default we use the name of the product or category
         # linked to the image processed
         # Note the url will be slugify by the get_or_create_thumnail
+        self.ensure_one()
         return self.display_name
 
+    @api.multi
     def _get_image_data_for_record(self):
         self.ensure_one()
         res = []
@@ -35,18 +39,30 @@ class ShopinvaderImageMixin(models.AbstractModel):
         for image_relation in self[self._image_field]:
             url_key = self._get_image_url_key(image_relation)
             image_data = {}
-            tag = ''
-            if image_relation.tag_id:
-                tag = image_relation.tag_id.name
             for resize in resizes:
                 thumbnail = image_relation.image_id.get_or_create_thumbnail(
                     resize.size_x,
                     resize.size_y,
                     url_key=url_key)
-                image_data[resize.key] = {
-                    'src': thumbnail.url,
-                    'alt': self.name,
-                    'tag': tag,
-                    }
+                image_data[resize.key] = self._prepare_data_resize(
+                    thumbnail, image_relation)
             res.append(image_data)
         return res
+
+    @api.multi
+    def _prepare_data_resize(self, thumbnail, image_relation):
+        """
+        Prepare data to fill images serialized field
+        :param thumbnail: storage.thumbnail recordset
+        :param image_relation: product.image.relation recordset
+        :return: dict
+        """
+        self.ensure_one()
+        tag = ''
+        if image_relation.tag_id:
+            tag = image_relation.tag_id.name
+        return {
+            'src': thumbnail.url,
+            'alt': self.name,
+            'tag': tag,
+        }


### PR DESCRIPTION
**Actual behaviour**
Actually, when the images (serialized field) is computed, the url is the one of the storage backend (to reach the file/image etc).
But we doesn't want to use this url into a website.
Example: https://s3.amazon.com/arandomdirectory/mypicture.jpg

**Expected behaviour**
We want to force a specific url (keep only the final part - filename - with arguments) depending on the se.backend.
Example: `http://images.mycustomer.com/arandomdirectory/mypicture.jpg?value=1`
`image_proxy_url = "https://image.mywebsite.dev/special-directory/here/"`
Expected result: `https://image.mywebsite.dev/special-directory/here/mypicture.jpg?value=1`
So the protocol must be replaced (http, https etc) and only the final part should stay.

**Code**
- [x] Add setup
- [x] Add an url field on the `shopinvader.backend` model
- [x] Replace the `storage.backend` url with forced url (during images field compute)
- [x] Add unit test