### PR TITLE
[10.0][UPD] shopinvader: force update pricelist and prices

### DIFF
--- a/shopinvader/__manifest__.py
+++ b/shopinvader/__manifest__.py
@@ -28,6 +28,7 @@
         "component_event",
         "sale",
         "sale_discount_display_amount",
+        "sale_order_price_recalculation",
         "onchange_helper",
         "queue_job",
     ],

--- a/shopinvader/__manifest__.py
+++ b/shopinvader/__manifest__.py
@@ -61,6 +61,7 @@
         "data/ir_export_product.xml",
         "data/ir_export_category.xml",
         "data/cart_step.xml",
+        "data/ir_cron.xml",
     ],
     "demo": [
         "demo/account_demo.xml",

--- a/shopinvader/data/ir_cron.xml
+++ b/shopinvader/data/ir_cron.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <record id="shopinvader_sale_order_price_recompute" model="ir.cron">
+        <field name="name">Shopinvader - Recompute prices on carts</field>
+        <field name="active" eval="True"/>
+        <field name="user_id" ref="base.user_root"/>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall" eval="-1"/>
+        <field name="doall" eval="False"/>
+        <field name="model">shopinvader.backend</field>
+        <field name="function">_launch_sale_price_update</field>
+        <field name="nextcall" eval="(DateTime.now()).strftime('%Y-%m-%d 06:00:00')"/>
+    </record>
+</odoo>

--- a/shopinvader/models/sale.py
+++ b/shopinvader/models/sale.py
@@ -161,6 +161,43 @@ class SaleOrder(models.Model):
             self.reset_price_tax()
         return True
 
+    @api.multi
+    def _update_pricelist_and_update_line_prices(self):
+        """
+        On current sale orders (self):
+        - Update the pricelist with the one set on the backend;
+            => If no pricelist, use the default define on the partner.
+        - Then launch the price update (module sale_order_price_recalculation).
+        :return: bool
+        """
+        backends = self.mapped("shopinvader_backend_id").filtered(
+            lambda b: b.pricelist_id
+        )
+        other_sales = self
+        for backend in backends:
+            pricelist = backend.pricelist_id
+            sales = self.filtered(
+                lambda s, b=backend: s.shopinvader_backend_id == b
+            )
+            other_sales -= sales
+            sales.write({"pricelist_id": pricelist.id})
+        # We don't have a pricelist on the backend so use the one set
+        # on the partner
+        partner_pricelists = other_sales.mapped(
+            "partner_id.property_product_pricelist"
+        )
+        # Group by pricelist to do less write as possible.
+        for pricelist in partner_pricelists:
+            sales = other_sales.filtered(
+                lambda s, p=pricelist: s.partner_id.property_product_pricelist
+                == p
+            )
+            sales.write({"pricelist_id": pricelist.id})
+        # Even if the pricelist is not updated on the SO, we have to launch
+        # the price recalculation in case of pricelist content is updated.
+        self.recalculate_prices()
+        return True
+
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"

--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -4,8 +4,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models, tools
+from odoo.addons.queue_job.job import job
 from odoo.addons.server_environment import serv_config
 from odoo.http import request
+from odoo.osv import expression
 
 
 class ShopinvaderBackend(models.Model):
@@ -337,3 +339,56 @@ class ShopinvaderBackend(models.Model):
     def _get_from_http_request(self):
         auth_api_key = getattr(request, "auth_api_key", None)
         return self.browse(self._get_id_from_auth_api_key(auth_api_key))
+
+    @api.multi
+    @job(default_channel="root.shopinvader")
+    def _job_sale_price_update(self, sales):
+        """
+        Jobify the process to update prices.
+        After launching the price update, we also have to re-apply promotions
+        (in case of the promotion change and conditions doesn't match anymore).
+        Could be inherited to add others prices recompute.
+        :param sales: sale.order recordset
+        :return: None
+        """
+        sales._update_pricelist_and_update_line_prices()
+
+    @api.multi
+    @job(default_channel="root.shopinvader")
+    def _job_split_sale_price_update(self, sales):
+        """
+        Split the current job on many SO to 1 job per SO.
+        To avoid rollback full price update in case of error.
+        Better to have 1 SO bad recomputed instead of all SO.
+        :param sales: sale.order recordset
+        :return: bool
+        """
+        for sale in sales:
+            description = "Recompute prices for cart %s" % sale.display_name
+            self.with_delay(description=description)._job_sale_price_update(
+                sale
+            )
+        return True
+
+    @api.model
+    def _launch_sale_price_update(self, domain=False):
+        """
+        Retrieve cart to update then apply the recalculation
+        (could be used for a cron)
+        :param domain: list/domain
+        :return: bool
+        """
+        domain = domain or []
+        if domain:
+            domain = expression.normalize_domain(domain)
+        sale_domain = expression.normalize_domain(
+            [("typology", "=", "cart"), ("state", "=", "draft")]
+        )
+        domain = expression.AND([domain, sale_domain])
+        sale_carts = self.env["sale.order"].search(domain)
+        if sale_carts:
+            description = "Recompute prices for carts (split: 1 job per cart)"
+            return self.with_delay(
+                description=description
+            )._job_split_sale_price_update(sale_carts)
+        return True

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -27,6 +27,10 @@ class CommonCase(SavepointCase, ComponentMixin):
         cls.setUpComponent()
         cls.env = cls.env(context={"lang": "en_US"})
         cls.backend = cls.env.ref("shopinvader.backend_1")
+        cls.product_1 = cls.env.ref("product.product_product_4b")
+        cls.precision = cls.env["decimal.precision"].precision_get(
+            "Product Price"
+        )
         cls.backend.bind_all_product()
         cls.shopinvader_session = {}
         cls.api_key = "myApiKey"

--- a/shopinvader/tests/test_sale.py
+++ b/shopinvader/tests/test_sale.py
@@ -157,6 +157,124 @@ class SaleCase(CommonCase, CommonTestDownload):
             ],
         )
 
+    def _create_sale_order(self):
+        """
+        Create a new sale.order with 1 line.
+        :return: bool
+        """
+        self.sale = sale = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "partner_shipping_id": self.partner.id,
+                "partner_invoice_id": self.partner.id,
+                "pricelist_id": self.backend.pricelist_id.id,
+                "typology": "cart",
+                "shopinvader_backend_id": self.backend.id,
+                "date_order": fields.Datetime.now(),
+                "project_id": self.backend.account_analytic_id.id,
+            }
+        )
+        so_line_obj = self.env["sale.order.line"]
+        line_values = {
+            "order_id": sale.id,
+            "product_id": self.product_1.id,
+            "product_uom_qty": 1,
+            "shopinvader_variant_id": self.product_1.shopinvader_bind_ids.id,
+        }
+        new_line_values = so_line_obj.play_onchanges(
+            line_values, line_values.keys()
+        )
+        new_line_values.update(line_values)
+        self.line = so_line_obj.create(new_line_values)
+        return True
+
+    def test_update_pricelist(self):
+        """
+        Cases to test:
+        - A pricelist is defined on the backend (applied on the SO)
+            => Then change the pricelist (check new price applied)
+        - No pricelist defined on the backend (so the default comes from partner)
+            => Then define a pricelist on the backend (check applied)
+        - Pricelist on the backend (applied on SO)
+            => Then remove it (check pricelist from partner is applied)
+        :return:
+        """
+        # Let the user to set some discount if necessary
+        self.env.ref("sale.group_discount_per_so_line").write(
+            {"users": [(4, self.env.user.id, False)]}
+        )
+        fixed_price = 650
+        reduction = -100
+        self._create_pricelists(fixed_price, reduction)
+        self._create_sale_order()
+        self.assertEqual(self.backend.pricelist_id, self.sale.pricelist_id)
+        self.backend.write({"pricelist_id": self.first_pricelist.id})
+        self.sale._update_pricelist_and_update_line_prices()
+        self.assertEqual(self.first_pricelist, self.sale.pricelist_id)
+        self.assertAlmostEqual(
+            self.line.price_unit, fixed_price, places=self.precision
+        )
+        self.backend.write({"pricelist_id": self.second_pricelist.id})
+        self.sale._update_pricelist_and_update_line_prices()
+        self.assertEqual(self.second_pricelist, self.sale.pricelist_id)
+        self.assertAlmostEqual(
+            self.line.price_unit,
+            fixed_price + reduction,
+            places=self.precision,
+        )
+
+    def _create_pricelists(self, fixed_price, reduction):
+        """
+        Create 2 new pricelists (one with a fixed price) and another
+        (based on the first) with the given reduction.
+        :param fixed_price: float
+        :param reduction: float
+        :return: bool
+        """
+        pricelist_values = {
+            "name": "Custom pricelist 1",
+            "discount_policy": "with_discount",
+            "item_ids": [
+                (
+                    0,
+                    0,
+                    {
+                        "applied_on": "1_product",
+                        "product_tmpl_id": self.product_1.product_tmpl_id.id,
+                        "compute_price": "fixed",
+                        "fixed_price": fixed_price,
+                    },
+                )
+            ],
+        }
+        self.first_pricelist = self.env["product.pricelist"].create(
+            pricelist_values
+        )
+        pricelist_values = {
+            "name": "Custom pricelist 2",
+            "discount_policy": "with_discount",
+            "item_ids": [
+                (
+                    0,
+                    0,
+                    {
+                        "applied_on": "1_product",
+                        "product_tmpl_id": self.product_1.product_tmpl_id.id,
+                        "compute_price": "formula",
+                        "base": "pricelist",
+                        "price_surcharge": reduction,
+                        "base_pricelist_id": self.first_pricelist.id,
+                        "date_start": fields.Date.today(),
+                        "date_end": fields.Date.today(),
+                    },
+                )
+            ],
+        }
+        self.second_pricelist = self.env["product.pricelist"].create(
+            pricelist_values
+        )
+        return True
+
     def test_download01(self):
         """
         Data

--- a/shopinvader_promotion_rule/models/__init__.py
+++ b/shopinvader_promotion_rule/models/__init__.py
@@ -2,3 +2,4 @@
 # Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import sale_order
+from . import shopinvader_backend

--- a/shopinvader_promotion_rule/models/shopinvader_backend.py
+++ b/shopinvader_promotion_rule/models/shopinvader_backend.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+from odoo.addons.queue_job.job import job
+
+
+class ShopinvaderBackend(models.Model):
+    _inherit = "shopinvader.backend"
+
+    @api.multi
+    @job(default_channel="root.shopinvader")
+    def _job_sale_price_update(self, sales):
+        """
+        Inherit to re-compute also promotions rules
+        :param sales: sale.order recordset
+        :return:None
+        """
+        result = super(ShopinvaderBackend, self)._job_sale_price_update(sales)
+        # This function is called now because this module depends on
+        # shopinvader_promotion_rule. But maybe it should be extracted into
+        # a new module.
+        sales.apply_promotions()
+        return result


### PR DESCRIPTION
**Goal**
We have to force price update of cart because the pricelist on the backend can change. Also, some promotion could have a limit date. So prices should stay correct.

**Example**
Currently, you have a customer with a cart. On this cart, the pricelist is the one set on the backend. Items use prices from this pricelist.
Then you decide to update the pricelist (on the backend). So every cart should use this pricelist.

More specific case: you have a promotion rule and a cart use this one. The customer keep the cart during few days and the discount reach the limit date. We should update prices on this cart.

The module `sale_order_price_recalculation` (from oca/sale-workflow) is perfect for that.

**Still in WIP because we have to find a correct way to launch this behavior.**
- We can not do this into the cart/get because it could take a very long time to recompute.
- We could maybe do a cron/job to update every cart (but each 10 minutes? 1 hours?). And we have to avoid concurrent update (if customer add item during the price re-computation). Seems wobbly

Any better ideas are welcome!