### PR TITLE
[FIX] replace user name by user contact name to be able to change the user name

### DIFF
--- a/partner_contact_company/__manifest__.py
+++ b/partner_contact_company/__manifest__.py
@@ -16,6 +16,7 @@
     ],
     'data': [
         'views/partner_view.xml',
+        'views/users_view.xml',
     ],
     'demo': [
         'demo/partner.xml',

--- a/partner_contact_company/views/users_view.xml
+++ b/partner_contact_company/views/users_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="view_users_form" model="ir.ui.view">
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="arch" type="xml">
+            <field name="name" position="replace">
+                <field name="contact_name" required="1"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
With the module partner_contact_company the field name is readonly, so it is the same on res_users.

We display the field contact_name instead of name in user form to be able to modify the field.