### PR TITLE
[10.0][IMP] Improvement to avoid warning message

### DIFF
--- a/shopinvader/models/shopinvader_partner.py
+++ b/shopinvader/models/shopinvader_partner.py
@@ -64,7 +64,12 @@ class ShopinvaderPartner(models.Model):
             if not self._is_same_partner_value(partner, vals):
                 self._create_child_partner(partner, vals)
             return partner
-        return partner.create(vals.copy())
+        partner_values = vals.copy()
+        keys = partner_values.keys()
+        # Some fields are related to shopinvader.partner and doesn't exist
+        # in res.partner
+        [partner_values.pop(k) for k in keys if k not in partner._fields]
+        return partner.create(partner_values)
 
     @api.model
     def _get_unique_partner_domain(self, vals):

--- a/shopinvader/services/customer.py
+++ b/shopinvader/services/customer.py
@@ -63,7 +63,7 @@ class CustomerService(Component):
     def _prepare_params(self, params):
         address = self.component(usage='addresses')
         params = address._prepare_params(params)
-        params['backend_id'] = self.shopinvader_backend.id,
+        params['backend_id'] = self.shopinvader_backend.id
         return params
 
     def _get_and_assign_cart(self):


### PR DESCRIPTION
**Improvements**
- [x] During the creation of `res.partner`, use only fields related to the `res.partner` (instead of `shopinvader.partner`)
- [x] During the fill of `backend_id`, the comma give the ID as a tuple