### PR TITLE
[10.0][FIX] Multi backend issue during login

### DIFF
--- a/shopinvader/controllers/main.py
+++ b/shopinvader/controllers/main.py
@@ -22,8 +22,12 @@ class InvaderController(main.RestController):
     def _get_partner_from_headers(cls, headers):
         partner_model = request.env["shopinvader.partner"]
         partner_email = headers.get("HTTP_PARTNER_EMAIL")
+        backend = cls._get_shopinvader_backend_from_request()
         if partner_email:
-            partner_domain = [("partner_email", "=", partner_email)]
+            partner_domain = [
+                ("partner_email", "=", partner_email),
+                ("backend_id", "=", backend.id),
+            ]
             partner = partner_model.search(partner_domain)
             if len(partner) == 1:
                 return partner.record_id

--- a/shopinvader/demo/backend_demo.xml
+++ b/shopinvader/demo/backend_demo.xml
@@ -10,4 +10,13 @@
         <field name="account_analytic_id" ref="account_analytic_0"/>
     </record>
 
+    <record id="backend_2" model="shopinvader.backend">
+        <field name="name">Demo Shopinvader Website 2</field>
+        <field name="location">http://locomotive:3000</field>
+        <field name="lang_ids" eval="[(6, 0, [ref('base.lang_en')])]"/>
+        <field name="last_step_id" ref="cart_end"/>
+        <field name="pricelist_id" ref="product.list0"/>
+        <field name="account_analytic_id" ref="account_analytic_0"/>
+    </record>
+
 </odoo>

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -98,14 +98,24 @@ class ProductCommonCase(CommonCase):
 
 class ShopinvaderRestCase(BaseRestCase):
     AUTH_API_KEY_NAME = "api_key_shopinvader_test"
+    AUTH_API_KEY_NAME2 = "api_key_shopinvader_test2"
 
     def setUp(self, *args, **kwargs):
         super(ShopinvaderRestCase, self).setUp(*args, **kwargs)
         self.backend = self.env.ref("shopinvader.backend_1")
+        # To ensure multi-backend works correctly, we just have to create
+        # a new one on the same company.
+        self.backend_copy = self.env.ref("shopinvader.backend_2")
         self.api_key = "myApiKey"
+        self.api_key2 = "myApiKey2"
         self.auth_api_key_name = self.AUTH_API_KEY_NAME
+        self.auth_api_key_name2 = self.AUTH_API_KEY_NAME2
         if self.auth_api_key_name not in serv_config.sections():
             serv_config.add_section(self.auth_api_key_name)
             serv_config.set(self.auth_api_key_name, "user", "admin")
             serv_config.set(self.auth_api_key_name, "key", self.api_key)
-        self.backend.auth_api_key_name = self.auth_api_key_name
+        if self.auth_api_key_name2 not in serv_config.sections():
+            serv_config.add_section(self.auth_api_key_name2)
+            serv_config.set(self.auth_api_key_name2, "user", "admin")
+            serv_config.set(self.auth_api_key_name2, "key", self.api_key2)
+        self.backend.auth_api_key_name = self.auth_api_key_name2

--- a/shopinvader_guest_mode/services/guest_service.py
+++ b/shopinvader_guest_mode/services/guest_service.py
@@ -85,9 +85,12 @@ class GuestService(Component):
             super(GuestService, self)._send_welcome_message(binding)
 
     def _get_binding(self, email):
-        return self.env["shopinvader.partner"].search(
-            [("email", "=", email), ("is_guest", "=", True)]
-        )
+        domain = [
+            ("email", "=", email),
+            ("is_guest", "=", True),
+            ("backend_id", "=", self.shopinvader_backend.id),
+        ]
+        return self.env["shopinvader.partner"].search(domain, limit=1)
 
     def _archive_existing_binding(self, email):
         """


### PR DESCRIPTION
**Issue 1:**
You have more than 1 backend (on the same company), and 1 user binded to 1 backend. If this user try to login on the second backend, it'll works (but he is not binded on this second backend!).
**Issue 2:**
In this scenario, if the user is binded on these 2 backends, he is not able to login because the search will find 2 results (so too many partners found!)

**Fix:**
Just add the backend into the search domain.
Similar issue for guest mode.