### PR TITLE
[10.0][FIX] shopinvader.partner force email in lower case

### DIFF
--- a/shopinvader/wizards/shopinvader_partner_binding_line.py
+++ b/shopinvader/wizards/shopinvader_partner_binding_line.py
@@ -55,7 +55,14 @@ class ShopinvaderPartnerBindingLine(models.TransientModel):
             )
             if not partner_binding:
                 bind_values = {"backend_id": backend.id}
-                record.partner_id.write(
-                    {"shopinvader_bind_ids": [(0, False, bind_values)]}
-                )
+                partner_values = {
+                    "shopinvader_bind_ids": [(0, False, bind_values)]
+                }
+                # Locomotive doesn't work with uppercase.
+                # And we have to do the write before the binding
+                email_lower = (record.partner_id.email or "").lower()
+                # Do the update only if necessary
+                if record.partner_id.email != email_lower:
+                    partner_values.update({"email": email_lower})
+                record.partner_id.write(partner_values)
         return {}


### PR DESCRIPTION
**Current issue:**
When an email is in upper case, we have a traceback related to the locomotive API during the manual binding (using dedicated wizard).

**How to reproduce:**
- Ensure your shopinvader backend is correctly linked to a locomotive;
- Go on a partner form view (not already binded to a backend);
- Put the email in upper case;
- Use the binding wizard;
- Booom!

**Fix:**
Just force the partner's email in lower case in case of binding.
Don't need a migration script (for existing binding) because if the email was in upper case, there is no binding due to this bug. So nothing to fix.