### PR TITLE
[10.0][FIX] shopinvader_promotion_rule: avoid to call the auto_apply rule twice after applying a coupon code

### DIFF
--- a/shopinvader_promotion_rule/services/cart.py
+++ b/shopinvader_promotion_rule/services/cart.py
@@ -39,11 +39,12 @@ class CartService(Component):
         if is_coupon_code_specified:
             if coupon_code:
                 cart.add_coupon(coupon_code)
-            else:
-                if cart.coupon_code:
-                    # the promotion has been removed:
-                    # * clear the promotion
-                    cart.clear_promotions()
+                return res
+
+            if cart.coupon_code:
+                # the promotion has been removed:
+                # * clear the promotion
+                cart.clear_promotions()
         # apply default promotion
         cart.apply_promotions()
         return res


### PR DESCRIPTION
This ticket aims to avoid double code processing when adding a coupon code.

Add coupon removes and re-applies automatic rules:
https://github.com/OCA/sale-workflow/blob/10.0/sale_promotion_rule/models/sale_promotion_rule.py#L221
https://github.com/OCA/sale-workflow/blob/10.0/sale_promotion_rule/models/sale_promotion_rule.py#L224

So it is not useful to re-call:
https://github.com/shopinvader/odoo-shopinvader/blob/10.0/shopinvader_promotion_rule/services/cart.py#L48

There is no need to add a new test for that. The non-failure of the existing one is enough as we just avoid to call twice the same process.