### PR TITLE
[10.0][FIX] shopinvader_delivery_carrier should returns only outgoing pickings

### DIFF
--- a/shopinvader_delivery_carrier/services/delivery.py
+++ b/shopinvader_delivery_carrier/services/delivery.py
@@ -159,4 +159,7 @@ class DeliveryService(Component):
         sale_obj = self.env[sale_service._expose_model]
         sale_domain = sale_service._get_base_search_domain()
         pickings = sale_obj.search(sale_domain).mapped("picking_ids")
+        pickings = pickings.filtered(
+            lambda p: p.picking_type_id.code == "outgoing"
+        )
         return [("id", "in", pickings.ids)]

--- a/shopinvader_delivery_carrier/tests/test_delivery_service.py
+++ b/shopinvader_delivery_carrier/tests/test_delivery_service.py
@@ -39,6 +39,8 @@ class TestDeliveryService(CommonCase):
             carrier_dict = current_data.get("carrier", {})
             sale_dict = current_data.get("sale", {})
             self.assertEquals(current_data.get("delivery_id"), picking.id)
+            # Ensure we have only outgoing picking
+            self.assertEquals(picking.picking_type_id.code, "outgoing")
             self.assertEquals(
                 current_data.get("tracking_reference"),
                 picking.carrier_tracking_ref or None,


### PR DESCRIPTION
Currently, if you have internal pickings related to a sale order, they are sent to the front side.
But only outgoing pickings should be sent to the front.