### PR TITLE
[10.0][FIX] Disable product if all variants are unbinded

### DIFF
--- a/shopinvader/models/product_template.py
+++ b/shopinvader/models/product_template.py
@@ -2,6 +2,7 @@
 # Copyright 2017 Akretion (http://www.akretion.com).
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from contextlib import contextmanager
 
 from odoo import api, fields, models
 
@@ -49,3 +50,29 @@ class ProductTemplate(models.Model):
             # TODO we should propose to redirect the old url
             record.shopinvader_bind_ids.unlink()
         return super(ProductTemplate, self).unlink()
+
+    @api.multi
+    @contextmanager
+    def _manage_name_update(self):
+        """
+        When the product name is updated, re-sync url
+        :return:
+        """
+        self_name = {r: r.name for r in self}
+        yield
+        for record in self:
+            if not record.shopinvader_bind_ids:
+                continue
+            if record.name != self_name.get(record):
+                record.shopinvader_bind_ids._sync_urls()
+
+    @api.multi
+    def write(self, vals):
+        """
+        Inherit the write to re-sync url if necessary
+        :param vals: dict
+        :return: bool
+        """
+        with self._manage_name_update():
+            result = super(ProductTemplate, self).write(vals)
+        return result

--- a/shopinvader/models/shopinvader_variant.py
+++ b/shopinvader/models/shopinvader_variant.py
@@ -2,6 +2,7 @@
 # Copyright 2017 Akretion (http://www.akretion.com).
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from contextlib import contextmanager
 
 from odoo import api, fields, models
 from odoo.tools import float_compare, float_round
@@ -46,6 +47,44 @@ class ShopinvaderVariant(models.Model):
     description = fields.Html(
         related="shopinvader_product_id.description", readonly=False
     )
+
+    @contextmanager
+    @api.multi
+    def _action_product_disabled(self):
+        """
+        Action a deactivation of a variant, if every variants are disabled:
+        disable the product too.
+        :return:
+        """
+        product_active_dict = {
+            p: p.active for p in self.mapped("shopinvader_product_id")
+        }
+        yield
+        for variant in self:
+            if variant.active:
+                continue
+            shopinv_product = variant.shopinvader_product_id
+            # If the product is already disabled, we don't have anything to do!
+            if not product_active_dict.get(shopinv_product, True):
+                continue
+            # If every variants of the product are disabled
+            # (The product is enable; checked by previous IF).
+            if all(
+                [not v.active for v in shopinv_product.shopinvader_variant_ids]
+            ):
+                shopinv_product.write({"active": False})
+
+    @api.multi
+    def write(self, vals):
+        """
+        Inherit to manage behaviour when the variant is disabled.
+        We may habe to disable also the shopinvader.product
+        :param vals: dict
+        :return: bool
+        """
+        with self._action_product_disabled():
+            result = super(ShopinvaderVariant, self).write(vals)
+        return result
 
     @api.multi
     def _build_seo_title(self):

--- a/shopinvader/tests/test_product.py
+++ b/shopinvader/tests/test_product.py
@@ -3,6 +3,9 @@
 # @author Benoît GUILLOT <benoit.guillot@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from contextlib import contextmanager
+
+from odoo import fields
 
 from .common import ProductCommonCase
 
@@ -751,3 +754,78 @@ class ProductCase(ProductCommonCase):
         bind_product.write({"active": True})
         self.assertEqual(urls.mapped("model_id"), bind_product)
         self.assertFalse(bind_product.is_urls_sync_required)
+
+    @contextmanager
+    def _check_correct_unbind_active(self, variants):
+        """
+        During the execution of some cases, check the value of
+        shopinvader products depending on related variants.
+        :param variants: shopinvader.variant recordset
+        :return:
+        """
+        variants = variants.with_context(active_test=False)
+        # Save if the shopinvader product is active or not
+        product_active_dict = {
+            p: p.active for p in variants.mapped("shopinvader_product_id")
+        }
+        yield
+        for variant in variants:
+            shopinv_product = variant.shopinvader_product_id
+            product_active = product_active_dict.get(shopinv_product)
+            all_variants = shopinv_product.shopinvader_variant_ids
+            # If all variants are disabled, the product should be disabled too.
+            if all([not a.active for a in all_variants]):
+                self.assertFalse(shopinv_product.active)
+                self._check_category_after_unbind(shopinv_product)
+            # But if at least 1 is active, the product should stay into his
+            # previous state.
+            elif product_active:
+                self.assertTrue(shopinv_product.active)
+            else:
+                self.assertFalse(shopinv_product.active)
+
+    def _check_category_after_unbind(self, shopinv_product):
+        """
+        When the product has been disabled, existing url should be
+        a redirect to the category.
+        :param shopinv_product: shopinvader.product recordset
+        :return: bool
+        """
+        category = fields.first(
+            shopinv_product.shopinvader_categ_ids.filtered(
+                lambda c: c.active and not c.shopinvader_child_ids
+            )
+        )
+        if category:
+            for url in shopinv_product.url_url_ids:
+                self.assertTrue(url.redirect)
+                self.assertEquals(url.model_id, category)
+        return True
+
+    def test_unbind_variant(self):
+        """
+        For this test, we check the behavior during unbind of a
+        shopinvader.variant.
+        If every variants of a shopinvader.product are disabled (active False),
+        we have to also disable the product.
+        :return:
+        """
+        shopinv_product = self.shopinvader_variants.mapped(
+            "shopinvader_product_id"
+        )
+        self.assertEquals(len(shopinv_product), 1)
+        self.assertGreaterEqual(len(self.shopinvader_variants), 1)
+        # Init: every variants and shopinv product are active True
+        self.shopinvader_variants.write({"active": True})
+        shopinv_product.write({"active": True})
+        # Disable every variants
+        with self._check_correct_unbind_active(self.shopinvader_variants):
+            self.shopinvader_variants.write({"active": False})
+        # Re-enable variants
+        with self._check_correct_unbind_active(self.shopinvader_variants):
+            self.shopinvader_variants.write({"active": True})
+        # Re-enable also the shopinvader product
+        shopinv_product.write({"active": True})
+        # Disable only 1 variant
+        with self._check_correct_unbind_active(self.shopinvader_variants):
+            fields.first(self.shopinvader_variants).write({"active": False})

--- a/shopinvader/tests/test_product.py
+++ b/shopinvader/tests/test_product.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from contextlib import contextmanager
+from uuid import uuid4
 
 from odoo import fields
 
@@ -84,6 +85,47 @@ class ProductCase(ProductCommonCase):
                 }
             },
         )
+
+    @contextmanager
+    def _check_url(self, shopinvader_variants):
+        """
+        Check url if name has been updated
+        :param shopinvader_variants: shopinvader.variant recordset
+        :return:
+        """
+        shopinv_variant_names = {r: r.name for r in shopinvader_variants}
+        shopinv_variant_urls = {r: r.url_url_ids for r in shopinvader_variants}
+        yield
+        shopinvader_variants.refresh()
+        for shopinv_variant in shopinvader_variants:
+            existing_urls = shopinv_variant_urls.get(shopinv_variant)
+            new_url = shopinv_variant.url_url_ids.filtered(
+                lambda u: u not in existing_urls
+            )
+            if (
+                shopinv_variant_names.get(shopinv_variant)
+                != shopinv_variant.name
+            ):
+                self.assertEquals(len(new_url), 1)
+            else:
+                self.assertEquals(len(new_url), 0)
+
+    def test_product_name_url(self):
+        """
+        Check the case where the product template has a new name.
+        Do the write directly on the product template to check if a new url
+        is automatically created (as the inherit from abstract url is done
+        on shopinvader.product and not on product.template).
+        :return:
+        """
+        product_product = self.shopinvader_variant.record_id
+        # The name updated
+        with self._check_url(self.shopinvader_variant):
+            product_product.write({"name": str(uuid4())})
+        # The name is not really updated
+        with self._check_url(self.shopinvader_variant):
+            product_product.write({"name": product_product.name})
+        return
 
     def test_product_get_price(self):
         # base_price_list doesn't define a tax mapping. We are tax included
@@ -443,7 +485,13 @@ class ProductCase(ProductCommonCase):
         self.user.write(
             {
                 "groups_id": [
-                    (4, self.env.ref("sales_team.group_sale_manager").id)
+                    (4, self.env.ref("sales_team.group_sale_manager").id),
+                    (
+                        4,
+                        self.env.ref(
+                            "shopinvader.group_shopinvader_manager"
+                        ).id,
+                    ),
                 ]
             }
         )


### PR DESCRIPTION
**Current behavior:**
- If every `shopinvader.variant` are unbind, the `shopinvader.product` (related to these variants) still binded.
- If the name of `product.template` is updated (directly on this model), the url is not re-computed.

**New behavior:**
- If every `shopinvader.variant` are unbind, the `shopinvader.product` is automatically unbinded.
- If the name of `product.template` is updated, the url is re-computed (only if binded)

**Bonus:**
As the `shopinvader.product` is unbinded, the URL is automatically set as `redirect=True` and redirect to the category (if any).

I take care of infinite loop and I don't have any error about that.