### PR TITLE
[10.0][FIX] shopinvader guest mode export

### DIFF
--- a/shopinvader_locomotive/component/event_listeners.py
+++ b/shopinvader_locomotive/component/event_listeners.py
@@ -46,7 +46,7 @@ class ShopinvaderRecordListener(Component):
             return
         if "shopinvader_bind_ids" not in record._fields:
             return
-        for binding in record.shopinvader_bind_ids:
+        for binding in record._get_binding_to_export():
             binding.with_delay().export_record(_fields=fields)
 
     def on_record_unlink(self, record, fields=None):

--- a/shopinvader_locomotive/models/__init__.py
+++ b/shopinvader_locomotive/models/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from . import res_partner
 from . import shopinvader_backend
 from . import locomotive_binding
 from . import shopinvader_partner

--- a/shopinvader_locomotive/models/res_partner.py
+++ b/shopinvader_locomotive/models/res_partner.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    @api.multi
+    def _get_binding_to_export(self):
+        """
+        Get every shopinvader partner to export
+        :return: shopinvader.partner recordset
+        """
+        return self.mapped("shopinvader_bind_ids")

--- a/shopinvader_locomotive/tests/test_shopinvader_partner.py
+++ b/shopinvader_locomotive/tests/test_shopinvader_partner.py
@@ -138,3 +138,16 @@ class TestShopinvaderPartner(CommonShopinvaderPartner):
             )
             # export ran as demo user even if no access on shopinvader_partner
             self._perform_created_job()
+
+    def test_get_binding_to_export(self):
+        """
+        Ensure the function _get_binding_to_export() correctly return
+        shopinvader.partner related to current partner.
+        :return:
+        """
+        shop_partner = self._create_shopinvader_partner(
+            self.data, u"5a953d6aae1c744cfcfb3cd3"
+        )[0]
+        partner = shop_partner.record_id
+        self.assertEqual(partner._get_binding_to_export(), shop_partner)
+        return

--- a/shopinvader_locomotive_guest_mode/__init__.py
+++ b/shopinvader_locomotive_guest_mode/__init__.py
@@ -1,1 +1,2 @@
 from . import component
+from . import models

--- a/shopinvader_locomotive_guest_mode/models/__init__.py
+++ b/shopinvader_locomotive_guest_mode/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import res_partner

--- a/shopinvader_locomotive_guest_mode/models/res_partner.py
+++ b/shopinvader_locomotive_guest_mode/models/res_partner.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    @api.multi
+    def _get_binding_to_export(self):
+        """
+        Inherit to restrict binding to export:
+        - Exclude guest
+        :return: shopinvader.partner recordset
+        """
+        bindings = super(ResPartner, self)._get_binding_to_export()
+        bindings = bindings.filtered(lambda b: not b.is_guest)
+        return bindings

--- a/shopinvader_locomotive_guest_mode/tests/__init__.py
+++ b/shopinvader_locomotive_guest_mode/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_backend
+from . import test_shopinvader_partner

--- a/shopinvader_locomotive_guest_mode/tests/test_shopinvader_partner.py
+++ b/shopinvader_locomotive_guest_mode/tests/test_shopinvader_partner.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.addons.shopinvader_locomotive.tests.test_shopinvader_partner import (
+    CommonShopinvaderPartner,
+)
+
+
+class TestShopinvaderPartnerGuest(CommonShopinvaderPartner):
+    def setUp(self, *args, **kwargs):
+        super(TestShopinvaderPartnerGuest, self).setUp(*args, **kwargs)
+        self.backend2 = self.backend.search(
+            [("id", "!=", self.backend.id)], limit=1
+        )
+        backends = self.backend
+        backends |= self.backend2
+        backends.write({"is_guest_mode_allowed": True})
+
+    def _create_shopinvader_guest_for_partner(self, partner, backend=False):
+        backend = backend or self.backend
+        self._init_job_counter()
+        shopinvader_partner = self.env["shopinvader.partner"].create(
+            {
+                "record_id": partner.id,
+                "backend_id": backend.id,
+                "is_guest": True,
+            }
+        )
+        # The creation of a shopinvader partner into odoo must trigger
+        # the creation of a user account into locomotive
+        self._check_nbr_job_created(0)
+        return shopinvader_partner
+
+    def _create_shopinvader_guest_partner(self, data, backend=False):
+        partner = self.env["res.partner"].create(data)
+        return self._create_shopinvader_guest_for_partner(
+            partner, backend=backend
+        )
+
+    def test_get_binding_to_export1(self):
+        """
+        Ensure the function _get_binding_to_export() correctly return
+        shopinvader.partner related to current partner.
+        :return:
+        """
+        shop_partner_guest = self._create_shopinvader_guest_partner(self.data)
+        partner = shop_partner_guest.record_id
+        self.assertNotIn(shop_partner_guest, partner._get_binding_to_export())
+        partner.write({"name": "have a new name"})
+        self._check_nbr_job_created(0)
+        return
+
+    def test_get_binding_to_export2(self):
+        """
+        Ensure the function _get_binding_to_export() correctly return
+        shopinvader.partner related to current partner.
+        :return:
+        """
+        shop_partner, params = self._create_shopinvader_partner(
+            self.data, u"5a953d6aae1c744cfcfb3cd3"
+        )
+        partner = shop_partner.record_id
+        shop_partner_guest = self._create_shopinvader_guest_for_partner(
+            partner, backend=self.backend2
+        )
+        result_export = partner._get_binding_to_export()
+        self.assertIn(shop_partner, result_export)
+        self.assertNotIn(shop_partner_guest, result_export)
+        partner.write({"name": "have a new name"})
+        self._check_nbr_job_created(1)
+        return


### PR DESCRIPTION
Part of the issue https://github.com/shopinvader/locomotive-shopinvader/issues/51

**Issue**
When a guest partner is created (`is_guest = True`), an update on it (on the related `res.partner`; via Odoo or by `address/update` service) will trigger the job to update the record on locomotive. This update create the partner in locomotive and assign to it an `external_id`.

**How to reproduce**
- Browse the website in guest mode;
- Create a cart and try to validate it by using guest mode;
- Fill your information and validate (don't go further on the process);
- Check into backend, you should have the partner with a binding (without `external_id` as it's guest);
- Then, update these information (on front side. Imagine the real case when a customer have a typo into address or name);
- Refresh the partner into your backend (maybe you have to wait few seconds until the job is finished) => you have an `external_id` for your binded partner. _BOOM!_

**Fix**
_Module `shopinvader_locomotive`_
- Create an inheritable function to get `shopinvader.partner` to export.

_Module `shopinvader_locomotive_guest_mode`_
- Just filter results provided by the new function, to remove when `is_guest = True`.

I think it's better to avoid job creation upstream instead of ignoring the job when the partner is a guest.