### PR TITLE
[12.0][FIX] shopinvader: increase protection of the cart entry points

### DIFF
--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -297,9 +297,14 @@ class CartService(Component):
             vals[
                 "project_id"
             ] = self.shopinvader_backend.account_analytic_id.id
+        if self.shopinvader_backend.pricelist_id:
+            # We must always force the pricelist. In the case of sale_profile
+            # the pricelist is not set on the backend
+            vals.update(
+                {"pricelist_id": self.shopinvader_backend.pricelist_id.id}
+            )
         if self.shopinvader_backend.sequence_id:
             vals["name"] = self.shopinvader_backend.sequence_id._next()
-        vals.update({"pricelist_id": self.shopinvader_backend.pricelist_id.id})
         return vals
 
     def _get_onchange_trigger_fields(self):

--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -165,12 +165,35 @@ class CartService(Component):
 
     def _update_item(self, cart, params, item=False):
         if not item:
-            item = self._get_cart_item(cart, params)
-        self._upgrade_cart_item_quantity(cart, item, params["item_qty"])
+            item = self._get_cart_item(cart, params, raise_if_not_found=False)
+        if item:
+            self._upgrade_cart_item_quantity(cart, item, params["item_qty"])
+            return
+        # The item id is maybe the one from a previous cart.
+        line_id = params["item_id"]
+        line = self.env["sale.order.line"].search(
+            [
+                ("id", "=", line_id),
+                ("order_id.partner_id", "=", cart.partner_id.id),
+            ]
+        )
+        if line:
+            # silently create a new line on the new cart from the previous
+            # line. This case could occurs if the customer click on the add
+            # button from within an old session still open in its browser
+            add_item_params = self._prepare_add_item_params_from_line(line)
+            add_item_params["item_qty"] = params["item_qty"]
+            self._add_item(cart, add_item_params)
+            return params["item_qty"]
+        raise NotFound("No cart item found with id %s" % params["item_id"])
 
     def _delete_item(self, cart, params):
-        item = self._get_cart_item(cart, params)
-        item.unlink()
+        item = self._get_cart_item(cart, params, raise_if_not_found=False)
+        if item:
+            item.unlink()
+
+    def _prepare_add_item_params_from_line(self, sale_order_line):
+        return {"product_id": sale_order_line.product_id.id, "item_qty": 1}
 
     def _prepare_shipping(self, shipping, params):
         if "address" in shipping:
@@ -240,22 +263,21 @@ class CartService(Component):
 
         :return: sale.order recordset (cart)
         """
-        domain = [
-            ("typology", "=", "cart"),
-            ("shopinvader_backend_id", "=", self.shopinvader_backend.id),
-        ]
         cart = self.env["sale.order"].browse()
         if self.cart_id:
+            # here we take advantage of the cache. If the cart has been
+            # already loaded, no SQL query will be issued
+            # an alternative would be to build a domain with the expected
+            # criteria on the cart but in this case, each time the _get method
+            # would have been called, a new SQL query would have been done
             cart = self.env["sale.order"].browse(self.cart_id)
         if (
             cart.shopinvader_backend_id == self.shopinvader_backend
             and cart.typology == "cart"
+            and cart.state == "draft"  # ensure that we only work on draft
         ):
             return cart
-        elif self.partner:
-            domain.append(("partner_id", "=", self.partner.id))
-            return self.env["sale.order"].search(domain, limit=1)
-        return cart
+        return self._create_empty_cart()
 
     def _create_empty_cart(self):
         vals = self._prepare_cart()
@@ -301,7 +323,7 @@ class CartService(Component):
         )
         return res
 
-    def _get_cart_item(self, cart, params):
+    def _get_cart_item(self, cart, params, raise_if_not_found=True):
         # We search the line based on the item id and the cart id
         # indeed the item_id information is given by the
         # end user (untrusted data) and the cart id by the
@@ -309,7 +331,7 @@ class CartService(Component):
         item = cart.mapped("order_line").filtered(
             lambda l, id_=params["item_id"]: l.id == id_
         )
-        if not item:
+        if not item and raise_if_not_found:
             raise NotFound("No cart item found with id %s" % params["item_id"])
         return item
 

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -187,6 +187,26 @@ class AnonymousCartCase(CartCase):
         )
         return
 
+    def test_cart_robustness(self):
+        """
+        The cart used by the service must always be with typology='cart'
+        and state='draft' for the current backend
+        If for some reason, these conditions are no more met, the service
+        silently create a new cart to replace the one into the session
+        """
+        cart = self.service._get()
+        cart_bis = self.service._get()
+        self.assertEqual(cart, cart_bis)
+        cart.write({"state": "sale"})
+        cart_bis = self.service._get()
+        self.assertNotEqual(cart, cart_bis)
+        self.assertEqual(cart_bis.typology, "cart")
+        self.assertEqual(cart_bis.state, "draft")
+        cart = cart_bis
+        cart.write({"typology": "sale"})
+        cart_bis = self.service._get()
+        self.assertNotEqual(cart, cart_bis)
+
 
 class CommonConnectedCartCase(CartCase):
     def setUp(self, *args, **kwargs):
@@ -289,6 +309,23 @@ class ConnectedCartCase(CommonConnectedCartCase):
         )
         domain = [("name", "=", description), ("date_created", ">=", now)]
         self.assertEquals(self.env["queue.job"].search_count(domain), 0)
+
+    def test_cart_robustness(self):
+        """
+        The cart used by the service must always be with typology='cart'
+        and state='draft' for the current backend
+        If for some reason, these conditions are no more met, the service
+        silently create a new cart to replace the one into the session
+        """
+        cart = self.service._get()
+        cart_bis = self.service._get()
+        self.assertEqual(cart, cart_bis)
+        cart.write({"state": "sale"})
+        cart_bis = self.service._get()
+        self.assertNotEqual(cart, cart_bis)
+        self.assertEqual(cart_bis.typology, "cart")
+        self.assertEqual(cart_bis.state, "draft")
+        self.assertEqual(cart_bis.partner_id, self.partner)
 
 
 class ConnectedCartNoTaxCase(CartCase):

--- a/shopinvader/tests/test_cart_item.py
+++ b/shopinvader/tests/test_cart_item.py
@@ -74,13 +74,44 @@ class AbstractItemCase(object):
         product_id = self.cart.order_line[0].product_id.id
         cart = self.update_item(line_id, 5)
         self.check_product_and_qty(cart["lines"]["items"][0], product_id, 5)
+        self.assertEqual(self.cart.id, cart["id"])
+
+    def test_update_item_robustness(self):
+        """
+        In this case we update an item on confirmed cart...
+        As result, a new item will be added on a new cart with the expectd qty
+        """
+        # by changing the typology, the cart is no more available on
+        # the cart service
+        self.cart.typology = "sale"
+        line_id = self.cart.order_line[0].id
+        product_id = self.cart.order_line[0].product_id.id
+        cart = self.update_item(line_id, 5)
+        self.check_product_and_qty(cart["lines"]["items"][0], product_id, 5)
+        # A new line has been created on a new cart...
+        self.assertNotEqual(self.cart.id, cart["id"])
 
     def test_delete_item(self):
         cart = self.service.search()["data"]
+        cart_id = cart["id"]
         items = cart["lines"]["items"]
         nbr_line = len(items)
         cart = self.delete_item(items[0]["id"])
         self.assertEqual(len(cart["lines"]["items"]), nbr_line - 1)
+        self.assertEqual(cart_id, cart["id"])
+
+    def test_delete_item_robustness(self):
+        """
+        In this case we remove an item of a confirmed cart...
+        The deletion must be ignored.. and a new empty cart returned
+        """
+        # by changing the typology, the cart is no more available on
+        # the cart service
+        self.cart.typology = "sale"
+        line_id = self.cart.order_line[0].id
+        cart = self.delete_item(line_id)
+        self.assertEqual(len(cart["lines"]["items"]), 0)
+        self.assertNotEqual(self.cart.id, cart["id"])
 
     def test_add_item_with_same_product_without_cart(self):
         self.remove_cart()


### PR DESCRIPTION
if trying to manipulate a cart that is not current anymore, ignore it, create a new cart; do not fail if removing an item that is not in cart anymore; create a new cart if adding an item when the current cart is closed

forward port of #374 