### PR TITLE
[IMP] reorganize shopinvader backend view (renamed to website view)

### DIFF
--- a/shopinvader/__manifest__.py
+++ b/shopinvader/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopinvader",
     "summary": "Shopinvader",
-    "version": "10.0.2.0.0",
+    "version": "10.0.2.0.1",
     "category": "e-commerce",
     "website": "https://akretion.com",
     "author": "Akretion",

--- a/shopinvader/demo/backend_demo.xml
+++ b/shopinvader/demo/backend_demo.xml
@@ -2,7 +2,7 @@
 <odoo>
 
     <record id="backend_1" model="shopinvader.backend">
-        <field name="name">Demo Shopinvader Backend</field>
+        <field name="name">Demo Shopinvader Website</field>
         <field name="location">http://location</field>
         <field name="auth_api_key_id" ref="auth_api_key_locomotive"/>
         <field name="lang_ids" eval="[(6, 0, [ref('base.lang_en')])]"/>

--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -37,7 +37,7 @@ class ShopinvaderBackend(models.Model):
     anonymous_partner_id = fields.Many2one(
         'res.partner',
         'Anonymous Partner',
-        help='Provide the fiscal position for unlogged users',
+        help='Provide partner settings for unlogged users (i.e. fiscal position)',
         required=True,
         default=lambda self: self.env.ref('shopinvader.anonymous'))
     sequence_id = fields.Many2one(

--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -37,11 +37,13 @@ class ShopinvaderBackend(models.Model):
     anonymous_partner_id = fields.Many2one(
         'res.partner',
         'Anonymous Partner',
+        help='Provide the fiscal position for unlogged users',
         required=True,
         default=lambda self: self.env.ref('shopinvader.anonymous'))
     sequence_id = fields.Many2one(
         'ir.sequence',
-        'Sequence')
+        'Sequence',
+        help='Naming policy for orders and carts')
     auth_api_key_id = fields.Many2one(
         'auth.api.key',
         required=True,

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -49,7 +49,7 @@
                             </group>
                         </page>
                         <page name="search_eng" string="Search engine">
-                            <group name="filter_ids" colspan="4">
+                            <group name="search_filters" colspan="4">
                                 <field name="filter_ids" nolabel="1"/>
                             </group>
                         </page>
@@ -72,7 +72,7 @@
                         </page>
                         <page name="localization" string="Localization">
                             <group name="languages" string="Languages">
-                                <span>Languages available in the website.</span>
+                                <span>Available languages in the website.</span>
                                 <newline />
                                 <field name="lang_ids" nolabel="1" />
                             </group>

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -3,7 +3,7 @@
     <record id="shopinvader_backend_view_form" model="ir.ui.view">
         <field name="model">shopinvader.backend</field>
         <field name="arch" type="xml">
-            <form string="Shopinvader Backend">
+            <form string="Shopinvader Website">
                 <header>
                     <button name="%(shopinvader_variant_binding_wizard_act_window)d"
                             type="action"
@@ -120,7 +120,7 @@
     </record>
 
     <record id="action_shopinvader_backend" model="ir.actions.act_window">
-        <field name="name">Shopinvader Backends</field>
+        <field name="name">Shopinvader Website</field>
         <field name="res_model">shopinvader.backend</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
@@ -128,7 +128,7 @@
     </record>
 
     <menuitem id="menu_shopinvader_backend"
-              name="Backends"
+              name="Websites"
               sequence="0"
               parent="menu_shopinvader_root"
               action="action_shopinvader_backend"/>

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -91,6 +91,7 @@
                                 </field>
                             </group>
                         </page>
+                        <page name="delivery" string="Delivery" />
                         <page name="developper" string="Developper">
                             <group name="developper" colspan="4">
                                 <group name="product" string="Product" col="10" colspan="4">

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -66,7 +66,9 @@
                             </group>
                         </page>
                         <page name="products" string="Products">
-                            <field name="use_shopinvader_product_name"/>
+                            <group>
+                                <field name="use_shopinvader_product_name"/>
+                            </group>
                         </page>
                         <page name="localization" string="Localization">
                             <group name="languages" string="Languages">

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -42,12 +42,20 @@
                         <field name="name" class="oe_inline"/>
                     </h1>
                     <notebook>
-                        <page name="config" string="Configuration">
+                        <page name="config" string="credentials">
                             <group name="config" colspan="4" col="4">
                                 <field name="location" placeholder="e.g. http://ecommerce.shopinvader.com"/>
-                                <field name="company_id"/>
                                 <field name="auth_api_key_id"/>
-                                <field name="lang_ids" widget="many2many_tags"/>
+                            </group>
+                        </page>
+                        <page name="search_eng" string="Search engine">
+                            <group name="filter_ids" colspan="4">
+                                <field name="filter_ids" nolabel="1"/>
+                            </group>
+                        </page>
+                        <page name="sale" string="Sale">
+                            <group name="cart_conf" string="Cart configuration">
+                                <field name="company_id"/>
                                 <field name="sequence_id"/>
                                 <field name="last_step_id"/>
                                 <field name="anonymous_partner_id"/>
@@ -58,11 +66,8 @@
                             <group name="allowed_country" colspan="4">
                                 <field name="allowed_country_ids" nolabel="1"/>
                             </group>
-                            <group name="filter_ids" colspan="4">
-                                <field name="filter_ids" nolabel="1"/>
-                            </group>
                         </page>
-                        <page name="email" string="Email">
+                        <page name="email" string="Notifications">
                             <group name="notification" string="Notification">
                                 <field name="notification_ids" nolabel="1">
                                     <tree editable="bottom">

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -42,9 +42,9 @@
                         <field name="name" class="oe_inline"/>
                     </h1>
                     <notebook>
-                        <page name="config" string="credentials">
+                        <page name="config" string="Credentials">
                             <group name="config" colspan="4" col="4">
-                                <field name="location" placeholder="e.g. http://ecommerce.shopinvader.com"/>
+                                <field name="location" placeholder="e.g. https://ecommerce.shopinvader.com"/>
                                 <field name="auth_api_key_id"/>
                             </group>
                         </page>
@@ -55,15 +55,27 @@
                         </page>
                         <page name="sale" string="Sale">
                             <group name="cart_conf" string="Cart configuration">
-                                <field name="company_id"/>
-                                <field name="sequence_id"/>
                                 <field name="last_step_id"/>
                                 <field name="anonymous_partner_id"/>
                                 <field name="pricelist_id" required="1"/>
-                                <field name="account_analytic_id"/>
-                                <field name="use_shopinvader_product_name"/>
                             </group>
-                            <group name="allowed_country" colspan="4">
+                            <group name="sale_conf" string="Sale configuration">
+                                <field name="company_id"/>
+                                <field name="sequence_id"/>
+                                <field name="account_analytic_id"/>
+                            </group>
+                        </page>
+                        <page name="products" string="Products">
+                            <field name="use_shopinvader_product_name"/>
+                        </page>
+                        <page name="localization" string="Localization">
+                            <group name="languages" string="Languages">
+                                <span>Languages available in the website.</span>
+                                <newline />
+                                <field name="lang_ids" nolabel="1" />
+                            </group>
+                            <group name="allowed_country" string="Countries">
+                                <span>Allowed countries in delivery addresses</span><newline />
                                 <field name="allowed_country_ids" nolabel="1"/>
                             </group>
                         </page>

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -109,12 +109,6 @@
                                             string="Bind all category"
                                             type="object"/>
                                 </group>
-                                <group name="site" string="Site Configuration" col="10" colspan="4">
-                                    <button
-                                            name="export_store_configuration"
-                                            string="Export Store Config"
-                                            type="object"/>
-                                </group>
                             </group>
                         </page>
                     </notebook>

--- a/shopinvader_assortment/__manifest__.py
+++ b/shopinvader_assortment/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Shopinvader Assortment',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'license': 'AGPL-3',
     'author': 'ACSONE SA/NV',
     'website': 'http://acsone.eu',

--- a/shopinvader_assortment/views/shopinvader_backend.xml
+++ b/shopinvader_assortment/views/shopinvader_backend.xml
@@ -9,15 +9,17 @@
         <field name="model">shopinvader.backend</field>
         <field name="inherit_id" ref="shopinvader.shopinvader_backend_view_form"/>
         <field name="arch" type="xml">
-            <field name="pricelist_id" position="before">
-                <field name="product_manual_binding"/>
-                <field name="product_assortment_id"
-                       attrs="{'invisible': [('product_manual_binding', '=', True)],
-                               'required': [('product_manual_binding', '!=', True)]}"
-                       context="{'form_view_ref': 'product_assortment.product_assortment_view_form',
-                                 'product_assortment': True,
-                                 'default_is_assortment': 1}"/>
-            </field>
+            <page name="products" position="inside">
+                <group name="product_assortment" string="Assortment">
+                    <field name="product_manual_binding"/>
+                    <field name="product_assortment_id"
+                           attrs="{'invisible': [('product_manual_binding', '=', True)],
+                                   'required': [('product_manual_binding', '!=', True)]}"
+                           context="{'form_view_ref': 'product_assortment.product_assortment_view_form',
+                                     'product_assortment': True,
+                                     'default_is_assortment': 1}"/>
+                </group>
+            </page>
         </field>
     </record>
 

--- a/shopinvader_delivery_carrier/__manifest__.py
+++ b/shopinvader_delivery_carrier/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopinvader Carrier",
     "summary": "Carrier integration for Shopinvader",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "e-commerce",
     "website": "https://akretion.com",
     "author": "Akretion",

--- a/shopinvader_delivery_carrier/views/backend_view.xml
+++ b/shopinvader_delivery_carrier/views/backend_view.xml
@@ -6,16 +6,14 @@
         <field name="inherit_id"
                ref="shopinvader.shopinvader_backend_view_form"/>
         <field name="arch" type="xml">
-            <notebook position="inside">
-                <page name="carrier" string="Carriers">
-                    <group name="carrier" colspan="4">
-                        <field name="carrier_ids"
-                               colspan="4"
-                               nolabel="True">
-                        </field>
-                    </group>
-                </page>
-            </notebook>
+            <page name="delivery" position="inside">
+                <group name="carrier" colspan="4">
+                    <field name="carrier_ids"
+                           colspan="4"
+                           nolabel="True">
+                    </field>
+                </group>
+            </page>
         </field>
     </record>
 

--- a/shopinvader_image/__manifest__.py
+++ b/shopinvader_image/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopinvader image",
     "summary": "Add the export of Image for Shopinvader",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "e-commerce",
     "website": "https://akretion.com",
     "author": "Akretion",

--- a/shopinvader_image/models/shopinvader_backend.py
+++ b/shopinvader_image/models/shopinvader_backend.py
@@ -12,8 +12,8 @@ class ShopinvaderBackend(models.Model):
     shopinvader_variant_resize_ids = fields.Many2many(
         comodel_name='shopinvader.image.resize',
         relation="product_image_resize",
-        string='Product Image Resize')
+        string='Product Image Size')
     shopinvader_category_resize_ids = fields.Many2many(
         comodel_name='shopinvader.image.resize',
         relation="category_image_resize",
-        string='Category Image Resize')
+        string='Category Image Size')

--- a/shopinvader_image/views/shopinvader_backend_view.xml
+++ b/shopinvader_image/views/shopinvader_backend_view.xml
@@ -6,11 +6,12 @@
         <field name="inherit_id"
                ref="shopinvader.shopinvader_backend_view_form"/>
         <field name="arch" type="xml">
-            <field name="pricelist_id" position="after">
-                <separator name="image" colspan="4"/>
-                <field name="shopinvader_variant_resize_ids" widget="many2many_tags"/>
-                <field name="shopinvader_category_resize_ids" widget="many2many_tags"/>
-            </field>
+            <page name="products" position="inside">
+                <group name="image" string="Images" colspan="4">
+                    <field name="shopinvader_variant_resize_ids" widget="many2many_tags"/>
+                    <field name="shopinvader_category_resize_ids" widget="many2many_tags"/>
+                </group>
+            </page>
         </field>
     </record>
 

--- a/shopinvader_locomotive/__manifest__.py
+++ b/shopinvader_locomotive/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Shopinvader Locomotive CMS Connector',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Connector',
     'summary': 'Manage communications between Shopinvader and Locomotive CMS',
     'author': 'Akretion',

--- a/shopinvader_locomotive/views/shopinvader_backend_view.xml
+++ b/shopinvader_locomotive/views/shopinvader_backend_view.xml
@@ -16,11 +16,12 @@
                     class="oe_highlight"
                     groups="shopinvader.group_shopinvader_manager"/>
             </header>
-            <field name="company_id" position="after">
-                <separator name="image" colspan="4"/>
-                <field name="username" colspan="2"/>
+            <field name="location" position="after">
+                <field name="username" string="Email" colspan="2"/>
                 <field name="password" colspan="2"/>
                 <field name="handle" colspan="2"/>
+            </field>
+            <field name="pricelist_id" position="after">
                 <field
                     name="currency_ids"
                     widget="many2many_tags"

--- a/shopinvader_locomotive/views/shopinvader_backend_view.xml
+++ b/shopinvader_locomotive/views/shopinvader_backend_view.xml
@@ -8,14 +8,16 @@
         <field name="inherit_id"
                ref="shopinvader.shopinvader_backend_view_form"/>
         <field name="arch" type="xml">
-            <header position="inside">
-                <button
-                    name="synchronize_metadata"
-                    type="object"
-                    string="Synchronize Metadata"
-                    class="oe_highlight"
-                    groups="shopinvader.group_shopinvader_manager"/>
-            </header>
+            <page name="developper" position="inside">
+                <group name="locomotive" string="LocomotiveCMS">
+                    <button
+                        name="synchronize_metadata"
+                        type="object"
+                        string="Synchronize Metadata"
+                        class="oe_highlight"
+                        groups="shopinvader.group_shopinvader_manager"/>
+                </group>
+            </page>
             <field name="location" position="after">
                 <field name="username" string="Email" colspan="2"/>
                 <field name="password" colspan="2"/>

--- a/shopinvader_locomotive/views/shopinvader_backend_view.xml
+++ b/shopinvader_locomotive/views/shopinvader_backend_view.xml
@@ -10,6 +10,8 @@
         <field name="arch" type="xml">
             <page name="developper" position="inside">
                 <group name="locomotive" string="LocomotiveCMS">
+                    <span>Synchronize metadata push this configuration to locomotive.
+                        For ex: countries, currencies, indexes (TODO), credentials (TODO)</span>
                     <button
                         name="synchronize_metadata"
                         type="object"

--- a/shopinvader_payment/__manifest__.py
+++ b/shopinvader_payment/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopinvader Payment",
     "summary": "Payment integration for Shopinvader",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "e-commerce",
     "website": "https://akretion.com",
     "author": "Akretion",

--- a/shopinvader_payment/views/backend_view.xml
+++ b/shopinvader_payment/views/backend_view.xml
@@ -6,17 +6,15 @@
     <field name="inherit_id"
            ref="shopinvader.shopinvader_backend_view_form"/>
     <field name="arch" type="xml">
-        <notebook position="inside">
-            <page name="payment" string="Payment">
-                <group name="payment_method" colspan="4">
-                    <field name="payment_method_ids"
-                           string="Payment Method"
-                           colspan="4"
-                           nolabel="True">
-                    </field>
-                </group>
-            </page>
-        </notebook>
+        <page name="sale" position="inside">
+            <group name="payment_method" string="Payment" colspan="4">
+                <field name="payment_method_ids"
+                       string="Payment Method"
+                       colspan="4"
+                       nolabel="True">
+                </field>
+            </group>
+        </page>
     </field>
 </record>
 

--- a/shopinvader_product_stock/__manifest__.py
+++ b/shopinvader_product_stock/__manifest__.py
@@ -9,7 +9,7 @@
                "export (by backend)",
     'description': """
         Connector search engine for Stock""",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "e-commerce",
     "website": "https://akretion.com",
     "author": "Akretion,ACSONE SA/NV",

--- a/shopinvader_product_stock/views/shopinvader_backend.xml
+++ b/shopinvader_product_stock/views/shopinvader_backend.xml
@@ -5,11 +5,13 @@
         <field name="inherit_id" ref="shopinvader.shopinvader_backend_view_form"/>
         <field name="priority" eval="90"/>
         <field name="arch" type="xml">
-            <field name="pricelist_id" position="after">
-                <field name="product_stock_field_id" widget="selection"/>
-                <field name="synchronize_stock" widget="selection"/>
-                <field name="warehouse_ids" widget="many2many_tags"/>
-            </field>
+            <page name="products" position="inside">
+                <group name="stock" string="Stock">
+                    <field name="product_stock_field_id" widget="selection"/>
+                    <field name="synchronize_stock" widget="selection"/>
+                    <field name="warehouse_ids" widget="many2many_tags"/>
+                </group>
+            </page>
         </field>
     </record>
 </odoo>

--- a/shopinvader_sale_profile/__manifest__.py
+++ b/shopinvader_sale_profile/__manifest__.py
@@ -9,7 +9,7 @@
         This ShopInvader submodule give the possibility to specify some
         sale profiles (with pricelist per profile) per backend to apply on
         your customers""",
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'depends': [
         'base',
         'shopinvader_locomotive',

--- a/shopinvader_search_engine/__manifest__.py
+++ b/shopinvader_search_engine/__manifest__.py
@@ -5,7 +5,7 @@
 
 
 {'name': 'Shopinvader Catalog Search Engine Connector',
- 'version': '10.0.1.0.0',
+ 'version': '10.0.1.0.1',
  'author': 'Akretion',
  'website': 'www.akretion.com',
  'license': 'AGPL-3',

--- a/shopinvader_search_engine/views/shopinvader_backend_view.xml
+++ b/shopinvader_search_engine/views/shopinvader_backend_view.xml
@@ -6,10 +6,10 @@
         <field name="inherit_id"
                ref="shopinvader.shopinvader_backend_view_form"/>
         <field name="arch" type="xml">
-            <field name="auth_api_key_id" position="after">
+            <page name="search_eng" position="inside">
                 <field name="se_backend_id"/>
-            </field>
-            <group name="category" position="after">
+            </page>
+            <page name="developper" position="inside">
                 <group name="indexes" string="Search engined indexes" col="10" colspan="4">
                     <button
                             name="force_recompute_all_binding_index"
@@ -24,7 +24,7 @@
                             string="Clear"
                             type="object"/>
                 </group>
-            </group>
+            </page>
         </field>
     </record>
 


### PR DESCRIPTION
This PR refactors the shopinvader backend.

Backend is renamed to website in (technical name stays shopinvader.backend).
New pages are added, and dependend modules are updated to fit the new structure.
Some help message are added to fields.
![screenshot_2018-12-11 demo shopinvader backend - odoo 1](https://user-images.githubusercontent.com/8331206/49821637-36620b80-fd7b-11e8-8e82-00eda1a66795.png)
![screenshot_2018-12-11 demo shopinvader backend - odoo](https://user-images.githubusercontent.com/8331206/49821638-36620b80-fd7b-11e8-88e7-7afcad2f429d.png)

The goal is to have a more clear and predictable user interface.

