### PR TITLE
[10.0][FIX] shopinvader_sale_profile: Export default role if no profile

### DIFF
--- a/shopinvader_sale_profile/components/__init__.py
+++ b/shopinvader_sale_profile/components/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import shopinvader_partner_export_mapper
+from . import shopinvader_sale_profile_listener

--- a/shopinvader_sale_profile/components/shopinvader_partner_export_mapper.py
+++ b/shopinvader_sale_profile/components/shopinvader_partner_export_mapper.py
@@ -11,5 +11,7 @@ class ShopinvaderPartnerExportMapper(Component):
     _inherit = "shopinvader.partner.export.mapper"
 
     @mapping
-    def sale_profile(self, record):
+    def role(self, record):
+        if not record.backend_id.use_sale_profile:
+            return super(ShopinvaderPartnerExportMapper, self).role(record)
         return {"role": record.sale_profile_id.code}

--- a/shopinvader_sale_profile/components/shopinvader_sale_profile_listener.py
+++ b/shopinvader_sale_profile/components/shopinvader_sale_profile_listener.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.component.core import Component
+
+
+class ShopinvaderRecordListener(Component):
+
+    _inherit = "shopinvader.record.event.listener"
+
+    _apply_on = ["res.partner"]
+
+    def _get_fields_to_export(self):
+        """
+        We need to extend the trigger fields to update partner role
+        TODO: As this is not perfect - it does not trigger when
+              shopinvader.partner model or backend is modified
+        :return: list
+        """
+        res = super(ShopinvaderRecordListener, self)._get_fields_to_export()
+        res.extend(["vat", "property_product_pricelist", "country_id"])
+        return res

--- a/shopinvader_sale_profile/tests/__init__.py
+++ b/shopinvader_sale_profile/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 from . import test_shopinvader_sale_profile
 from . import test_customer_service
+from . import test_shopinvader_partner
 from . import test_shopinvader_variant

--- a/shopinvader_sale_profile/tests/test_shopinvader_partner.py
+++ b/shopinvader_sale_profile/tests/test_shopinvader_partner.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com).
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+
+from odoo.addons.shopinvader_locomotive.tests.test_shopinvader_partner import (
+    CommonShopinvaderPartner,
+)
+
+_logger = logging.getLogger(__name__)
+
+# pylint: disable=W7936
+try:
+    import requests_mock
+except (ImportError, IOError) as err:
+    _logger.debug(err)
+
+
+class TestShopinvaderPartner(CommonShopinvaderPartner):
+    def setUp(self):
+        super(TestShopinvaderPartner, self).setUp()
+
+    def _get_shopinvader_partner(self, shopinvader_partner, external_id):
+        with requests_mock.mock() as m:
+            m.post(
+                self.base_url + "/tokens.json", json={"token": u"744cfcfb3cd3"}
+            )
+            # Request to modify / fake json arg
+            res = m.put(
+                self.base_url
+                + "/content_types/customers/entries/"
+                + external_id,
+                json={"test": 1},
+            )
+            self._perform_created_job()
+            return shopinvader_partner, res.request_history[0].json()
+
+    def test_profile_create_shopinvader_partner_from_odoo(self):
+
+        shop_partner, params = self._create_shopinvader_partner(
+            self.data, u"5a953d6aae1c744cfcfb3cd3"
+        )
+        role = params.get("content_entry").get("role")
+        self.assertEquals("default", role)
+        # Use Sale profile from now
+        self._init_job_counter()
+        self.backend.pricelist_id = False
+        self.backend.use_sale_profile = True
+        # Used to restart export job
+        shop_partner.record_id.write({"vat": "BE0477472701"})
+        self._check_nbr_job_created(1)
+        partner, params = self._get_shopinvader_partner(
+            shop_partner, u"5a953d6aae1c744cfcfb3cd3"
+        )
+        role = params.get("content_entry").get("role")
+        self.assertEquals("public_tax_inc", role)


### PR DESCRIPTION
If we install shopinvader_sale_profile without activating sale profiles and
creating partners, they are exported with a role == false. This fixes it.