### PR TITLE
[10.0][ADD] Return also state label (not only technical value)

### DIFF
--- a/shopinvader/services/abstract_sale.py
+++ b/shopinvader/services/abstract_sale.py
@@ -22,9 +22,11 @@ class AbstractSaleService(AbstractComponent):
 
     def _convert_one_sale(self, sale):
         sale.ensure_one()
+        state_label = self._get_selection_label(sale, "shopinvader_state")
         return {
             "id": sale.id,
             "state": sale.shopinvader_state,
+            "state_label": state_label,
             "name": sale.name,
             "date": sale.date_order,
             "step": self._convert_step(sale),

--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -98,6 +98,20 @@ class BaseShopinvaderService(AbstractComponent):
     def _get_base_search_domain(self):
         return []
 
+    def _get_selection_label(self, record, field):
+        """
+        Get the translated label of the record selection field
+        :param record: recordset
+        :param field: str
+        :return: str
+        """
+        if field not in record._fields:
+            return ""
+        # convert_to_export(...) give the label of the selection (translated).
+        return record._fields.get(field).convert_to_export(
+            record[field], record
+        )
+
     def _get_openapi_default_parameters(self):
         defaults = super(
             BaseShopinvaderService, self

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -78,6 +78,17 @@ class CommonCase(SavepointCase, ComponentMixin):
         def cleanupShopinvaderResponseTestMode():
             shopinvader_response.set_testmode(False)
 
+    def _get_selection_label(self, record, field):
+        """
+        Get the translated label of the record selection field
+        :param record: recordset
+        :param field: str
+        :return: str
+        """
+        return record._fields.get(field).convert_to_export(
+            record[field], record
+        )
+
 
 class ProductCommonCase(CommonCase):
     def setUp(self):

--- a/shopinvader/tests/test_sale.py
+++ b/shopinvader/tests/test_sale.py
@@ -39,6 +39,11 @@ class SaleCase(CommonCase, CommonTestDownload):
         res = self.service.get(self.sale.id)
         self.assertEqual(res["id"], self.sale.id)
         self.assertEqual(res["name"], self.sale.name)
+        self.assertEqual(res["state"], self.sale.shopinvader_state)
+        self.assertEqual(
+            res["state_label"],
+            self._get_selection_label(self.sale, "shopinvader_state"),
+        )
 
     def test_cart_are_not_readable_as_sale(self):
         with self.assertRaises(MissingError):
@@ -51,6 +56,9 @@ class SaleCase(CommonCase, CommonTestDownload):
         sale = res["data"][0]
         self.assertEqual(sale["id"], self.sale.id)
         self.assertEqual(sale["name"], self.sale.name)
+        self.assertEqual(sale["state"], self.sale.shopinvader_state)
+        state_label = self._get_selection_label(self.sale, "shopinvader_state")
+        self.assertEqual(sale["state_label"], state_label)
 
     def test_hack_read_other_customer_sale(self):
         sale = self.env.ref("sale.sale_order_1")

--- a/shopinvader_invoice/services/invoice.py
+++ b/shopinvader_invoice/services/invoice.py
@@ -58,7 +58,9 @@ class InvoiceService(Component):
             "amount_untaxed": {"type": "float"},
             "amount_due": {"type": "float"},
             "type": {"type": "string"},
+            "type_label": {"type": "string"},
             "state": {"type": "string"},
+            "state_label": {"type": "string"},
         }
         schema = {"data": {"type": "dict", "schema": invoice_schema}}
         return schema
@@ -78,6 +80,8 @@ class InvoiceService(Component):
             "amount_due": {"type": "float"},
             "type": {"type": "string"},
             "state": {"type": "string"},
+            "type_label": {"type": "string"},
+            "state_label": {"type": "string"},
         }
         schema = {
             "size": {"type": "integer"},
@@ -101,26 +105,10 @@ class InvoiceService(Component):
             "amount_tax",
             "amount_untaxed",
             "residual:amount_due",
+            "type",
+            "state",
         ]
         return to_parse
-
-    def _get_selection_label(self, invoice, field):
-        """
-        Get the translated label of the invoice selection field
-        :param invoice: account.invoice recordset
-        :param field: str
-        :return: str
-        """
-        if field not in invoice._fields:
-            return ""
-        # _description_selection return a list of tuple (str, str).
-        # Exactly like the definition of Selection field but this function
-        # translate possible values.
-        type_dict = dict(
-            invoice._fields.get(field)._description_selection(invoice.env)
-        )
-        technical_value = invoice[field]
-        return type_dict.get(technical_value, technical_value)
 
     def _to_json_invoice(self, invoice):
         invoice.ensure_one()
@@ -128,8 +116,8 @@ class InvoiceService(Component):
         values = invoice.jsonify(parser)[0]
         values.update(
             {
-                "type": self._get_selection_label(invoice, "type"),
-                "state": self._get_selection_label(invoice, "state"),
+                "type_label": self._get_selection_label(invoice, "type"),
+                "state_label": self._get_selection_label(invoice, "state"),
             }
         )
         return values

--- a/shopinvader_invoice/tests/test_invoice_service.py
+++ b/shopinvader_invoice/tests/test_invoice_service.py
@@ -33,19 +33,6 @@ class TestInvoiceService(CommonCase):
         ) as work:
             self.service_guest = work.component(usage="invoice")
 
-    def _get_selection_label(self, invoice, field):
-        """
-        Get the translated label of the invoice selection field
-        :param invoice: account.invoice recordset
-        :param field: str
-        :return: str
-        """
-        technical_type = invoice[field]
-        type_dict = dict(
-            invoice._fields.get(field)._description_selection(invoice.env)
-        )
-        return type_dict.get(technical_type, technical_type)
-
     def _check_data_content(self, data, invoices):
         """
         Check data based on given invoices
@@ -64,8 +51,10 @@ class TestInvoiceService(CommonCase):
             self.assertEquals(
                 current_data.get("date_invoice"), invoice.date_invoice
             )
-            self.assertEquals(current_data.get("state"), state_label)
-            self.assertEquals(current_data.get("type"), type_label)
+            self.assertEquals(current_data.get("state"), invoice.state)
+            self.assertEquals(current_data.get("type"), invoice.type)
+            self.assertEquals(current_data.get("state_label"), state_label)
+            self.assertEquals(current_data.get("type_label"), type_label)
             self.assertEquals(
                 current_data.get("amount_total"), invoice.amount_total
             )


### PR DESCRIPTION
Depends on MR #407 
(Please review first depending MR to avoid comment code related to others MR)

Currently we return (into json result) the state (technical value) of the object (cart and invoice for this case). But we also have to return the translated label of this state (as the front doesn't have to manage translation on data).
