### PR TITLE
[10.0][FIX] shopinvader: prevent any creation of empty cart by search service

### DIFF
--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -29,6 +29,8 @@ class CartService(Component):
     def search(self):
         """Return the cart that have been set in the session or
            search an existing cart for the current partner"""
+        if not self.cart_id:
+            return {}
         return self._to_json(self._get())
 
     def update(self, **params):

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -263,6 +263,22 @@ class AnonymousCartCase(CartCase, CartClearTest):
         cart_bis = self.service._get()
         self.assertNotEqual(cart, cart_bis)
 
+    def test_cart_search_no_create(self):
+        """
+        - if search is called with a cart_id in session, cart must be returned
+        - if search is called without any cart_id in session,
+          result must be empty
+        """
+        self.assertTrue(self.service.shopinvader_session.get("cart_id"))
+        search_result = self.service.search()
+        self.assertEqual(
+            search_result["store_cache"]["cart"]["name"], self.cart.name
+        )
+        # reset cart_id parameter
+        self.service.shopinvader_session.update({"cart_id": False})
+        search_result = self.service.search()
+        self.assertDictEqual(search_result, {})
+
 
 class CommonConnectedCartCase(CartCase):
     """


### PR DESCRIPTION
As the /cart url is referenced in sitemap.xml, some robots call it regularly and trigger empty carts creation.
This PR aims to avoid this side effect.
