### PR TITLE
[10.0][IMP] Set a higher priority on the job to sent notification

### DIFF
--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -100,11 +100,6 @@ class ShopinvaderBackend(models.Model):
         "statistics reasons. A new cart is created automatically when the "
         "customer will add a new item.",
     )
-    authorize_not_binded_products = fields.Boolean(
-        help="Check this if you want to authorize cart to display products"
-        "that are not binded to this backend. This can be useful if"
-        "you want to modify existing carts from backend."
-    )
 
     _sql_constraints = [
         (
@@ -271,19 +266,6 @@ class ShopinvaderBackend(models.Model):
     def bind_all_category(self):
         self._bind_all_content("product.category", "shopinvader.category", [])
 
-    @api.multi
-    def _get_notification_job_priority(self):
-        """
-        Get the priority for notifications.
-        (cfr queue job doc: 0 is the maximum priority; 10 is the default one).
-        Set a higher priority because if we let the default priority and the
-        system has a lot of job to execute, some notification could come late
-        (like emails who contains payment information) and end-customer could
-        lose patience.
-        :return: int
-        """
-        return 2
-
     def _send_notification(self, notification, record):
         self.ensure_one()
         record.ensure_one()
@@ -298,11 +280,15 @@ class ShopinvaderBackend(models.Model):
             record._name,
             record.id,
         )
-        job_priority = self._get_notification_job_priority()
         for notif in notifs:
-            notif.with_delay(
-                description=description, priority=job_priority
-            ).send(record.id)
+            job_priority = notif.queue_job_priority
+            # If < 0 => Live notification
+            if job_priority < 0:
+                notif.send(record.id)
+            else:
+                notif.with_delay(
+                    description=description, priority=job_priority
+                ).send(record.id)
         return True
 
     def _extract_configuration(self):

--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -100,6 +100,11 @@ class ShopinvaderBackend(models.Model):
         "statistics reasons. A new cart is created automatically when the "
         "customer will add a new item.",
     )
+    authorize_not_binded_products = fields.Boolean(
+        help="Check this if you want to authorize cart to display products"
+        "that are not binded to this backend. This can be useful if"
+        "you want to modify existing carts from backend."
+    )
 
     _sql_constraints = [
         (
@@ -266,6 +271,19 @@ class ShopinvaderBackend(models.Model):
     def bind_all_category(self):
         self._bind_all_content("product.category", "shopinvader.category", [])
 
+    @api.multi
+    def _get_notification_job_priority(self):
+        """
+        Get the priority for notifications.
+        (cfr queue job doc: 0 is the maximum priority; 10 is the default one).
+        Set a higher priority because if we let the default priority and the
+        system has a lot of job to execute, some notification could come late
+        (like emails who contains payment information) and end-customer could
+        lose patience.
+        :return: int
+        """
+        return 2
+
     def _send_notification(self, notification, record):
         self.ensure_one()
         record.ensure_one()
@@ -280,8 +298,11 @@ class ShopinvaderBackend(models.Model):
             record._name,
             record.id,
         )
+        job_priority = self._get_notification_job_priority()
         for notif in notifs:
-            notif.with_delay(description=description).send(record.id)
+            notif.with_delay(
+                description=description, priority=job_priority
+            ).send(record.id)
         return True
 
     def _extract_configuration(self):

--- a/shopinvader/models/shopinvader_notification.py
+++ b/shopinvader/models/shopinvader_notification.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
-from odoo.addons.queue_job.job import job
+from odoo.addons.queue_job.job import DEFAULT_PRIORITY, job
 from odoo.tools.translate import _
 
 
@@ -59,6 +59,14 @@ class ShopinvaderNotification(models.Model):
     model_id = fields.Many2one("ir.model", "Model", required=True)
     template_id = fields.Many2one(
         "mail.template", "Mail Template", required=True
+    )
+    queue_job_priority = fields.Integer(
+        string="Priority",
+        default=DEFAULT_PRIORITY,
+        help="Determine the priority to execute the job who trigger the "
+        "notification.\n"
+        "0 being the higher priority. Default is 10 (cfr queue job).\n"
+        "You can set a negative value to have live notification",
     )
 
     @api.onchange("notification_type")

--- a/shopinvader/tests/__init__.py
+++ b/shopinvader/tests/__init__.py
@@ -15,3 +15,4 @@ from . import test_shopinvader_variant_seo_title
 from . import test_res_partner
 from . import test_invoice
 from . import test_shopinvader_partner_binding
+from . import test_notification

--- a/shopinvader/tests/test_notification.py
+++ b/shopinvader/tests/test_notification.py
@@ -10,6 +10,7 @@ class CommonNotificationCase(CommonCase):
     def setUp(self):
         super(CommonNotificationCase, self).setUp()
         self.cart = self.env.ref("shopinvader.sale_order_2")
+        self.expected_priority = self.backend._get_notification_job_priority()
 
     def _check_notification(self, notif_type, record):
         notif = self.env["shopinvader.notification"].search(
@@ -34,6 +35,7 @@ class NotificationCartCase(CommonNotificationCase):
         self._init_job_counter()
         self.cart.action_confirm_cart()
         self._check_nbr_job_created(1)
+        self.assertEquals(self.expected_priority, self.created_jobs.priority)
         self._perform_created_job()
         self._check_notification("cart_confirmation", self.cart)
 
@@ -42,6 +44,7 @@ class NotificationCartCase(CommonNotificationCase):
         self._init_job_counter()
         self.cart.action_confirm()
         self._check_nbr_job_created(1)
+        self.assertEquals(self.expected_priority, self.created_jobs.priority)
         self._perform_created_job()
         self._check_notification("sale_confirmation", self.cart)
 
@@ -54,6 +57,7 @@ class NotificationCartCase(CommonNotificationCase):
         self._init_job_counter()
         self.cart.invoice_ids.action_invoice_open()
         self._check_nbr_job_created(1)
+        self.assertEquals(self.expected_priority, self.created_jobs.priority)
         self._perform_created_job()
         self._check_notification("invoice_open", self.cart.invoice_ids[0])
 

--- a/shopinvader/tests/test_notification.py
+++ b/shopinvader/tests/test_notification.py
@@ -10,7 +10,6 @@ class CommonNotificationCase(CommonCase):
     def setUp(self):
         super(CommonNotificationCase, self).setUp()
         self.cart = self.env.ref("shopinvader.sale_order_2")
-        self.expected_priority = self.backend._get_notification_job_priority()
 
     def _check_notification(self, notif_type, record):
         notif = self.env["shopinvader.notification"].search(
@@ -29,22 +28,50 @@ class CommonNotificationCase(CommonCase):
         )
         self.assertEqual(len(message), 1)
 
+    def _check_job_priority(self, job, notif_type=False, force_priority=False):
+        """
+        Ensure the job priority is correct
+        :param job: queue.job recordset
+        :param notif_type: str
+        :param force_priority: int
+        :return: bool
+        """
+        if isinstance(force_priority, bool):
+            notification = self.env["shopinvader.notification"].search(
+                [
+                    ("backend_id", "=", self.backend.id),
+                    ("notification_type", "=", notif_type),
+                ],
+                limit=1,
+            )
+            priority = notification.queue_job_priority
+        else:
+            priority = force_priority
+        self.assertEquals(priority, job.priority)
+        return True
+
 
 class NotificationCartCase(CommonNotificationCase):
     def test_cart_notification(self):
         self._init_job_counter()
         self.cart.action_confirm_cart()
         self._check_nbr_job_created(1)
-        self.assertEquals(self.expected_priority, self.created_jobs.priority)
+        self._check_job_priority(self.created_jobs, "cart_confirmation")
         self._perform_created_job()
         self._check_notification("cart_confirmation", self.cart)
 
     def test_sale_notification(self):
+        priority = 30
+        self.env["shopinvader.notification"].search([]).write(
+            {"queue_job_priority": priority}
+        )
         self.cart.action_confirm_cart()
         self._init_job_counter()
         self.cart.action_confirm()
         self._check_nbr_job_created(1)
-        self.assertEquals(self.expected_priority, self.created_jobs.priority)
+        self._check_job_priority(
+            self.created_jobs, "sale_confirmation", force_priority=priority
+        )
         self._perform_created_job()
         self._check_notification("sale_confirmation", self.cart)
 
@@ -57,7 +84,7 @@ class NotificationCartCase(CommonNotificationCase):
         self._init_job_counter()
         self.cart.invoice_ids.action_invoice_open()
         self._check_nbr_job_created(1)
-        self.assertEquals(self.expected_priority, self.created_jobs.priority)
+        self._check_job_priority(self.created_jobs, "invoice_open")
         self._perform_created_job()
         self._check_notification("invoice_open", self.cart.invoice_ids[0])
 

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -95,6 +95,7 @@
                                         <field name="model_id"/>
                                         <field name="template_id"
                                                domain="[('model_id', '=', model_id)]"/>
+                                        <field name="queue_job_priority"/>
                                     </tree>
                                 </field>
                             </group>


### PR DESCRIPTION
Because in some case, the notification/email contains payment information and end-customer could lose patience

Tests on notifications were disabled (not into `__init__.py`) so I re-add it.