### PR TITLE
[FIX] shopinvader_payment: method is not called at the right place and has no effect with a provider

### DIFF
--- a/shopinvader_payment/services/abstract_payment.py
+++ b/shopinvader_payment/services/abstract_payment.py
@@ -157,6 +157,7 @@ class AbstractPaymentService(AbstractComponent):
         params['return_url'] = self._get_return_url(provider_name)
         transaction = self.env['gateway.transaction'].generate(
             provider_name, target, **params)
+        self._update_target_with_transaction(target, transaction)
         return self._execute_payment_action(
             provider_name, transaction, target, params)
 
@@ -165,7 +166,6 @@ class AbstractPaymentService(AbstractComponent):
         if transaction.url:
             return {'redirect_to': transaction.url}
         elif transaction.state in ('succeeded', 'to_capture'):
-            self._update_target_with_transaction(target, transaction)
             return self._action_after_payment(target)
         else:
             raise UserError(_('Payment failed please retry'))


### PR DESCRIPTION
With a 3D secure payment, this code is not called so we need to do it earlier