### PR TITLE
[10.0][FIX] Fix compute of shopinvader_parent_id who should be sudo

### DIFF
--- a/shopinvader/models/shopinvader_category.py
+++ b/shopinvader/models/shopinvader_category.py
@@ -35,6 +35,7 @@ class ShopinvaderCategory(models.Model):
         compute='_compute_parent_category',
         store=True,
         index=True,
+        compute_sudo=True,
     )
     shopinvader_child_ids = fields.Many2many(
         'shopinvader.category',


### PR DESCRIPTION
**Actual behaviour (bug)**
**Step to reproduce**
- Define a product.category X with some children
- Define a backend on company A and bind a category X
- Define a backend on company B and bind a category X
On this second bind, you will have an access error.

During the binding, the `depends` (on `_compute_parent_category` function) ask to recompute the target field. But the record rule `shopinvader.shopinvader_category_comp_rule` doesn't allow a user to read a `shopinvader.category` from another backend (on another company). So it raises an `AccessError`.

**Fix**
Just force sudo for this field computation (add `compute_sudo=True`)