### PR TITLE
[12.0][FIX] fix issue when confirming quotation

### DIFF
--- a/shopinvader/models/sale.py
+++ b/shopinvader/models/sale.py
@@ -63,7 +63,7 @@ class SaleOrder(models.Model):
     @api.multi
     def action_confirm_cart(self):
         for record in self:
-            if record.typology != "cart":
+            if record.typology == "sale":
                 # cart is already confirmed
                 continue
             record.write({"typology": "sale"})


### PR DESCRIPTION
The quotation service call action_confirm_cart, and in this case the typology is "quotation".
In a long terme maybe the best will be to have a action_confirm_typology and passing the current typology (cart, quotation....) so each will have it's one dedicated notoification.
Right I think it's simplier to focus on the current behaviour