### PR TITLE
shopinvader partner: propagate to partner_user

### DIFF
--- a/shopinvader/controllers/main.py
+++ b/shopinvader/controllers/main.py
@@ -90,6 +90,8 @@ class InvaderController(main.RestController):
         res = super(InvaderController, self)._get_component_context()
         headers = request.httprequest.environ
         res["partner"] = self._get_partner_from_headers(headers)
+        # allow having a different partner for the user in extending modules
+        res["partner_user"] = res["partner"]
         res[
             "shopinvader_session"
         ] = self._get_shopinvader_session_from_headers(headers)

--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -19,7 +19,20 @@ class BaseShopinvaderService(AbstractComponent):
 
     @property
     def partner(self):
+        # partner that matches the real profile on client side
+        # or its main contact which in any case is used for all
+        # account information.
         return self.work.partner
+
+    @property
+    def partner_user(self):
+        # partner that matches the real user on client side.
+        # The standard `self.partner` will match `partner_user`
+        # only when the main customer account is logged in.
+        # In this way we can support multiple actors for the same profile.
+        # TODO: check if there are place wher it's better to use
+        # `partner_user` instead of `partner`.
+        return self.work.partner_user
 
     @property
     def shopinvader_session(self):


### PR DESCRIPTION
Allow to have a different partner than the profile one for current user.
Needed as base change for multi user account #471 