### PR TITLE
[10.0][ADD] Add a 'clear' on cart service + backend config

### DIFF
--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -82,6 +82,24 @@ class ShopinvaderBackend(models.Model):
     website_public_name = fields.Char(
         help="Public name of your backend/website."
     )
+    clear_cart_options = fields.Selection(
+        selection=[
+            ("delete", "Delete"),
+            ("clear", "Clear"),
+            ("cancel", "Cancel"),
+        ],
+        required=True,
+        string="Clear cart",
+        default="clear",
+        help="Action to execute on the cart when the front want to clear the "
+        "current cart:\n"
+        "- Delete: delete the cart (and items);\n"
+        "- Clear: keep the cart but remove items;\n"
+        "- Cancel: The cart is canceled but kept into the database.\n"
+        "It could be useful if you want to keep cart for "
+        "statistics reasons. A new cart is created automatically when the "
+        "customer will add a new item.",
+    )
 
     _sql_constraints = [
         (

--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -56,8 +56,20 @@ class CartService(Component):
         self._delete_item(cart, params)
         return self._to_json(cart)
 
+    def clear(self):
+        """
+        Clear the current cart (by $session)
+        :return: dict/json
+        """
+        cart = self._get()
+        cart = self._clear_cart(cart)
+        return self._to_json(cart)
+
     # Validator
     def _validator_search(self):
+        return {}
+
+    def _validator_clear(self):
         return {}
 
     def _subvalidator_shipping(self):
@@ -134,6 +146,50 @@ class CartService(Component):
             vals.update(new_values)
             item.write(vals)
         cart.recompute()
+
+    def _do_clear_cart_cancel(self, cart):
+        """
+        Cancel the existing cart.
+        Don't need to create a new one because it'll done automatically
+        when the customer will add a new item.
+        :param cart: sale.order recordset
+        :return: sale.order recordset
+        """
+        cart.action_cancel()
+        return cart.browse()
+
+    def _do_clear_cart_delete(self, cart):
+        """
+        Delete/unlink the given cart
+        :param cart: sale.order recordset
+        :return: sale.order recordset
+        """
+        cart.unlink()
+        return cart.browse()
+
+    def _do_clear_cart_clear(self, cart):
+        """
+        Remove items from given cart.
+        :param cart: sale.order recordset
+        :return: sale.order recordset
+        """
+        cart.write({"order_line": [(5, False, False)]})
+        return cart
+
+    def _clear_cart(self, cart):
+        """
+        Action to clear the cart, depending on the backend configuration.
+        :param cart: sale.order recordset
+        :return: sale.order recordset
+        """
+        clear_option = self.shopinvader_backend.clear_cart_options
+        do_clear = "_do_clear_cart_%s" % clear_option
+        if hasattr(self, do_clear):
+            cart = getattr(self, do_clear)(cart)
+        else:
+            _logger.error("The %s function doesn't exists.", do_clear)
+            raise NotImplementedError(_("Missing feature to clear the cart!"))
+        return cart
 
     def _add_item(self, cart, params):
         existing_item = self._check_existing_cart_item(cart, params)
@@ -237,7 +293,11 @@ class CartService(Component):
 
     def _to_json(self, cart):
         if not cart:
-            return {"data": {}, "store_cache": {"cart": {}}}
+            return {
+                "data": {},
+                "store_cache": {"cart": {}},
+                "set_session": {"cart_id": 0},
+            }
         res = super(CartService, self)._to_json(cart)[0]
 
         return {

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -15,6 +15,7 @@ class CartCase(CommonCase):
         self.address = self.env.ref("shopinvader.partner_1_address_1")
         self.fposition = self.env.ref("shopinvader.fiscal_position_2")
         self.default_fposition = self.env.ref("shopinvader.fiscal_position_0")
+        self.product_1 = self.env.ref("product.product_product_4b")
         templates = self.env["product.template"].search([])
         templates.write(
             {"taxes_id": [(6, 0, [self.env.ref("shopinvader.tax_1").id])]}
@@ -36,7 +37,56 @@ class CartCase(CommonCase):
         super(CartCase, self).tearDown()
 
 
-class AnonymousCartCase(CartCase):
+class CartClearTest(object):
+    def _check_clear_cart_result(self, cart):
+        """
+        Check the cart clear.
+        :param cart: sale.order recordset
+        :return: bool
+        """
+        cart_id = cart.id
+        existing_carts = cart.search([])
+        self.service.shopinvader_session.update({"cart_id": cart.id})
+        result = self.service.dispatch("clear")
+        session = result.get("set_session")
+        new_carts = cart.search([("id", "not in", existing_carts.ids)])
+        clear_option = self.backend.clear_cart_options
+        if clear_option == "clear":
+            self.assertFalse(new_carts)
+            self.assertEquals(cart_id, cart.exists().id)
+            self.assertIsInstance(session, dict)
+            self.assertEquals(session.get("cart_id"), cart_id)
+            self.assertFalse(cart.order_line)
+        elif clear_option == "delete":
+            self.assertFalse(cart.exists())
+            self.assertIsInstance(session, dict)
+            self.assertEquals(session.get("cart_id"), 0)
+        elif clear_option == "cancel":
+            # We only check that the previous cart is cancelled.
+            # The new cart will be created if the customer add a new item.
+            # Test the creation of new cart is not the goal of this test.
+            self.assertEquals(len(new_carts), 0)
+            self.assertIsInstance(session, dict)
+            self.assertFalse(session.get("cart_id"))
+            # The previous should exists
+            self.assertEquals(cart_id, cart.exists().id)
+            self.assertEquals(cart.state, "cancel")
+        return True
+
+    def test_cart_clear(self):
+        self.backend.write({"clear_cart_options": "clear"})
+        self._check_clear_cart_result(self.cart)
+
+    def test_cart_delete(self):
+        self.backend.write({"clear_cart_options": "delete"})
+        self._check_clear_cart_result(self.cart)
+
+    def test_cart_cancel(self):
+        self.backend.write({"clear_cart_options": "cancel"})
+        self._check_clear_cart_result(self.cart)
+
+
+class AnonymousCartCase(CartCase, CartClearTest):
     def setUp(self, *args, **kwargs):
         super(AnonymousCartCase, self).setUp(*args, **kwargs)
         self.cart = self.env.ref("shopinvader.sale_order_1")
@@ -209,7 +259,7 @@ class AnonymousCartCase(CartCase):
         self.assertNotEqual(cart, cart_bis)
 
 
-class CommonConnectedCartCase(CartCase):
+class CommonConnectedCartCase(CartCase, CartClearTest):
     def setUp(self, *args, **kwargs):
         super(CommonConnectedCartCase, self).setUp(*args, **kwargs)
         self.cart = self.env.ref("shopinvader.sale_order_2")

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -61,6 +61,7 @@
                         </page>
                         <page name="sale" string="Sale">
                             <group name="cart_conf" string="Cart configuration">
+                                <field name="clear_cart_options"/>
                                 <field name="anonymous_partner_id"/>
                                 <field name="pricelist_id" required="1"/>
                             </group>


### PR DESCRIPTION
**Add a new `clear` service.**
**Configuration:**
On the backend, you have a new field (on sale tab) named "clear_cart_options".
You have 4 possibilities:
- Delete: to delete the cart;
- Clear: keep the cart but remove items;
- New & cancel: keep the cart (and items), cancel it and create a new one (the creation of the new one is not done directly; it'll be done automatically if the user add a new item).
