### PR TITLE
WIP [10.0][FIX] Shopinvader variant computed on the sale.order.line

### DIFF
--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -212,7 +212,7 @@ class AnonymousCartCase(CartCase, CartClearTest):
             "order_id": sale.id,
             "product_id": self.product_1.id,
             "product_uom_qty": 1,
-            "shopinvader_variant_id": self.product_1.shopinvader_bind_ids.id,
+            # "shopinvader_variant_id": self.product_1.shopinvader_bind_ids.id,
         }
         new_line_values = so_line_obj.play_onchanges(
             line_values, line_values.keys()


### PR DESCRIPTION
The shopinvader variant computed on the sale.order.line should use the lang of the context only in case of anonymous partner.

If the real customer define a lang, we should use this.
Currently, if a customer display a sale (with browser in specific lang), he'll have some pictures (defined by the images field on the related shopinvader_variant_id). But if he browse this same sale on a friend computer (into another language), he won't have any picture because the lang into the context is not the same.

**Todo:**

- Unit tests