### PR TITLE
[10.0][ADD] Add ask_mail (abstract) + Implement it for sale

### DIFF
--- a/partner_contact_company/models/partner.py
+++ b/partner_contact_company/models/partner.py
@@ -13,7 +13,12 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     company = fields.Char("Company", index=True)
-    contact_name = fields.Char("Contact name", index=True)
+    contact_name = fields.Char(
+        "Contact name",
+        index=True,
+        # We don't have to copy it to avoid issue
+        copy=False,
+    )
 
     name = fields.Char(
         compute="_compute_name",

--- a/shopinvader/models/shopinvader_notification.py
+++ b/shopinvader/models/shopinvader_notification.py
@@ -18,12 +18,24 @@ class ShopinvaderNotification(models.Model):
                 'name': _('Cart Confirmation'),
                 'model': 'sale.order',
                 },
+            'cart_send_email': {
+                'name': _('Cart ask by email'),
+                'model': 'sale.order',
+                },
+            'sale_send_email': {
+                'name': _('Sale ask by email'),
+                'model': 'sale.order',
+                },
             'sale_confirmation': {
                 'name': _('Sale Confirmation'),
                 'model': 'sale.order',
                 },
             'invoice_open': {
                 'name': _('Invoice Validated'),
+                'model': 'account.invoice',
+                },
+            'invoice_send_email': {
+                'name': _('Invoice send email'),
                 'model': 'account.invoice',
                 },
             'new_customer_welcome': {

--- a/shopinvader/services/__init__.py
+++ b/shopinvader/services/__init__.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import service
+from . import abstract_mail
 from . import abstract_sale
 from . import cart
 from . import sale

--- a/shopinvader/services/abstract_mail.py
+++ b/shopinvader/services/abstract_mail.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.addons.component.core import AbstractComponent
+
+
+class AbstractMailService(AbstractComponent):
+    _inherit = 'base.shopinvader.service'
+    _name = 'shopinvader.abstract.mail.service'
+
+    def ask_email(self, _id):
+        """
+        Ask to receive the record ID by email
+        :param _id: int
+        :return:
+        """
+        self._ask_email(_id)
+        return {}
+
+    def _validator_ask_email(self):
+        return {}
+
+    def _is_logged(self):
+        """
+        Check if the current partner is a real partner (not the anonymous one
+        and not empty)
+        :return: bool
+        """
+        logged = False
+        if self.partner and \
+                self.partner != self.shopinvader_backend.anonymous_partner_id:
+            logged = True
+        return logged
+
+    def _get_email_notification_type(self, record):
+        """
+        Based on the given record, get the notification type.
+        By default, it's build like this:
+        <_usage>_send_email
+        :param record: target record
+        :return: str
+        """
+        if hasattr(self, '_usage') and self._usage:
+            return '%s_send_email' % self._usage
+        return ''
+
+    def _load_target_email(self, record_id):
+        """
+        Load the record (based on expose model)
+        :param record_id: int
+        :return: record or None
+        """
+        if not getattr(self, '_expose_model', False):
+            return None
+        return self.env[self._expose_model].browse(record_id)
+
+    def _get_email_recipient(self, record, notif_type):
+        """
+        Get the default recipient of the given record (partner_id by default).
+        :param record: target record
+        :param notif_type: str
+        :return: res.partner recordset
+        """
+        partner = self.env['res.partner'].browse()
+        if record and hasattr(record, 'partner_id') and record.partner_id:
+            partner = record.partner_id
+        return partner
+
+    def _allow_email_notification(self, partner, record, notif_type):
+        """
+        Based on given record, partner and notif_type, check if the partner
+        is allowed to launch this kind of notification
+        :param partner: res.partner
+        :param record: target record
+        :param notif_type: str
+        :return: bool
+        """
+        if not notif_type:
+            return False
+        recipient_partner = self._get_email_recipient(record, notif_type)
+        return partner == recipient_partner
+
+    def _ask_email(self, _id):
+        """
+        Send the notification about the email on the backend
+        :param _id: int
+        :return: dict
+        """
+        # Can not ask an email if not logged
+        if not self._is_logged():
+            return {}
+        target = self._load_target_email(_id)
+        if not target:
+            return {}
+        notif_type = self._get_email_notification_type(target)
+        allow = self._allow_email_notification(
+            self.partner, target, notif_type)
+        if notif_type and allow:
+            self._launch_notification(target, notif_type)
+        return {}
+
+    def _launch_notification(self, targets, notif_type):
+        """
+        Action to launch the notification (on the current backend) for the
+        given record
+        :param targets: recordset
+        :param notif_type: str
+        :return: bool
+        """
+        if not targets:
+            return True
+        for target in targets:
+            self.shopinvader_backend._send_notification(notif_type, target)
+        return True

--- a/shopinvader/services/abstract_sale.py
+++ b/shopinvader/services/abstract_sale.py
@@ -7,7 +7,7 @@ from odoo.addons.component.core import AbstractComponent
 
 
 class AbstractSaleService(AbstractComponent):
-    _inherit = 'base.shopinvader.service'
+    _inherit = 'shopinvader.abstract.mail.service'
     _name = 'shopinvader.abstract.sale.service'
 
     def _parser_product(self):

--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -141,6 +141,7 @@ class CartService(Component):
                 'type': 'integer'
             },
         }
+
     # The following method are 'private' and should be never never NEVER call
     # from the controller.
     # All params are trusted as they have been checked before
@@ -325,6 +326,14 @@ class CartService(Component):
             'product_uom_qty': params['item_qty'],
             'order_id': cart.id,
         }
+
+    def _load_target_email(self, record_id):
+        """
+        As this service doesn't have a _expose_model, we have to do it manually
+        :param record_id: int
+        :return: record or None
+        """
+        return self.env['sale.order'].browse(record_id)
 
     def _get_openapi_default_parameters(self):
         defaults = super(

--- a/shopinvader/tests/test_sale.py
+++ b/shopinvader/tests/test_sale.py
@@ -5,6 +5,7 @@
 
 from .common import CommonCase
 from odoo.exceptions import MissingError
+from odoo import fields
 
 
 class SaleCase(CommonCase):
@@ -42,3 +43,42 @@ class SaleCase(CommonCase):
         # and his right the record does not exist
         with self.assertRaises(MissingError):
             self.service.get(sale.id)
+
+    def _create_notification_config(self):
+        template = self.env.ref("account.email_template_edi_invoice")
+        values = {
+            'model_id': self.env.ref("account.model_account_invoice").id,
+            'notification_type': 'invoice_send_email',
+            'template_id': template.id,
+        }
+        self.service.shopinvader_backend.notification_ids.unlink()
+        self.service.shopinvader_backend.write({
+            'notification_ids': [
+                (0, 0, values),
+            ],
+        })
+
+    def test_ask_email_invoice(self):
+        """
+        Test the ask_email when not logged.
+        As the user is not logged, no email should be created
+        :return:
+        """
+        self._create_notification_config()
+        now = fields.Date.today()
+        notif = "invoice_send_email"
+        self.sale.action_confirm()
+        for line in self.sale.order_line:
+            line.write({
+                'qty_delivered': line.product_uom_qty,
+            })
+        invoice_id = self.sale.action_invoice_create()
+        invoice = self.env['account.invoice'].browse(invoice_id)
+        description = "Notify %s for %s,%s" % (
+            notif, invoice._name, invoice.id)
+        domain = [
+            ('name', '=', description),
+            ('date_created', '>=', now),
+        ]
+        self.service.dispatch('ask_email_invoice', _id=self.sale.id)
+        self.assertEquals(self.env['queue.job'].search_count(domain), 1)


### PR DESCRIPTION
In some case, connected user can ask to re-send documents (pdf) by email.

To implement this behaviour, I create an abstract mail service.
This Abstract service add an entry point for a call "ask_email" with the record id (sale.order for example).

**Process of the abstract service**
- Load the target (using the id and the exposed model);
- Based on the target, determine the notification type;
- Check if the logged user is the owner of the record (using partner_id by default);
- Launch the notification.

I implement it into the abstract sale (to have it into sale and cart services).
For the sale service, maybe the user need invoices related to a sale. So I add a specific method/service call for this (still using the abstract mail service)

**How to use it (by interface)**
- Go into backend configuration
- Create a new notification (select the correct type), then a model and the mail template to use.
- Email will be sent automatically when a user request the email

**Done**
- [x] Add unit test


**Improvements**

- Do a check to avoid spamming the user himself (if the user click 50 times on the same button, do we have to bypass emails?)

