### PR TITLE
[10.0] shopinvader_guest_mode: fix bug on account creation + add data file for cron

### DIFF
--- a/shopinvader_guest_mode/__manifest__.py
+++ b/shopinvader_guest_mode/__manifest__.py
@@ -11,6 +11,10 @@
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://acsone.eu/",
     "depends": ["shopinvader"],
-    "data": ["views/shopinvader_backend.xml", "views/shopinvader_partner.xml"],
+    "data": [
+        "data/ir_cron.xml",
+        "views/shopinvader_backend.xml",
+        "views/shopinvader_partner.xml",
+    ],
     "demo": [],
 }

--- a/shopinvader_guest_mode/data/ir_cron.xml
+++ b/shopinvader_guest_mode/data/ir_cron.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <record forcecreate="True" id="ir_cron_product_pricelist_assortment" model="ir.cron">
+        <field name="name">Shopinvader: archive expired Guest accounts</field>
+        <field eval="False" name="active"/>
+        <field name="user_id" ref="base.user_root"/>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+        <field name="doall" eval="False" />
+        <field name="model">shopinvader.partner</field>
+        <field name="function">_deactivate_expired</field>
+        <field name="nextcall" eval="(DateTime.now()).strftime('%Y-%m-%d 22:00:00')" />
+    </record>
+</odoo>

--- a/shopinvader_guest_mode/services/__init__.py
+++ b/shopinvader_guest_mode/services/__init__.py
@@ -1,1 +1,2 @@
+from . import customer
 from . import guest_service

--- a/shopinvader_guest_mode/services/customer.py
+++ b/shopinvader_guest_mode/services/customer.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.component.core import Component
+
+
+class CustomerService(Component):
+    _inherit = "shopinvader.customer.service"
+    _usage = "customer"
+
+    def create(self, **params):
+        guest = self.component(usage="guest")
+        guest._archive_existing_binding(email=params["email"])
+        return super(CustomerService, self).create(**params)

--- a/shopinvader_guest_mode/tests/test_guest_service.py
+++ b/shopinvader_guest_mode/tests/test_guest_service.py
@@ -74,3 +74,14 @@ class TestGuestService(CommonCase):
         self.backend.is_guest_mode_allowed = True
         binding = self._create_guest()
         self.assertTrue(binding.is_guest)
+
+    def test_create_account_after_guest(self):
+        self.service.dispatch("create", params=self.data)["data"]
+        with self.work_on_services(
+            partner=None, shopinvader_session=self.shopinvader_session
+        ) as work:
+            customer_service = work.component(usage="customer")
+        data = self.data.copy()
+        data["is_company"] = False
+        data["external_id"] = "D5CdkqOEL"
+        customer_service.dispatch("create", params=data)


### PR DESCRIPTION
This PR aims to:

### Solve a bug
When a customer finished a transaction in guest mode, if he tries to create an account before the expiry date, it leads to an error message:

> "Only one active binging with the same email is allowed by backend."

### Add a missing xml data

A function exists to archive all expired guest accounts automatically. This PR adds a xml data to create a dedicated cron.