### PR TITLE
[10.0][FIX] shopinvader: change url_key of all bindings in case of product renaming

### DIFF
--- a/shopinvader/models/product_template.py
+++ b/shopinvader/models/product_template.py
@@ -61,10 +61,10 @@ class ProductTemplate(models.Model):
         self_name = {r: r.name for r in self}
         yield
         for record in self:
-            if not record.shopinvader_bind_ids:
+            if not record.suspend_security().shopinvader_bind_ids:
                 continue
             if record.name != self_name.get(record):
-                record.shopinvader_bind_ids._sync_urls()
+                record.suspend_security().shopinvader_bind_ids._sync_urls()
 
     @api.multi
     def write(self, vals):


### PR DESCRIPTION
When the name of a product is changed, the url_key is recomputed. So a redirect is generated on the old url_key.

Currently, this is only done for the bindings in the current company.
This PR aims to fix this problem and trigger the redirect on all bindings whatever the company.