### PR TITLE
[12.0] Customer/address service: add access info

### DIFF
--- a/shopinvader/components/__init__.py
+++ b/shopinvader/components/__init__.py
@@ -3,5 +3,6 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from . import core
+from . import access_info
 from . import partner_validator
 from . import product_product_event_listener

--- a/shopinvader/components/access_info.py
+++ b/shopinvader/components/access_info.py
@@ -1,0 +1,68 @@
+# Copyright 2019 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.component.core import Component
+
+
+class PartnerAccess(Component):
+    """Define access rules to partner from client side."""
+
+    _name = "shopinvader.partner.access"
+    _inherit = "base.shopinvader.component"
+    _usage = "access.info"
+    _apply_on = "res.partner"
+
+    @property
+    def service_work(self):
+        return getattr(self.work, "service_work", None)
+
+    @property
+    def partner(self):
+        return getattr(self.work, "partner", None)
+
+    @property
+    def partner_user(self):
+        return getattr(self.work, "partner_user", self.partner)
+
+    def is_main_partner(self):
+        return self.partner == self.partner_user
+
+    def is_owner(self, partner_id):
+        return partner_id == self.partner_user.id
+
+    def for_profile(self, partner_id):
+        info = {"read": True, "update": True, "delete": False}
+        if not self.is_main_partner() and partner_id != self.partner_user.id:
+            info["update"] = False
+        return info
+
+    def for_address(self, address_id):
+        info = {"read": True, "update": True, "delete": True}
+        if self.partner_user is not None:
+            if not self.is_main_partner():
+                if not self.is_owner(address_id):
+                    info.update(
+                        {"read": True, "update": False, "delete": False}
+                    )
+                else:
+                    # only main partner can delete your address
+                    info["delete"] = False
+        return info
+
+    def permission(self):
+        if self.partner is None:
+            return {"address": {}, "purchase": {}}
+        return {
+            # scope: permissions
+            "address": {
+                # can create addresses only if profile partner is enabled
+                "create": self.partner.shopinvader_enabled
+            },
+            "purchase": {
+                # can hit the button to add to cart
+                "add_to_cart": self.partner.shopinvader_enabled,
+                # can go on w/ checkout steps
+                "checkout": self.partner.shopinvader_enabled,
+            },
+        }

--- a/shopinvader/services/address.py
+++ b/shopinvader/services/address.py
@@ -23,7 +23,7 @@ class AddressService(Component):
     # The following method are 'public' and can be called from the controller.
 
     def get(self, _id):
-        return self._to_json(self._get(_id))
+        return self._to_address_info(_id)
 
     def search(self, **params):
         if not self.partner:
@@ -59,6 +59,9 @@ class AddressService(Component):
     # The following method are 'private' and should be never never NEVER call
     # from the controller.
     # All params are trusted as they have been checked before
+
+    def _to_address_info(self, _id):
+        return self._to_json(self._get(_id))
 
     # Validator
     def _validator_search(self):
@@ -163,7 +166,11 @@ class AddressService(Component):
         return res
 
     def _to_json(self, address):
-        return address.jsonify(self._json_parser())
+        data = address.jsonify(self._json_parser())
+        for item in data:
+            # access info on the current record partner record
+            item["access"] = self.access_info.for_address(item["id"])
+        return data
 
     def _prepare_params(self, params, mode="create"):
         for key in ["country", "state"]:

--- a/shopinvader/services/customer.py
+++ b/shopinvader/services/customer.py
@@ -104,6 +104,10 @@ class CustomerService(Component):
     def _to_customer_info(self, partner):
         address = self.component(usage="addresses")
         info = address._to_json(partner)[0]
+        # access info on the current record partner record
+        info["access"] = self.access_info.for_profile(partner.id)
+        # global permission for current partner user
+        info["permission"] = self.access_info.permission()
         return info
 
     def _prepare_create_response(self, binding):

--- a/shopinvader/services/partner_mixin.py
+++ b/shopinvader/services/partner_mixin.py
@@ -22,7 +22,10 @@ class PartnerServiceMixin(AbstractComponent):
     @property
     def access_info(self):
         with self.shopinvader_backend.work_on(
-            "res.partner", service_work=self.work
+            "res.partner",
+            partner=self.partner,
+            partner_user=self.partner_user,
+            service_work=self.work,
         ) as work:
             return work.component(usage="access.info")
 

--- a/shopinvader/tests/__init__.py
+++ b/shopinvader/tests/__init__.py
@@ -4,6 +4,7 @@ from . import test_cart
 from . import test_cart_item
 from . import test_address
 from . import test_partner_validation
+from . import test_partner_access_info
 from . import test_product
 from . import test_sale
 from . import test_shopinvader_variant_binding_wizard

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -26,6 +26,8 @@ class CommonMixin(ComponentMixin):
     @contextmanager
     def work_on_services(self, **params):
         params = params or {}
+        if params.get("partner") and not params.get("partner_user"):
+            params["partner_user"] = params["partner"]
         if "shopinvader_backend" not in params:
             params["shopinvader_backend"] = self.backend
         if "shopinvader_session" not in params:

--- a/shopinvader/tests/test_partner_access_info.py
+++ b/shopinvader/tests/test_partner_access_info.py
@@ -1,0 +1,109 @@
+# Copyright 2019 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from .common import CommonCase
+
+
+class TestPartnerAccessInfo(CommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestPartnerAccessInfo, cls).setUpClass()
+        cls.partner = cls.env.ref("shopinvader.partner_1")
+        cls.contact = cls.partner.create(
+            {
+                "name": "Just an address",
+                "type": "contact",
+                "parent_id": cls.partner.id,
+            }
+        )
+
+    def test_access_info_owner1(self):
+        with self.backend.work_on(
+            "res.partner", partner=self.partner, partner_user=self.partner
+        ) as work:
+            info = work.component(usage="access.info")
+
+        self.assertTrue(info.is_owner(self.partner.id))
+
+        # on my partner I can RU
+        self.assertEqual(
+            info.for_profile(self.partner.id),
+            {"read": True, "update": True, "delete": False},
+        )
+        # on my addresses I can RUD
+        self.assertEqual(
+            info.for_address(self.contact.id),
+            {"read": True, "update": True, "delete": True},
+        )
+
+    def test_access_info_owner2(self):
+        with self.backend.work_on(
+            "res.partner", partner=self.partner, partner_user=self.partner
+        ) as work:
+            info = work.component(usage="access.info")
+
+        self.assertTrue(info.is_owner(self.partner.id))
+
+        # partner is enabled, can do everything
+        self.partner.shopinvader_enabled = True
+        expected = {
+            "address": {"create": True},
+            "purchase": {"add_to_cart": True, "checkout": True},
+        }
+        self.assertEqual(info.permission(), expected)
+
+        # partner is disabled, can do nothing
+        self.partner.shopinvader_enabled = False
+        expected = {
+            "address": {"create": False},
+            "purchase": {"add_to_cart": False, "checkout": False},
+        }
+        self.assertEqual(info.permission(), expected)
+
+    def test_access_info_non_owner1(self):
+        with self.backend.work_on(
+            "res.partner", partner=self.partner, partner_user=self.contact
+        ) as work:
+            info = work.component(usage="access.info")
+
+        self.assertFalse(info.is_owner(self.partner.id))
+        self.assertTrue(info.is_owner(self.contact.id))
+
+        # on my partner I can R only
+        self.assertEqual(
+            info.for_profile(self.partner.id),
+            {"read": True, "update": False, "delete": False},
+        )
+        # on my addresses I can RU only
+        self.assertEqual(
+            info.for_address(self.contact.id),
+            {"read": True, "update": True, "delete": False},
+        )
+
+    def test_access_info_non_owner2(self):
+        with self.backend.work_on(
+            "res.partner", partner=self.partner, partner_user=self.contact
+        ) as work:
+            info = work.component(usage="access.info")
+
+        self.assertFalse(info.is_owner(self.partner.id))
+        self.assertTrue(info.is_owner(self.contact.id))
+
+        # no matter if the partner user is enabled
+        self.contact.shopinvader_enabled = True
+
+        # partner is enabled, can do everything
+        self.partner.shopinvader_enabled = True
+        expected = {
+            "address": {"create": True},
+            "purchase": {"add_to_cart": True, "checkout": True},
+        }
+        self.assertEqual(info.permission(), expected)
+
+        # partner is disabled, can do nothing
+        self.partner.shopinvader_enabled = False
+        expected = {
+            "address": {"create": False},
+            "purchase": {"add_to_cart": False, "checkout": False},
+        }
+        self.assertEqual(info.permission(), expected)


### PR DESCRIPTION
I extrapolated and modified a little bit the access info machinery added in #471 .

NOTE: w/out the change described here https://github.com/shopinvader/odoo-shopinvader/issues/530 this will be incomplete because customer access info will be wiped on update.