### PR TITLE
[10.0][FIX] shopinvader: increase protection of the cart entry points

### DIFF
--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -298,9 +298,14 @@ class CartService(Component):
             vals[
                 "project_id"
             ] = self.shopinvader_backend.account_analytic_id.id
+        if self.shopinvader_backend.pricelist_id:
+            # We must always force the pricelist. In the case of sale_profile
+            # the pricelist is not set on the backend
+            vals.update(
+                {"pricelist_id": self.shopinvader_backend.pricelist_id.id}
+            )
         if self.shopinvader_backend.sequence_id:
             vals["name"] = self.shopinvader_backend.sequence_id._next()
-        vals.update({"pricelist_id": self.shopinvader_backend.pricelist_id.id})
         return vals
 
     def _get_onchange_trigger_fields(self):

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -188,6 +188,26 @@ class AnonymousCartCase(CartCase):
         )
         return
 
+    def test_cart_robustness(self):
+        """
+        The cart used by the service must always be with typology='cart'
+        and state='draft' for the current backend
+        If for some reason, these conditions are no more met, the service
+        silently create a new cart to replace the one into the session
+        """
+        cart = self.service._get()
+        cart_bis = self.service._get()
+        self.assertEqual(cart, cart_bis)
+        cart.write({"state": "sale"})
+        cart_bis = self.service._get()
+        self.assertNotEqual(cart, cart_bis)
+        self.assertEqual(cart_bis.typology, "cart")
+        self.assertEqual(cart_bis.state, "draft")
+        cart = cart_bis
+        cart.write({"typology": "sale"})
+        cart_bis = self.service._get()
+        self.assertNotEqual(cart, cart_bis)
+
 
 class CommonConnectedCartCase(CartCase):
     def setUp(self, *args, **kwargs):
@@ -290,6 +310,23 @@ class ConnectedCartCase(CommonConnectedCartCase):
         )
         domain = [("name", "=", description), ("date_created", ">=", now)]
         self.assertEquals(self.env["queue.job"].search_count(domain), 0)
+
+    def test_cart_robustness(self):
+        """
+        The cart used by the service must always be with typology='cart'
+        and state='draft' for the current backend
+        If for some reason, these conditions are no more met, the service
+        silently create a new cart to replace the one into the session
+        """
+        cart = self.service._get()
+        cart_bis = self.service._get()
+        self.assertEqual(cart, cart_bis)
+        cart.write({"state": "sale"})
+        cart_bis = self.service._get()
+        self.assertNotEqual(cart, cart_bis)
+        self.assertEqual(cart_bis.typology, "cart")
+        self.assertEqual(cart_bis.state, "draft")
+        self.assertEqual(cart_bis.partner_id, self.partner)
 
 
 class ConnectedCartNoTaxCase(CartCase):


### PR DESCRIPTION
if trying to manipulate a cart that is not current anymore, ignore it, create a new cart; do not fail if removing an item that is not in cart anymore; create a new cart if adding an item when the current cart is closed

partial implementation of #373