### PR TITLE
[10.0][FIX] shopinvader_image: Key is a required field of shopinvader.image…

### DIFF
--- a/shopinvader_image/views/shopinvader_image_resize_view.xml
+++ b/shopinvader_image/views/shopinvader_image_resize_view.xml
@@ -17,6 +17,7 @@
              <tree string="Product" editable="bottom">
                 <field name="display_name"/>
                 <field name="name"/>
+                <field name="key"/>
                 <field name="size_x"/>
                 <field name="size_y"/>
              </tree>


### PR DESCRIPTION
….resize

Add the field 'key' to the tree view since this field is required and the view is editable. Otherwise it's not possible to create new shopinvader.image.resize from the tree view

backport of #393 