### PR TITLE
[10.0][IMP] Use the technical user to recompute and export

### DIFF
--- a/shopinvader_search_engine/__manifest__.py
+++ b/shopinvader_search_engine/__manifest__.py
@@ -11,7 +11,11 @@
     "website": "www.akretion.com",
     "license": "AGPL-3",
     "category": "Generic Modules",
-    "depends": ["shopinvader", "connector_search_engine"],
+    "depends": [
+        "shopinvader",
+        "connector_search_engine",
+        "base_technical_user",
+    ],
     "data": [
         "views/shopinvader_backend_view.xml",
         "views/product_view.xml",

--- a/shopinvader_search_engine/models/shopinvader_backend.py
+++ b/shopinvader_search_engine/models/shopinvader_backend.py
@@ -19,14 +19,30 @@ class ShopinvaderBackend(models.Model):
 
     @api.multi
     def force_recompute_all_binding_index(self):
-        self.mapped("se_backend_id.index_ids").force_recompute_all_binding()
+        self_sudoer = self._use_technical_user_if_set()
+        self_sudoer.mapped(
+            "se_backend_id.index_ids"
+        ).force_recompute_all_binding()
         return True
 
     @api.multi
     def force_batch_export_index(self):
-        for index in self.mapped("se_backend_id.index_ids"):
+        self_sudoer = self._use_technical_user_if_set()
+        for index in self_sudoer.mapped("se_backend_id.index_ids"):
             index.force_batch_export()
         return True
+
+    def _use_technical_user_if_set(self):
+        """
+        Change the current user by the technical user if it's set on the
+        current user's company.
+        :return: self
+        """
+        self_sudoer = self
+        tech_user = self.env.user.company_id.user_tech_id
+        if tech_user:
+            self_sudoer = self.sudo(tech_user.id)
+        return self_sudoer
 
     @api.multi
     def clear_index(self):

--- a/shopinvader_search_engine/tests/__init__.py
+++ b/shopinvader_search_engine/tests/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import test_shopinvader_backend

--- a/shopinvader_search_engine/tests/test_shopinvader_backend.py
+++ b/shopinvader_search_engine/tests/test_shopinvader_backend.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from uuid import uuid4
+
+from odoo.addons.shopinvader.tests.common import CommonCase
+
+
+class TestShopinvaderBackend(CommonCase):
+    """
+    Tests for shopinvader.backend
+    """
+
+    def _create_technical_user(self):
+        """
+
+        :return:
+        """
+        return self.env["res.users"].create(
+            {"name": "Super awesome technical user", "login": str(uuid4())}
+        )
+
+    def test_use_technical_user_if_set(self):
+        """
+        Check if the _use_technical_user_if_set change the current user (sudo)
+        correctly.
+        :return:
+        """
+        # For this case, disable the user_tech_id. So it should take current
+        # user.
+        user = self.env.user
+        self.env.user.company_id.write({"user_tech_id": False})
+        self.assertEqual(
+            user, self.backend._use_technical_user_if_set().env.user
+        )
+        # Now create a technical user and assign it on the company
+        user = self._create_technical_user()
+        self.env.user.company_id.write({"user_tech_id": user.id})
+        self.assertEqual(
+            user, self.backend._use_technical_user_if_set().env.user
+        )
+        # Try with another technical user
+        user = self._create_technical_user()
+        self.env.user.company_id.write({"user_tech_id": user.id})
+        self.assertEqual(
+            user, self.backend._use_technical_user_if_set().env.user
+        )
+        # Finally remove the technical user
+        self.env.user.company_id.write({"user_tech_id": False})
+        user = self.env.user
+        self.assertEqual(
+            user, self.backend._use_technical_user_if_set().env.user
+        )
+        return


### PR DESCRIPTION
On the shopinvader backend view, you have buttons to "Recompute" and "Export".

Edit the current behavior to use the technical user (only if it set on the current user's company).
Because currently, if a user click on this button, he can't switch his company until the end of each jobs (it will cause Access rights exception).

As the technical user not required (on the company) and to keep compatibility: no error will be raised if no technical user (it will use the current user, as currently).

Build/Tests will fails because need update on oca_dependencies.txt (fixed into #505 )