### PR TITLE
[10.0][FIX] cart/search create empty cart in some case

### DIFF
--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -31,7 +31,8 @@ class CartService(Component):
            search an existing cart for the current partner"""
         if not self.cart_id:
             return {}
-        return self._to_json(self._get())
+        # If the cart_id doesn't exist anymore, we don't have to create a new
+        return self._to_json(self._get(create_if_not_found=False))
 
     def update(self, **params):
         cart = self._get()

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -413,6 +413,30 @@ class ConnectedCartCase(CommonConnectedCartCase, CartClearTest):
         self.assertEqual(cart_bis.state, "draft")
         self.assertEqual(cart_bis.partner_id, self.partner)
 
+    def test_cart_deleted_then_search(self):
+        """
+        When a user have a cart into session (cart_id) and this cart is
+        removed (or doesn't match anymore to be loaded by the service),
+        the search shouldn't create a new empty cart.
+        This test ensure the search will not create a new cart is this case.
+        :return:
+        """
+        cart = self.service._get()
+        # Ensure correctly created
+        self.assertTrue(cart.exists())
+        # Put the cart into the session
+        self.service.shopinvader_session.update({"cart_id": cart.id})
+        # Delete the cart
+        cart.unlink()
+        self.assertFalse(cart.exists())
+        nb_sale_order_before = self.cart.search_count([])
+        result = self.service.search()
+        nb_sale_order_after = self.cart.search_count([])
+        self.assertDictEqual(result.get("data", {}), {})
+        # Ensure no new SO has been created
+        self.assertEqual(nb_sale_order_after, nb_sale_order_before)
+        return
+
 
 class ConnectedCartNoTaxCase(CartCase):
     def setUp(self, *args, **kwargs):


### PR DESCRIPTION
**Bug**
When a user have a cart_id (from session) no more accessible by the service (because removed, expired etc), a call to cart/search create a new (empty) cart.

**Fix**
During the search, do not create an empty cart.