### PR TITLE
[10.0][FIX] automatic_url_key should be computed in sudo

### DIFF
--- a/base_url/models/abstract_url.py
+++ b/base_url/models/abstract_url.py
@@ -27,7 +27,7 @@ class AbstractUrl(models.AbstractModel):
         selection=[("auto", "Automatic"), ("manual", "Manual")], default="auto"
     )
     automatic_url_key = fields.Char(
-        compute="_compute_automatic_url_key", store=True
+        compute="_compute_automatic_url_key", store=True, compute_sudo=True
     )
     manual_url_key = fields.Char()
     url_key = fields.Char(


### PR DESCRIPTION
How to reproduce:
- Login as normal user (not admin);
- Create a backend on company A;
- Bind a product A on this backend;
- Create another backend on company B;
- Bind the product A on this second backend;
- Try to update the name of this product
=> You should have an exception.
Because the compute of `automatic_url_key` try to update the url (with the new name). But the current user doesn't have access to the other company.

Fix
Use `compute_sudo=True`.
