### PR TITLE
[10.0][FIX] Quick fixes to avoid field who doesn't exist during create/write

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -6,10 +6,8 @@ e-commerce
 search-engine
 product-attribute
 product-variant
+sale-workflow
 storage https://github.com/akretion/storage 10.0
 base_rest https://github.com/oca/rest-framework 10.0
 odoo-pim https://github.com/shopinvader/odoo-pim 10.0
 odoo-misc https://github.com/shopinvader/odoo-misc 10.0
-
-# TODO remove me when the PR is merged https://github.com/OCA/sale-workflow/pull/755
-sale-workflow https://github.com/acsone/sale-workflow 10.0-sale_promotion_rule_discount_amount-lmi

--- a/shopinvader/models/shopinvader_partner.py
+++ b/shopinvader/models/shopinvader_partner.py
@@ -106,4 +106,9 @@ class ShopinvaderPartner(models.Model):
         if not v.get("type"):
             v["type"] = "other"
         v.pop("email")
+        # Remove field who doesn't exist in res.partner (partner_email,...)
+        partner_fields = self.env["res.partner"]._fields.keys()
+        for key in vals:
+            if key not in partner_fields:
+                v.pop(key)
         return v

--- a/shopinvader/models/shopinvader_partner.py
+++ b/shopinvader/models/shopinvader_partner.py
@@ -86,13 +86,23 @@ class ShopinvaderPartner(models.Model):
         """ we check if one of the given value is different than values
             of the given partner
         """
-        data = partner._convert_to_write(partner._cache)
-        for key in data:
-            if key not in vals:
+        skip_keys = self._is_same_partner_value_skip_keys(partner)
+        keys_to_check = []
+        for key in vals.keys():
+            if key in skip_keys or key not in partner:
                 continue
+            keys_to_check.append(key)
+            # pylint: disable=pointless-statement
+            partner[key]  # make sure key is cached
+        data = partner._convert_to_write(partner._cache)
+        for key in keys_to_check:
             if data[key] != vals[key]:
                 return False
         return True
+
+    def _is_same_partner_value_skip_keys(self, partner):
+        """Take control of keys to ignore for the match."""
+        return ("backend_id", "partner_email")
 
     @api.model
     def _create_child_partner(self, parent, vals):

--- a/shopinvader/tests/test_customer.py
+++ b/shopinvader/tests/test_customer.py
@@ -61,14 +61,14 @@ class TestCustomer(CommonCase):
         data = {
             "email": "address@customer.example.com",
             "name": "Address",
-            "country": {"id": self.env.ref("base.fr").id},
+            "country_id": self.env.ref("base.fr").id,
         }
         partner = self.env["res.partner"].create(data)
         self.assertEqual(partner.address_type, "profile")
         data = {
             "email": "parent@customer.example.com",
             "name": "Parent",
-            "country": {"id": self.env.ref("base.fr").id},
+            "country_id": self.env.ref("base.fr").id,
         }
         parent = self.env["res.partner"].create(data)
         partner.parent_id = parent.id


### PR DESCRIPTION
During some create/write, there is some fields who doesn't exist.

About `_prepare_create_child_params(...)`, the `vals` contains values to create/write on `shopinvader.partner`. So as the `vals` is used to create a new `res.partner`, we have to remove these unknown fields (`backend_id`, `partner_email` etc).