### PR TITLE
[12.0][FIX] The account analytic account is not correctly filled during cart creation

### DIFF
--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -282,7 +282,7 @@ class CartService(Component):
         vals.update(self.env["sale.order"].play_onchanges(vals, vals.keys()))
         if self.shopinvader_backend.account_analytic_id.id:
             vals[
-                "project_id"
+                "analytic_account_id"
             ] = self.shopinvader_backend.account_analytic_id.id
         if self.shopinvader_backend.pricelist_id:
             # We must always force the pricelist. In the case of sale_profile

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -148,7 +148,7 @@ class AnonymousCartCase(CartCase):
                 "typology": "cart",
                 "shopinvader_backend_id": self.backend.id,
                 "date_order": fields.Datetime.now(),
-                "project_id": self.backend.account_analytic_id.id,
+                "analytic_account_id": self.backend.account_analytic_id.id,
             }
         )
         so_line_obj = self.env["sale.order.line"]
@@ -319,6 +319,9 @@ class ConnectedCartCase(CommonConnectedCartCase):
         self.assertEqual(cart_bis.typology, "cart")
         self.assertEqual(cart_bis.state, "draft")
         self.assertEqual(cart_bis.partner_id, self.partner)
+        self.assertEqual(
+            self.backend.account_analytic_id, cart_bis.analytic_account_id
+        )
 
     def test_cart_delete_robustness(self):
         """


### PR DESCRIPTION
The `project_id` field on `sale.order` has been renamed in v12.0 (into `analytic_account_id`).
Add also a unit test to ensure that the account analytic account is correctly filled with the value from the backend.