### PR TITLE
[12.0][FIX] shopinvader: Don't browse on non-existent cart

### DIFF
--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -270,7 +270,7 @@ class CartService(Component):
             # an alternative would be to build a domain with the expected
             # criteria on the cart but in this case, each time the _get method
             # would have been called, a new SQL query would have been done
-            cart = self.env["sale.order"].browse(self.cart_id)
+            cart = self.env["sale.order"].browse(self.cart_id).exists()
         if (
             cart.shopinvader_backend_id == self.shopinvader_backend
             and cart.typology == "cart"

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -327,6 +327,22 @@ class ConnectedCartCase(CommonConnectedCartCase):
         self.assertEqual(cart_bis.state, "draft")
         self.assertEqual(cart_bis.partner_id, self.partner)
 
+    def test_cart_delete_robustness(self):
+        """
+        If for some reason, the cart does not exist anymore but
+        in session, these conditions are no more met, the service
+        silently create a new cart to replace the one into the session
+        """
+        cart = self.service._get()
+        cart_bis = self.service._get()
+        self.assertEqual(cart, cart_bis)
+        cart.unlink()
+        cart_bis = self.service._get()
+        self.assertNotEqual(cart, cart_bis)
+        self.assertEqual(cart_bis.typology, "cart")
+        self.assertEqual(cart_bis.state, "draft")
+        self.assertEqual(cart_bis.partner_id, self.partner)
+
 
 class ConnectedCartNoTaxCase(CartCase):
     def setUp(self, *args, **kwargs):


### PR DESCRIPTION
Use exists() with browse() if cart id is still in session
but record in Odoo does not exist anymore (deleted)