### PR TITLE
Invader backend: add `Export index settings` button

### DIFF
--- a/shopinvader_search_engine/models/shopinvader_backend.py
+++ b/shopinvader_search_engine/models/shopinvader_backend.py
@@ -38,7 +38,7 @@ class ShopinvaderBackend(models.Model):
         return True
 
     @api.multi
-    def add_misssing_index(self):
+    def add_missing_index(self):
         self.ensure_one()
         ir_models = self._get_default_models()
         index_obj = self.env["se.index"]

--- a/shopinvader_search_engine/models/shopinvader_backend.py
+++ b/shopinvader_search_engine/models/shopinvader_backend.py
@@ -66,3 +66,7 @@ class ShopinvaderBackend(models.Model):
     @api.multi
     def force_resynchronize_index(self):
         self.mapped("se_backend_id.index_ids").resynchronize_all_bindings()
+
+    @api.multi
+    def export_index_settings(self):
+        self.mapped("se_backend_id.index_ids").export_settings()

--- a/shopinvader_search_engine/views/shopinvader_backend_view.xml
+++ b/shopinvader_search_engine/views/shopinvader_backend_view.xml
@@ -48,7 +48,7 @@
                 </group>
                 <group colspan="4">
                     <button
-                            name="add_misssing_index"
+                            name="add_missing_index"
                             string="Add missing index"
                             type="object"/>
                 </group>

--- a/shopinvader_search_engine/views/shopinvader_backend_view.xml
+++ b/shopinvader_search_engine/views/shopinvader_backend_view.xml
@@ -42,6 +42,12 @@
                             You can also drop index but this will introduce downtime, so it's
                             better to force a resynchronization"/>
                     <button
+                            name="export_index_settings"
+                            string="Export index settings"
+                            help="Loop trough all the indexes and export their settings (filters, facets, etc).
+                                  This is mandatory if you have updated filters."
+                            type="object"/>
+                    <button
                             name="clear_index"
                             string="Clear"
                             type="object"/>


### PR DESCRIPTION
Right now if you want to export settings you have to run a cron manually on ALL indexes or clear the settings and export again everything.

~~Depends on https://github.com/OCA/search-engine/pull/41~~