### PR TITLE
[10.0][IMP] Improve view about delivery carrier

### DIFF
--- a/shopinvader_delivery_carrier/views/backend_view.xml
+++ b/shopinvader_delivery_carrier/views/backend_view.xml
@@ -8,9 +8,13 @@
         <field name="arch" type="xml">
             <page name="delivery" position="inside">
                 <group name="carrier" colspan="4">
-                    <field name="carrier_ids"
-                           colspan="4"
-                           nolabel="True">
+                    <field name="carrier_ids" colspan="4" nolabel="True">
+                        <tree string="Carrier">
+                            <field name="sequence" widget="handle"/>
+                            <field name="name"/>
+                            <field name="country_ids"/>
+                            <field name="delivery_type"/>
+                        </tree>
                     </field>
                 </group>
             </page>


### PR DESCRIPTION
Into the delivery carrier of shopinvader, add `country_ids` field.
In case of international rules, it could be a mess to manage them (in "one look").