### PR TITLE
Invader settings: fix default for sys param

### DIFF
--- a/shopinvader/models/shopinvader_config_settings.py
+++ b/shopinvader/models/shopinvader_config_settings.py
@@ -10,7 +10,7 @@ class ShopinvaderConfigSettings(models.TransientModel):
     _name = "shopinvader.config.settings"
 
     no_partner_duplicate = fields.Boolean(
-        default=True,
+        default='True',
         config_parameter="shopinvader.no_partner_duplicate",
         help="If checked, when a binding is created for a backend, we first "
         "try to find a partner with the same email and if found we link "


### PR DESCRIPTION
Boolean defaults for sys params must be bool-like strings
since thee comparison is done like `value = value.lower() == 'true'`

Settins are currently broken like this:

```
[...]
  File "/odoo/src/odoo/api.py", line 718, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "/odoo/src/odoo/addons/base/models/res_config.py", line 546, in default_get
    value = value.lower() == 'true'
AttributeError: 'bool' object has no attribute 'lower'
```
That comparison should check `value` value 1st, but yeah.... 