### PR TITLE
[FIX] shopinvader_promotion_rule: Remove coupon only if an emtpy valu…

### DIFF
--- a/shopinvader_locomotive/tests/test_backend.py
+++ b/shopinvader_locomotive/tests/test_backend.py
@@ -79,6 +79,7 @@ class TestBackend(LocoCommonCase):
         return metafields
 
     def test_synchronize_metadata(self):
+        ref = self.env.ref
         with mock_site_api(self.base_url, self.site) as mock:
             self.backend.synchronize_metadata()
             metafields = self._extract_metafields(
@@ -100,16 +101,26 @@ class TestBackend(LocoCommonCase):
                     },
                     'available_countries': {
                         "en": [
-                            {"name": "France", "id": 76},
-                            {"name": "United States", "id": 235},
+                            {
+                                "name": "France",
+                                "id": ref('base.fr').id
+                            },
+                            {
+                                "name": "United States",
+                                "id": ref('base.us').id
+                            },
                         ]
                     },
-                    'currencies_rate': {"USD": 1.5289, "EUR": 1.0}
+                    'currencies_rate': {
+                        "USD": ref('base.USD').rate,
+                        "EUR": ref('base.EUR').rate
+                    }
                 }
             }
             self.assertEqual(metafields, expected_metafields)
 
     def test_synchronize_currency(self):
+        ref = self.env.ref
         with mock_site_api(self.base_url, self.site) as mock:
             self.backend.synchronize_currency()
             metafields = self._extract_metafields(
@@ -120,7 +131,10 @@ class TestBackend(LocoCommonCase):
                     'bar': 'test',
                     'all_filters': {},
                     'available_countries': {},
-                    'currencies_rate': {"USD": 1.5289, "EUR": 1.0}
+                    'currencies_rate': {
+                        "USD": ref('base.USD').rate,
+                        "EUR": ref('base.EUR').rate
+                    }
                 }
             }
             self.assertEqual(metafields, expected_metafields)

--- a/shopinvader_promotion_rule/services/cart.py
+++ b/shopinvader_promotion_rule/services/cart.py
@@ -16,20 +16,23 @@ class CartService(Component):
     _inherit = 'shopinvader.cart.service'
 
     def _update(self, cart, params):
+        is_coupon_code_specified = "coupon_code" in params
         coupon_code = params.pop('coupon_code', None)
-        if coupon_code is not None:
-            if 'payment_params' in params:
-                raise UserError(
-                    _("Appling discount and paying can "
-                      "not be done in the same call"))
+        if is_coupon_code_specified:
+            if coupon_code is not None:
+                if 'payment_params' in params:
+                    raise UserError(
+                        _("Appling discount and paying can "
+                          "not be done in the same call"))
         res = super(CartService, self)._update(cart, params)
-        if coupon_code:
-            cart.add_coupon(coupon_code)
-        else:
-            if cart.coupon_code:
-                # the promotion has been removed:
-                # * clear the promotion
-                cart.clear_promotions()
+        if is_coupon_code_specified:
+            if coupon_code:
+                cart.add_coupon(coupon_code)
+            else:
+                if cart.coupon_code:
+                    # the promotion has been removed:
+                    # * clear the promotion
+                    cart.clear_promotions()
         # apply default promotion
         cart.apply_promotions()
         return res
@@ -52,7 +55,7 @@ class CartService(Component):
     # Validator
     def _validator_update(self):
         res = super(CartService, self)._validator_update()
-        res['coupon_code'] = {'type': 'string'}
+        res['coupon_code'] = {'type': 'string', 'nullable': True}
         return res
 
     # converter

--- a/shopinvader_promotion_rule/tests/test_cart.py
+++ b/shopinvader_promotion_rule/tests/test_cart.py
@@ -64,10 +64,18 @@ class TestCart(CommonConnectedCartCase, AbstractCommonPromotionCase):
             'code': 'ELDONGHUT',
             'name': u'Best Promo',
             'discount_amount': 20.0}, promotion_rule_coupon)
-
-        # if we remove the coupon, the coupon rule is removed but the default
-        # rules are applied
+        # if we update the cart without specifying a coupon into the message
+        # the coupon is preserved
         res = self.service.dispatch('update', params={})
+        for line in self.cart.order_line:
+            self.check_discount_rule_set(
+                line, self.promotion_rule_coupon
+            )
+
+        # if we update the cart with an empty coupon,
+        # the coupon rule is removed but the default
+        # rules are applied
+        res = self.service.dispatch('update', params={'coupon_code': None})
         for line in self.cart.order_line:
             self.check_discount_rule_set(
                 line, self.promotion_rule_auto


### PR DESCRIPTION
…e is provided

Without this fix, the coupon is removed when the cart is updated at payment step...