### PR TITLE
[10.0][FIX] shopinvader_image: Avoid the deletion of images installed by demo data

### DIFF
--- a/shopinvader_image/__manifest__.py
+++ b/shopinvader_image/__manifest__.py
@@ -20,6 +20,7 @@
         "data/ir_export_category.xml",
     ],
     "demo": [
+        "demo/storage_image_product_image_tag_demo.xml",
         "demo/shopinvader_image_resize_demo.xml",
         "demo/backend_demo.xml",
     ],

--- a/shopinvader_image/hooks.py
+++ b/shopinvader_image/hooks.py
@@ -30,7 +30,16 @@ def post_init_hook(cr, registry):
     module_obj = env["ir.module.module"]
     module = module_obj.search([("name", "=", "shopinvader_image")])
     if module.demo:
-        #  loaded data requires that the component registry is loaded
+        # Loaded data requires that the component registry is loaded!
+        # The components registry is loaded at the end of the server
+        # initialization. By default demo data are loaded as part of the
+        # server initialization process. Unfortunately, since the way images
+        # are stored is managed by components we need that these components
+        # are available when creating an image. We must therefore delay the
+        # creation of our demo images to take place once the server is fully
+        # initialized and components are ready to be used. That's why these
+        # demo data files are loaded into a post_init_hook in place of
+        # the normal process.
         builder = env["component.builder"]
         # build the components of every installed addons
         comp_registry = builder._init_global_registry()

--- a/shopinvader_image/hooks.py
+++ b/shopinvader_image/hooks.py
@@ -9,7 +9,6 @@ from odoo.modules.module import get_resource_path
 DEMO_POST_INIT = [
     "demo/storage_file_demo.xml",
     "demo/storage_image_demo.xml",
-    "demo/storage_image_product_image_tag_demo.xml",
     "demo/product_image_relation_demo.xml",
     "demo/product_product_image_relation_demo.xml",
 ]
@@ -41,3 +40,22 @@ def post_init_hook(cr, registry):
         # load data requiring components
         for demo in DEMO_POST_INIT:
             load_xml(env, "shopinvader_image", demo)
+        # prevent removal of demo data since the xml files are not declared
+        # into the demo section and therefore the xml_ids are no more found on
+        # addon update
+        cr.execute(
+            """
+            update
+                ir_model_data
+            set
+                module='__export__'
+            where
+                module='shopinvader_image'
+                and model in (
+                    'storage.file',
+                    'storage.image',
+                    'product.image.relation',
+                    'product.product'
+                )
+        """
+        )


### PR DESCRIPTION
backport of #385 