### PR TITLE
Fix computed index field on search engine bindings

### DIFF
--- a/shopinvader_search_engine/models/shopinvader_category.py
+++ b/shopinvader_search_engine/models/shopinvader_category.py
@@ -16,7 +16,8 @@ class ShopinvaderCategory(models.Model):
         store=True,
         required=False)
 
-    @api.depends('backend_id.se_backend_id')
+    @api.depends('backend_id.se_backend_id',
+                 'backend_id.se_backend_id.index_ids')
     def _compute_index(self):
         for record in self:
             se_backend = record.backend_id.se_backend_id

--- a/shopinvader_search_engine/models/shopinvader_variant.py
+++ b/shopinvader_search_engine/models/shopinvader_variant.py
@@ -16,7 +16,8 @@ class ShopinvaderVariant(models.Model):
         store=True,
         required=False)
 
-    @api.depends('backend_id.se_backend_id')
+    @api.depends('backend_id.se_backend_id',
+                 'backend_id.se_backend_id.index_ids')
     def _compute_index(self):
         for record in self:
             se_backend = record.backend_id.se_backend_id


### PR DESCRIPTION
When assigning first multiple language on the shopinvader backend you
end up creating multiple search engine bindings, one per product and
per lang.
And for each lang that has no index entry in the search engine backend
the field index on binding is empty.  Which is fine.

But, when adding the missing lang in search engine backend indexes,
index field on binding was not recomputed.

The only option to recompute it was to trigger a rewrite on Search
engine backend on the shopinvader backend.

This fix extends the depends on indexes of the binding field index
to be triggered when adding a new index entry in search engine. Thus
you don't need to hack your way anymore with the search engine field
on the shopinvader backend.