### PR TITLE
Tests: skip HttpCase on demand

### DIFF
--- a/shopinvader/tests/test_controller.py
+++ b/shopinvader/tests/test_controller.py
@@ -2,6 +2,8 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import os
+import unittest
 from uuid import uuid4
 
 import requests
@@ -10,6 +12,7 @@ from odoo.tools import mute_logger
 from .common import ShopinvaderRestCase
 
 
+@unittest.skipIf(os.getenv("SKIP_HTTP_CASE"), "HTTP case disabled.")
 class ShopinvaderControllerCase(ShopinvaderRestCase):
     def setUp(self, *args, **kwargs):
         super(ShopinvaderControllerCase, self).setUp(*args, **kwargs)


### PR DESCRIPTION
This helps a lot when testing the whole suite w/ pytest
or any other test runner that does not run the odoo server.