### PR TITLE
[ADD][10.0] Auto-bind related categories during product binding

### DIFF
--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -207,8 +207,10 @@ class ShopinvaderBackend(models.Model):
         level = self.category_binding_level - 1
         categories = products.mapped("categ_id")
         # pull up until the correct level
+        parent_categories = categories
         while level > 0:
-            categories |= categories.mapped("parent_id")
+            parent_categories = parent_categories.mapped("parent_id")
+            categories |= parent_categories
             level -= 1
         return categories
 

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -104,6 +104,7 @@
                                             type="object"/>
                                 </group>
                                 <group name="category" string="Category" col="10" colspan="4">
+                                    <field name="category_binding_level"/>
                                     <button
                                             name="bind_all_category"
                                             string="Bind all category"

--- a/shopinvader/wizards/shopinvader_variant_binding_wizard.py
+++ b/shopinvader/wizards/shopinvader_variant_binding_wizard.py
@@ -69,16 +69,17 @@ class ShopinvaderVariantBindingWizard(models.TransientModel):
             for product in wizard.product_ids:
                 binded_products = binded_templates[product.product_tmpl_id]
                 for shopinvader_product in binded_products.values():
-                    data = {
-                        'record_id': product.id,
-                        'backend_id': wizard.backend_id.id,
-                        'shopinvader_product_id': shopinvader_product.id
-                    }
                     binded_variants = shopinvader_product. \
                         shopinvader_variant_ids
                     bind_record = binded_variants.filtered(
-                        lambda p: p.record_id.id == product.id)
+                        lambda p: p.record_id == product)
                     if not bind_record:
+                        data = {
+                            'record_id': product.id,
+                            'backend_id': wizard.backend_id.id,
+                            'shopinvader_product_id': shopinvader_product.id
+                        }
                         binding.create(data)
                     elif not bind_record.active:
                         bind_record.write({'active': True})
+            wizard.backend_id.auto_bind_categories()


### PR DESCRIPTION
**Actual behaviour**
When a user want to bind some products, he has to find manually which categories are related and then bind them.
**New behaviour**
Let the possibility to bind automatically categories related to binded products with a level number (to define how many parent's category to bind)

You can set 0 into the level field to don't bind automatically categories.

**Bonus**
Little optimisation into `_bind_all_content()` function (about searches)