### PR TITLE
[10.0][IMP] add test to create shopinvader category from category

### DIFF
--- a/shopinvader/tests/test_product.py
+++ b/shopinvader/tests/test_product.py
@@ -877,3 +877,23 @@ class ProductCase(ProductCommonCase):
         # Disable only 1 variant
         with self._check_correct_unbind_active(self.shopinvader_variants):
             fields.first(self.shopinvader_variants).write({"active": False})
+
+    def test_create_shopinvader_category_from_product_category(self):
+        categ = self.env["product.category"].search([])[0]
+        lang = self.env["res.lang"]._lang_get(self.env.user.lang)
+        categ.write(
+            {
+                "shopinvader_bind_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "backend_id": self.backend.id,
+                            "lang_id": lang.id,
+                            "seo_title": False,
+                            "active": True,
+                        },
+                    )
+                ]
+            }
+        )


### PR DESCRIPTION
This test should crash with the actual version.

I am still diging to understand excatly why it crashes if you create a shopinvader category from category instead of directly a shopinvader_category.

This PR is mainly to inform that I am working on it and get some help if someone has an idea