### PR TITLE
[FIX] remove carrier_id from sale order after add/update/delete actions

### DIFF
--- a/shopinvader_delivery_carrier/services/cart.py
+++ b/shopinvader_delivery_carrier/services/cart.py
@@ -120,4 +120,5 @@ class CartService(Component):
         cart.delivery_set()
 
     def _unset_carrier(self, cart):
+        cart.write({'carrier_id': False})
         cart._delivery_unset()

--- a/shopinvader_delivery_carrier/tests/test_carrier.py
+++ b/shopinvader_delivery_carrier/tests/test_carrier.py
@@ -81,15 +81,18 @@ class CarrierCase(CommonConnectedCartCase):
         self._apply_carrier_and_assert_set()
         cart = self.add_item(self.product_1.id, 2)
         self.assertEqual(cart['shipping']['amount']['total'], 0)
+        self.assertFalse(cart['shipping']['selected_carrier'])
 
     def test_reset_carrier_on_update_item(self):
         cart = self._apply_carrier_and_assert_set()
         items = cart['lines']['items']
         cart = self.update_item(items[0]['id'], 1)
         self.assertEqual(cart['shipping']['amount']['total'], 0)
+        self.assertFalse(cart['shipping']['selected_carrier'])
 
     def test_reset_carrier_on_delte_item(self):
         cart = self._apply_carrier_and_assert_set()
         items = cart['lines']['items']
         cart = self.delete_item(items[0]['id'])
         self.assertEqual(cart['shipping']['amount']['total'], 0)
+        self.assertFalse(cart['shipping']['selected_carrier'])


### PR DESCRIPTION
A previous PR #267 reset the carrier after a cart update. Unfortunately it calls an Odoo method which only remove the delivery sale order line, not the carrier on the sale order.
As result, we still return selected_carrier data to the front which causes some problem as the delivery method is still selected even if it has been removed on Odoo side