### PR TITLE
Fix currency and lang for customer update

### DIFF
--- a/shopinvader/services/address.py
+++ b/shopinvader/services/address.py
@@ -121,6 +121,7 @@ class AddressService(Component):
             "is_company": {"coerce": to_bool, "type": "boolean"},
             "opt_in": {"coerce": to_bool, "type": "boolean"},
             "opt_out": {"coerce": to_bool, "type": "boolean"},
+            "lang": {"type": "string", "required": False},
         }
         return res
 
@@ -156,6 +157,7 @@ class AddressService(Component):
             ("country_id:country", ["id", "name"]),
             "address_type",
             "is_company",
+            "lang",
             ("title", ["id", "name"]),
             "shopinvader_enabled:enabled",
             ("industry_id", ["id", "name"]),

--- a/shopinvader/services/customer.py
+++ b/shopinvader/services/customer.py
@@ -49,7 +49,6 @@ class CustomerService(Component):
                 "email": {"type": "string", "required": True},
                 "external_id": {"type": "string", "required": True},
                 "vat": {"type": "string", "required": False},
-                "lang": {"type": "string", "required": False},
                 "company_name": {"type": "string", "required": False},
                 "function": {"type": "string", "required": False},
             }

--- a/shopinvader_locomotive/views/shopinvader_backend_view.xml
+++ b/shopinvader_locomotive/views/shopinvader_backend_view.xml
@@ -47,7 +47,7 @@
                     name="currency_ids"
                     widget="many2many_tags"
                     colspan="2"
-                    groups="base.group_multi_currency"/>
+                    required="1" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
If you don't provide a currency the currency rate mapping is not updated
on store settings, hence the price won't be displayed properly and
you'll get only 0.0.

Also, is wrong to hide it for non `base.group_multi_currency` users
because your instance might not have any multi-currency need.

+++

As per #530 the `customer` service has no specific update endpoint hence the lang is ignored on updates.