### PR TITLE
[10.0][ADD] shopinvader_delivery_carrier add sale info related to returned pickings

### DIFF
--- a/shopinvader_delivery_carrier/services/delivery.py
+++ b/shopinvader_delivery_carrier/services/delivery.py
@@ -54,9 +54,11 @@ class DeliveryService(Component):
                 "type": "dict",
                 "nullable": True,
                 "schema": {
+                    "sale_id": {"type": "integer"},
                     "state": {"type": "string"},
                     "amount_total": {"type": "float"},
                     "date_order": {"type": "string", "nullable": True},
+                    "name": {"type": "string", "nullable": True},
                 },
             },
         }
@@ -96,7 +98,13 @@ class DeliveryService(Component):
         Get the parser of sale.order
         :return: list
         """
-        to_parse = ["state", "amount_total", "date_order"]
+        to_parse = [
+            "id:sale_id",
+            "name",
+            "state",
+            "amount_total",
+            "date_order",
+        ]
         return to_parse
 
     def _add_sale_order_info(self, picking):

--- a/shopinvader_delivery_carrier/tests/test_delivery_service.py
+++ b/shopinvader_delivery_carrier/tests/test_delivery_service.py
@@ -61,6 +61,8 @@ class TestDeliveryService(CommonCase):
                 self.assertEquals(
                     sale_dict.get("date_order"), picking.sale_id.date_order
                 )
+                self.assertEquals(sale_dict.get("sale_id"), picking.sale_id.id)
+                self.assertEquals(sale_dict.get("name"), picking.sale_id.name)
             else:
                 self.assertFalse(sale_dict)
         return True


### PR DESCRIPTION
Currently, we just have few details about sales related to returned pickings (amount, state etc).
I just add the `sale_id` and the `name` (of related sale order) into `sale` json key, the let the front side make a link.