### PR TITLE
[10.0][FIX] Translation issue for cart/sale in guest mode

### DIFF
--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -5,6 +5,7 @@
 # pylint: disable=consider-merging-classes-inherited
 
 import logging
+from contextlib import contextmanager
 
 from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
@@ -201,20 +202,85 @@ class CartService(Component):
         else:
             with self.env.norecompute():
                 vals = self._prepare_cart_item(params, cart)
-                # the next statement is done with suspending the security for
-                #  performance reasons. It is safe only if both 3 following
-                # fields are filled on the sale order:
-                # - company_id
-                # - fiscal_position_id
-                # - pricelist_id
-                new_values = (
-                    self.env["sale.order.line"]
-                    .suspend_security()
-                    .play_onchanges(vals, vals.keys())
-                )
+                new_values = self._sale_order_line_onchange(vals)
                 vals.update(new_values)
-                self.env["sale.order.line"].create(vals)
+                self._create_sale_order_line(vals)
             cart.recompute()
+
+    @contextmanager
+    def _ensure_ctx_lang(self, values):
+        """
+        Simulate the anonymous partner lang using the lang from the context.
+        To avoid to fill sale.order.line name/description with the anonymous
+        lang if the lang of the context is different.
+        This function update (in cache only) the anonymous partner's lang,
+        then you do your job (create etc) and the previous lang is
+        automatically reset with the original one.
+        Usage:
+        with self._simulate_anonymous_lang(vals):
+            # Do your job here
+        :param values: dict
+        :return:
+        """
+        order_id = values.get("order_id")
+        partner = self.env["sale.order"].browse(order_id).partner_id
+        anonymous_partner = self.shopinvader_backend.anonymous_partner_id
+        original_lang = partner.lang
+        ctx_lang = self.env.context.get("lang", partner.lang)
+        if (
+            partner
+            and anonymous_partner
+            and partner == anonymous_partner
+            and partner.lang != ctx_lang
+        ):
+            # We can update (in cache only) the partner's lang without
+            # doing a real write (sql; to avoid concurrent update).
+            # Also, as we can have multi-env, we have to update the value
+            # for each env.
+            # (about the draft mode: if 1 environment is in draft mode,
+            # every others are also in this state. So don't need to do
+            # it for each of them).
+            with self.env.do_in_draft():
+                # We have to save envs because the set en Env could change
+                # during iteration
+                envs = [e for e in self.env.envs]
+                for env in envs:
+                    env[partner._name].browse(partner.ids).lang = ctx_lang
+                yield
+                for env in envs:
+                    env[partner._name].browse(partner.ids).lang = original_lang
+        else:
+            yield
+
+    def _create_sale_order_line(self, vals):
+        """
+        Create the sale order line.
+        We also have to force the lang from the context because the
+        sale.order.line create could add some missing values (and call
+        the onchange on the product).
+        :param vals: dict
+        :return: sale.order.line recordset
+        """
+        with self._ensure_ctx_lang(vals):
+            line = self.env["sale.order.line"].create(vals)
+        return line
+
+    def _sale_order_line_onchange(self, vals):
+        """
+        Simulate the onchange on sale.order.line with given vals.
+        :param vals: dict
+        :return: dict
+        """
+        # the next statement is done with suspending the security for
+        #  performance reasons. It is safe only if both 3 following
+        # fields are filled on the sale order:
+        # - company_id
+        # - fiscal_position_id
+        # - pricelist_id
+        so_line_obj = self.env["sale.order.line"].suspend_security()
+        with self._ensure_ctx_lang(vals):
+            new_values = so_line_obj.play_onchanges(vals, vals.keys())
+        return new_values
 
     def _update_item(self, cart, params, item=False):
         if not item:


### PR DESCRIPTION
**Issue**
In guest mode, the partner_id of the cart/sale.order is the anonymous partner.
So Odoo use the lang of this partner/customer to fill the description/name of the sale.order.line.
But if the current user use another language, we'll have an invalid description (even if the user login after; the description/name is not updated).

**Fix**
Change the customer/partner_id language then re-update it with original lang.

**Improvement to do:**
This behavior can have a concurrent update (in case of we have 2 add_item in same time).
We already try the `do_in_draft()` from the `env` but it does a real write in SQL (so it's not a solution) (cfr `__set__` in `odoo.fields` who do the update in cache when `env` is in draft mode; but seems not working at all!)

**Todo**
- [x] Do this only if the partner_id is the anonymous partner
- [x] Unit test
- [x] Seems to have an issue in some case (when a price list who depends on another pricelist; the play_onchange doesn't return anything)