### PR TITLE
Misc fixes

### DIFF
--- a/shopinvader/models/product_product.py
+++ b/shopinvader/models/product_product.py
@@ -74,3 +74,13 @@ class ProductProduct(models.Model):
                 lambda x: x.backend_id == backend
             )
         )
+
+    def _get_invader_variant(self, backend, lang):
+        """Retrieve invader variant by backend and language.
+
+        :param backend: backend recordset
+        :param lang: lang code
+        """
+        return self.shopinvader_bind_ids.filtered(
+            lambda x: x.backend_id == backend and x.lang_id.code == lang
+        )

--- a/shopinvader/models/sale.py
+++ b/shopinvader/models/sale.py
@@ -119,33 +119,7 @@ class SaleOrder(models.Model):
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    shopinvader_variant_id = fields.Many2one(
-        "shopinvader.variant",
-        compute="_compute_shopinvader_variant",
-        string="Shopinvader Variant",
-    )
-
     def reset_price_tax(self):
         for line in self:
             line.product_id_change()
             line._onchange_discount()
-
-    @api.depends("order_id.shopinvader_backend_id", "product_id")
-    def _compute_shopinvader_variant(self):
-        lang = self._context.get("lang")
-        if not lang:
-            _logger.warning(
-                "No lang specified for getting the shopinvader variant "
-                "take the first binding"
-            )
-        for record in self:
-            bindings = record.product_id.shopinvader_bind_ids
-            for binding in bindings:
-                if (
-                    binding.backend_id
-                    != record.order_id.shopinvader_backend_id
-                ):
-                    continue
-                if lang and binding.lang_id.code != lang:
-                    continue
-                record.shopinvader_variant_id = binding

--- a/shopinvader/services/abstract_sale.py
+++ b/shopinvader/services/abstract_sale.py
@@ -43,11 +43,13 @@ class AbstractSaleService(AbstractComponent):
         return True
 
     def _convert_one_line(self, line):
-        if line.shopinvader_variant_id:
+        variant = line.product_id._get_invader_variant(
+            self.shopinvader_backend,
+            self.env.context.get("lang", line.order_id.partner_id.lang),
+        )
+        if variant:
             # TODO we should reuse the parser of the index
-            product = line.shopinvader_variant_id.jsonify(
-                self._parser_product()
-            )[0]
+            product = variant.jsonify(self._parser_product())[0]
         else:
             product = {}
         return {

--- a/shopinvader/services/partner_mixin.py
+++ b/shopinvader/services/partner_mixin.py
@@ -84,6 +84,12 @@ class PartnerServiceMixin(AbstractComponent):
             return handler(partner, mode)
         return partner
 
+    def _notify_partner_recipient_address(self, partner, mode):
+        # notify on the owner of the address
+        # Safe default to given partner in case we are updating the profile
+        # which is done w/ the addresses endpoint anyway.
+        return partner.parent_id if partner.parent_id else partner
+
     def _notify_partner_type(self, partner, mode):
         handler = getattr(
             self, "_notify_partner_type_" + partner.address_type, None

--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -32,7 +32,7 @@ class BaseShopinvaderService(AbstractComponent):
         # In this way we can support multiple actors for the same profile.
         # TODO: check if there are place wher it's better to use
         # `partner_user` instead of `partner`.
-        return self.work.partner_user
+        return getattr(self.work, "partner_user", self.partner)
 
     @property
     def shopinvader_session(self):

--- a/shopinvader/tests/__init__.py
+++ b/shopinvader/tests/__init__.py
@@ -14,4 +14,5 @@ from . import test_shopinvader_variant_seo_title
 from . import test_res_partner
 from . import test_invoice
 from . import test_shopinvader_partner_binding
+from . import test_notification
 from . import test_salesman_notification

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -216,7 +216,6 @@ class AnonymousCartCase(CartCase, CartClearTest):
             "order_id": sale.id,
             "product_id": self.product_1.id,
             "product_uom_qty": 1,
-            "shopinvader_variant_id": self.product_1.shopinvader_bind_ids.id,
         }
         new_line_values = so_line_obj.play_onchanges(
             line_values, line_values.keys()

--- a/shopinvader/tests/test_cart_item.py
+++ b/shopinvader/tests/test_cart_item.py
@@ -190,7 +190,6 @@ class AnonymousItemCase(AbstractItemCase, CommonCase):
         super(AnonymousItemCase, cls).setUpClass()
         cls.partner = cls.backend.anonymous_partner_id
         cls.cart = cls.env.ref("shopinvader.sale_order_1")
-        cls.cart.order_line._compute_shopinvader_variant()
 
     def setUp(self, *args, **kwargs):
         super(AnonymousItemCase, self).setUp(*args, **kwargs)
@@ -211,7 +210,6 @@ class ConnectedItemCase(AbstractItemCase, CommonCase):
         super(ConnectedItemCase, cls).setUpClass()
         cls.partner = cls.env.ref("shopinvader.partner_1")
         cls.cart = cls.env.ref("shopinvader.sale_order_2")
-        cls.cart.order_line._compute_shopinvader_variant()
 
     def setUp(self, *args, **kwargs):
         super(ConnectedItemCase, self).setUp(*args, **kwargs)


### PR DESCRIPTION
The most important one is "Cart service: fix variant computation" https://github.com/shopinvader/odoo-shopinvader/commit/617032d72b0512cf5cadecf522f3b8be1d6b9996
because it prevents product info display on cart or services alike that rely on the computed field.

For it I used the same approach as per the wishlist w/ a method on the product https://github.com/shopinvader/odoo-shopinvader/pull/514/files#diff-f93a77a39626d65d2a01cc8d3ca1ff14R77