### PR TITLE
[10.0][FIX] Fix login without existing email into HTTP header (+ tests)

### DIFF
--- a/shopinvader/controllers/main.py
+++ b/shopinvader/controllers/main.py
@@ -7,6 +7,7 @@ import logging
 
 from odoo.addons.base_rest.controllers import main
 from odoo.http import request
+from odoo.exceptions import MissingError
 
 _logger = logging.getLogger(__name__)
 
@@ -35,6 +36,9 @@ class InvaderController(main.RestController):
                         "More than one shopinvader.partner found for domain:"
                         " %s", partner_domain
                     )
+                # Could be because the email is not related to a partner or
+                # because the partner is inactive
+                raise MissingError("The given partner is not found!")
         return partner_model.browse([]).record_id
 
     @classmethod


### PR DESCRIPTION
**Issue:**
When an account exists into locomotive but not on the Odoo side, we could have unexpected results.
Because (on services), the `self.partner` is not a logged user but also not the anonymous user (`self.partner` is just empty recordset).
I think the system should automatically block (raise an exception) the process in this case.

**Fix:**
Just raise an exception if the email is not found (or too many partners found).
But if no email provided, we don't have to raise an exception (it could be a guest mode).