### PR TITLE
[12.0] shopinvader_locomotive: drop duplicated cron

### DIFF
--- a/shopinvader_locomotive/data/ir_cron.xml
+++ b/shopinvader_locomotive/data/ir_cron.xml
@@ -13,16 +13,4 @@
         <field name="code">model._scheduler_synchronize_currency()</field>
     </record>
 
-    <record forcecreate="True" id="ir_cron_export_binding" model="ir.cron">
-        <field name="name">Search engine: Generate job for exporting binding per index</field>
-        <field eval="True" name="active"/>
-        <field name="user_id" ref="base.user_root"/>
-        <field name="interval_number">1</field>
-        <field name="interval_type">days</field>
-        <field name="numbercall">-1</field>
-        <field eval="False" name="doall"/>
-        <field name="code">model.generate_batch_export_per_index()</field>
-        <field name="model_id" ref="connector_search_engine.model_se_index"/>
-    </record>
-
 </odoo>


### PR DESCRIPTION
The cron for batch reindex is already in search engine module https://github.com/OCA/search-engine/blob/71a79427400ab3111f8a18f4490e9c87c04213b8/connector_search_engine/data/ir_cron.xml