### PR TITLE
[12.0] [IMP] Shopinvader: allow the write on sale orders from partner without access

### DIFF
--- a/shopinvader/models/res_partner.py
+++ b/shopinvader/models/res_partner.py
@@ -84,16 +84,20 @@ class ResPartner(models.Model):
     def write(self, vals):
         super(ResPartner, self).write(vals)
         if "country_id" in vals:
-            carts = self.env["sale.order"].search(
-                [
-                    ("typology", "=", "cart"),
-                    ("partner_shipping_id", "in", self.ids),
-                ]
+            carts = (
+                self.env["sale.order"]
+                .sudo()
+                .search(
+                    [
+                        ("typology", "=", "cart"),
+                        ("partner_shipping_id", "in", self.ids),
+                    ]
+                )
             )
             for cart in carts:
                 # Trigger a write on cart to recompute the
                 # fiscal position if needed
-                cart.write_with_onchange(
+                cart.suspend_security().write_with_onchange(
                     {"partner_shipping_id": cart.partner_shipping_id.id}
                 )
         return True


### PR DESCRIPTION
The user may not have read/write access on sale.order when modifying the country of a partner.