### PR TITLE
[12.0] [IMP] shopinvader: Get rid of last_step_id

### DIFF
--- a/shopinvader/demo/backend_demo.xml
+++ b/shopinvader/demo/backend_demo.xml
@@ -5,7 +5,6 @@
         <field name="name">Demo Shopinvader Website</field>
         <field name="location">http://locomotive:3000</field>
         <field name="lang_ids" eval="[(6, 0, [ref('base.lang_en')])]"/>
-        <field name="last_step_id" ref="cart_end"/>
         <field name="pricelist_id" ref="product.list0"/>
         <field name="account_analytic_id" ref="account_analytic_0"/>
     </record>
@@ -14,7 +13,6 @@
         <field name="name">Demo Shopinvader Website 2</field>
         <field name="location">http://locomotive:3000</field>
         <field name="lang_ids" eval="[(6, 0, [ref('base.lang_en')])]"/>
-        <field name="last_step_id" ref="cart_end"/>
         <field name="pricelist_id" ref="product.list0"/>
         <field name="account_analytic_id" ref="account_analytic_0"/>
     </record>

--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -25,12 +25,6 @@ class ShopinvaderBackend(models.Model):
     nbr_product = fields.Integer(compute="_compute_nbr_content")
     nbr_variant = fields.Integer(compute="_compute_nbr_content")
     nbr_category = fields.Integer(compute="_compute_nbr_content")
-    last_step_id = fields.Many2one(
-        "shopinvader.cart.step",
-        string="Last cart step",
-        required=True,
-        default=lambda s: s._default_last_step_id(),
-    )
     allowed_country_ids = fields.Many2many(
         comodel_name="res.country", string="Allowed Country"
     )
@@ -127,15 +121,6 @@ class ShopinvaderBackend(models.Model):
         return self.env["res.company"]._company_default_get(
             "shopinvader.backend"
         )
-
-    @api.model
-    def _default_last_step_id(self):
-        last_step = self.env["shopinvader.cart.step"].browse()
-        try:
-            last_step = self.env.ref("shopinvader.cart_end")
-        except ValueError:
-            pass
-        return last_step
 
     def _to_compute_nbr_content(self):
         """

--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -33,13 +33,7 @@ class CartService(Component):
     def update(self, **params):
         cart = self._get()
         response = self._update(cart, params)
-        if response.get("action_confirm_cart"):
-            # TODO improve me, it will be better to block the cart
-            # confirmation if the user have set manually the end step
-            # and the payment method do not support it
-            # the best will be to have a params on the payment method
-            return self._confirm_cart(cart)
-        elif response.get("redirect_to"):
+        if response.get("redirect_to"):
             return response
         else:
             return self._to_json(cart)
@@ -228,18 +222,10 @@ class CartService(Component):
         return params
 
     def _update(self, cart, params):
-        action_confirm_cart = False
-        step_in_params = "step" in params
         params = self._prepare_update(cart, params)
-        if step_in_params:
-            if (
-                params.get("current_step_id")
-                == self.shopinvader_backend.last_step_id.id
-            ):
-                action_confirm_cart = True
         if params:
             cart.write_with_onchange(params)
-        return {"action_confirm_cart": action_confirm_cart}
+        return {}
 
     def _get_step_from_code(self, code):
         step = self.env["shopinvader.cart.step"].search([("code", "=", code)])
@@ -317,14 +303,6 @@ class CartService(Component):
             if changed_field in onchange_fields:
                 return True
         return False
-
-    def _confirm_cart(self, cart):
-        cart.action_confirm_cart()
-        res = self._to_json(cart)
-        self.shopinvader_response.set_session("cart_id", 0)
-        self.shopinvader_response.set_store_cache("last_sale", res["data"])
-        self.shopinvader_response.set_store_cache("cart", {})
-        return res
 
     def _get_cart_item(self, cart, params, raise_if_not_found=True):
         # We search the line based on the item id and the cart id

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -245,13 +245,6 @@ class ConnectedCartCase(CommonConnectedCartCase):
             cart.pricelist_id, cart.shopinvader_backend_id.pricelist_id
         )
 
-    def test_confirm_cart(self):
-        self.assertEqual(self.cart.typology, "cart")
-        self.service.dispatch(
-            "update", params={"step": {"next": self.backend.last_step_id.code}}
-        )
-        self.assertEqual(self.cart.typology, "sale")
-
     def test_confirm_cart_maually(self):
         self.assertEqual(self.cart.typology, "cart")
         self.cart.action_confirm()

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -61,7 +61,6 @@
                         </page>
                         <page name="sale" string="Sale">
                             <group name="cart_conf" string="Cart configuration">
-                                <field name="last_step_id"/>
                                 <field name="anonymous_partner_id"/>
                                 <field name="pricelist_id" required="1"/>
                             </group>


### PR DESCRIPTION
Cart confirmation is managed by the payments