### PR TITLE
[10.0][FIX] remove carrier_id when the shipping address is modified

### DIFF
--- a/shopinvader_delivery_carrier/services/cart.py
+++ b/shopinvader_delivery_carrier/services/cart.py
@@ -112,6 +112,11 @@ class CartService(Component):
         self._unset_carrier(cart)
         return res
 
+    def _update(self, cart, params):
+        if params.get("shipping", {}).get("address"):
+            self._unset_carrier(cart)
+        return super(CartService, self)._update(cart, params)
+
     def _set_carrier(self, cart, carrier_id):
         if carrier_id not in [x["id"] for x in cart._get_available_carrier()]:
             raise UserError(

--- a/shopinvader_delivery_carrier/tests/test_carrier.py
+++ b/shopinvader_delivery_carrier/tests/test_carrier.py
@@ -73,10 +73,18 @@ class CarrierCase(CommonCarrierCase):
         self.assertEqual(cart["shipping"]["amount"]["total"], 0)
         self.assertFalse(cart["shipping"]["selected_carrier"])
 
-    def test_reset_carrier_on_delte_item(self):
+    def test_reset_carrier_on_delete_item(self):
         cart = self._apply_carrier_and_assert_set()
         items = cart["lines"]["items"]
         cart = self.delete_item(items[0]["id"])
+        self.assertEqual(cart["shipping"]["amount"]["total"], 0)
+        self.assertFalse(cart["shipping"]["selected_carrier"])
+
+    def test_reset_carrier_on_changing_delivery_address(self):
+        self._apply_carrier_and_assert_set()
+        cart = self.service.dispatch(
+            "update", params={"shipping": {"address": {"id": self.address.id}}}
+        )["data"]
         self.assertEqual(cart["shipping"]["amount"]["total"], 0)
         self.assertFalse(cart["shipping"]["selected_carrier"])
 


### PR DESCRIPTION
If the shipping address is modified in the cart, we remove the carrier.