### PR TITLE
[12.0]][FIX] shopinvader_locomotive: limit partner export and manage write access

### DIFF
--- a/shopinvader_locomotive/__manifest__.py
+++ b/shopinvader_locomotive/__manifest__.py
@@ -16,6 +16,7 @@
         "connector_search_engine",
         "queue_job",
         "shopinvader",
+        "base_suspend_security",
     ],
     "data": ["views/shopinvader_backend_view.xml", "data/ir_cron.xml"],
     "demo": ["demo/backend_demo.xml"],

--- a/shopinvader_locomotive/component/event_listeners.py
+++ b/shopinvader_locomotive/component/event_listeners.py
@@ -35,9 +35,13 @@ class ShopinvaderRecordListener(Component):
 
     _apply_on = ["res.partner"]
 
+    def _get_fields_to_export(self):
+        return ["name", "email"]
+
     @skip_if(lambda self, record, **kwargs: self.no_connector_export(record))
     def on_record_write(self, record, fields=None):
-        if fields == ["shopinvader_bind_ids"]:
+        fields_to_export = self._get_fields_to_export()
+        if not set(fields_to_export).intersection(set(fields)):
             return
         if "shopinvader_bind_ids" not in record._fields:
             return

--- a/shopinvader_locomotive/models/locomotive_binding.py
+++ b/shopinvader_locomotive/models/locomotive_binding.py
@@ -18,7 +18,7 @@ class LocomotiveBinding(models.AbstractModel):
         self.ensure_one()
         with self.backend_id.work_on(self._name) as work:
             exporter = work.component(usage="record.exporter")
-            return exporter.run(self)
+            return exporter.run(self.suspend_security())
 
     @job(default_channel="root.shopinvader")
     @related_action(action="related_action_unwrap_binding")

--- a/shopinvader_locomotive/tests/__init__.py
+++ b/shopinvader_locomotive/tests/__init__.py
@@ -1,2 +1,2 @@
-# from . import test_shopinvader_partner
+from . import test_shopinvader_partner
 from . import test_backend

--- a/shopinvader_locomotive/tests/test_shopinvader_partner.py
+++ b/shopinvader_locomotive/tests/test_shopinvader_partner.py
@@ -4,6 +4,9 @@
 
 import logging
 
+from odoo import fields
+from odoo.exceptions import AccessError
+
 from .common import LocoCommonCase
 
 _logger = logging.getLogger(__name__)
@@ -84,4 +87,53 @@ class TestShopinvaderPartner(CommonShopinvaderPartner):
                 + "/content_types/customers/entries/5a953d6aae1c744cfcfb3cd3",
                 json={},
             )
+            self._perform_created_job()
+
+    def test_update_shopinvader_partner_from_odoo(self):
+        shop_partner, params = self._create_shopinvader_partner(
+            self.data, u"5a953d6aae1c744cfcfb3cd3"
+        )
+        self._init_job_counter()
+        partner = shop_partner.record_id
+        partner.write({"name": "TEST"})
+        # As we updated a field to export, a job should be created
+        self._check_nbr_job_created(1)
+
+    def test_no_update_shopinvader_partner_from_odoo(self):
+        shop_partner, params = self._create_shopinvader_partner(
+            self.data, u"5a953d6aae1c744cfcfb3cd3"
+        )
+        self._init_job_counter()
+        partner = shop_partner.record_id
+        partner.write({"city": "TEST"})
+        # As we did not updated a field to export, no job should be created
+        self._check_nbr_job_created(0)
+
+    def test_binding_access_rights(self):
+        shop_partner, params = self._create_shopinvader_partner(
+            self.data, u"5a953d6aae1c744cfcfb3cd3"
+        )
+        demo_user_id = self.ref("base.user_demo")
+        self._init_job_counter()
+        partner = shop_partner.record_id.sudo(demo_user_id)
+        # demo user has no write access on shopinvader_partner model
+        with self.assertRaises(AccessError):
+            shop_partner.sudo(demo_user_id).write(
+                {"sync_date": fields.Datetime.now()}
+            )
+
+        # demo user triggers an export to Locomotive
+        partner.write({"name": "TEST"})
+        # As we updated a field to export, a job should be created
+        self._check_nbr_job_created(1)
+        with requests_mock.mock() as m:
+            m.post(
+                self.base_url + "/tokens.json", json={"token": u"744cfcfb3cd3"}
+            )
+            m.put(
+                self.base_url
+                + "/content_types/customers/entries/5a953d6aae1c744cfcfb3cd3",
+                json={},
+            )
+            # export ran as demo user even if no access on shopinvader_partner
             self._perform_created_job()


### PR DESCRIPTION
forward port of #408 

1/ Restrict export of a partner to locomotive only if needed based on fields modified
2/ After an export, the sync_date is updated automatically but fails if the user has no right access on the binding model
