### PR TITLE
[10.0]FIX/Improve view of product.category/shopinvader.category

### DIFF
--- a/shopinvader/views/product_category_view.xml
+++ b/shopinvader/views/product_category_view.xml
@@ -13,64 +13,14 @@
                         </group>
                     </page>
                     <page name="shopinvader" string="Shopinvader">
-                        <group name="Shopinvader" colspan="4">
-                            <field name="shopinvader_bind_ids" nolabel="1">
-                                <tree>
-                                    <field name="backend_id"/>
-                                    <field name="lang_id"/>
-                                    <field name="sync_date"/>
-                                    <field name="external_id"/>
-                                </tree>
-                                <form>
-                                    <group colspan="4" col="4">
-                                        <field name="backend_id"/>
-                                        <field name="lang_id"/>
-                                        <field name="active"/>
-                                    </group>
-                                    <notebook>
-                                        <page name="description" string="Description">
-                                            <group colspan="4">
-                                                <field name="subtitle"/>
-                                                <separator string="Short Description" colspan="4"/>
-                                                <field name="short_description" nolabel="1" colspan="4"/>
-                                                <separator string="Description" colspan="4"/>
-                                                <field name="description" nolabel="1" colspan="4"/>
-                                            </group>
-                                        </page>
-                                        <page name="seo" string="SEO">
-                                            <group name="backend">
-                                                <group colspan="4">
-                                                    <field name="seo_title"/>
-                                                    <field name="meta_keywords"/>
-                                                    <field name="meta_description"/>
-                                                </group>
-                                                <group colspan="4">
-                                                    <field name="url_builder"/>
-                                                    <field
-                                                            name="manual_url_key"
-                                                            attrs="{
-                                                        'invisible': [('url_builder', '!=', 'manual')],
-                                                        'required': [('url_builder', '=', 'manual')]}"/>
-                                                    <field
-                                                            name="url_key"
-                                                            attrs="{'invisible': [('url_builder', '=', 'manual')]}"/>
-                                                </group>
-                                                <group colspan="4" string="Redirect Url">
-                                                     <field
-                                                            name="redirect_url_url_ids"
-                                                            nolabel="1"
-                                                            colspan="4">
-                                                        <tree>
-                                                            <field name="url_key"/>
-                                                        </tree>
-                                                    </field>
-                                                </group>
-                                            </group>
-                                        </page>
-                                    </notebook>
-                                </form>
-                            </field>
-                        </group>
+                        <field name="shopinvader_bind_ids" nolabel="1">
+                            <tree>
+                                <field name="backend_id"/>
+                                <field name="lang_id"/>
+                                <field name="sync_date"/>
+                                <field name="external_id"/>
+                            </tree>
+                        </field>
                     </page>
                 </notebook>
             </xpath>

--- a/shopinvader/views/shopinvader_category_view.xml
+++ b/shopinvader/views/shopinvader_category_view.xml
@@ -1,6 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
+<record id="view_shopinvader_category_form" model="ir.ui.view">
+    <field name="model">shopinvader.category</field>
+    <field name="arch" type="xml">
+        <form>
+            <group name="top">
+                <field name="backend_id"/>
+                <field name="lang_id"/>
+                <field name="active"/>
+            </group>
+            <notebook>
+                <page name="description" string="Description">
+                    <group name="description">
+                        <field name="subtitle"/>
+                        <separator string="Short Description" colspan="2"/>
+                        <field name="short_description" nolabel="1" colspan="2"/>
+                        <separator string="Description" colspan="2"/>
+                        <field name="description" nolabel="1" colspan="2"/>
+                    </group>
+                </page>
+                <page name="seo" string="SEO">
+                    <group name="meta_and_url">
+                        <field name="seo_title"/>
+                        <field name="meta_keywords"/>
+                        <field name="meta_description"/>
+                        <field name="url_builder"/>
+                        <field name="manual_url_key" attrs="{'invisible': [('url_builder', '!=', 'manual')], 'required': [('url_builder', '=', 'manual')]}"/>
+                        <field name="url_key" attrs="{'invisible': [('url_builder', '=', 'manual')]}"/>
+                    </group>
+                    <group name="redirect_url" string="Redirect Url">
+                        <field name="redirect_url_url_ids" nolabel="1" colspan="2">
+                            <tree>
+                                <field name="url_key"/>
+                            </tree>
+                        </field>
+                    </group>
+                </page>
+            </notebook>
+        </form>
+    </field>
+</record>
+
 <record id="view_shopinvader_category_tree" model="ir.ui.view">
     <field name="model">shopinvader.category</field>
     <field name="arch" type="xml">
@@ -27,12 +68,9 @@
 
 <record model="ir.actions.act_window" id="act_open_shopinvader_category_view">
     <field name="name">Shopinvader Category</field>
-    <field name="type">ir.actions.act_window</field>
     <field name="res_model">shopinvader.category</field>
     <field name="view_mode">tree</field>
     <field name="search_view_id" ref="view_shopinvader_category_search"/>
-    <field name="domain">[]</field>
-    <field name="context">{}</field>
 </record>
 
 <menuitem id="menu_shopinvader_category"


### PR DESCRIPTION
Before : the form view of shopinvader.category was embedded in the form view of product.category. It was a huge include of view, which could cause some problems with other modules that inherit the form view of product.category. For example, it caused problems with the module storage_image_product, cf https://github.com/akretion/storage/blob/10.0/storage_image_product/views/product_category.xml because that module uses xpath expr="//group[last()]" which matches a group of the embedded form view of shopinvader.category !!!

After : the form view of shopinvader.category has its own definition. No more problems with storage_image_product.