### PR TITLE
WIP Export facetting setting to algolia

### DIFF
--- a/shopinvader_algolia/models/__init__.py
+++ b/shopinvader_algolia/models/__init__.py
@@ -1,3 +1,5 @@
 # -*- coding: utf-8 -*-
 
 from . import shopinvader_variant
+from . import shopinvader_category
+from . import se_index

--- a/shopinvader_algolia/models/se_index.py
+++ b/shopinvader_algolia/models/se_index.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Akretion (http://www.akretion.com).
+# @author Florian da Costa <florian?dacosta@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SeIndex(models.Model):
+    _inherit = 'se.index'
+
+    def _get_setting_values(self):
+        data = super(SeIndex, self)._get_setting_values()
+        model = self.model_id.model
+        # TODO check backend se type and call specific algolia method?
+        facetting_values = self.env[model]._get_facetting_values(
+            self.backend_id)
+        data.update({'attributesForFaceting': facetting_values})
+        return data

--- a/shopinvader_algolia/models/shopinvader_category.py
+++ b/shopinvader_algolia/models/shopinvader_category.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Akretion (http://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class ShopinvaderCategory(models.Model):
+    _inherit = 'shopinvader.category'
+
+    @api.model
+    def _get_facetting_values(self, se_backend):
+        return [
+            "id",
+            "level",
+            "parent.id",
+            "redirect_url_key",
+            "url_key"
+        ]

--- a/shopinvader_algolia/models/shopinvader_variant.py
+++ b/shopinvader_algolia/models/shopinvader_variant.py
@@ -3,7 +3,7 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ShopinvaderVariant(models.Model):
@@ -28,3 +28,22 @@ class ShopinvaderVariant(models.Model):
             for categ in record.shopinvader_categ_ids:
                 record.hierarchical_categories['lvl%s' % categ.level] =\
                     get_full_name(categ.record_id)
+
+    @api.model
+    def _get_facetting_values(self, se_bakend):
+        default = [
+            "categories.id",
+            "Categories.lvl0hierarchical",
+            "Categories.lvl1hierarchical",
+            "Categories.lvl2hierarchical",
+            "main",
+            "redirect_url_key",
+            "url_key",
+            "sku",
+            "price.default.value",
+        ]
+        invader_backend = self.env['shopinvader.backend'].search(
+            [('se_backend_id', '=', se_bakend.id)])
+        filters = invader_backend.filter_ids
+        filter_facetting_values = [f.display_name for f in filters]
+        return default + filter_facetting_values


### PR DESCRIPTION
replace https://github.com/akretion/odoo-shopinvader/pull/250
Depends on https://github.com/akretion/connector-search-engine/pull/37

Also, it still misses one feature.
We should export settings at 2 moment: 
1) by cron, once a day, we force the setting export (already implemented)
2) At the first index creation (not implemented yet)
I wonder where I should do the second export.
I think I could do it in method `_jobify_batch_export`  because it is called both by daily export binding cron and the button at backend level.
If I do it there, should I do it in a job, to avoid to make the batch export job to fail if we fail to export the setting, or is it ok?
If the user do an export directly from the binding, it won't do the check either, but I do not think it is an issue, I guess the first export of the index should be done directly from the se backend or from the  cron.

Any ideal about this?

@hparfr @sebastienbeau 