### PR TITLE
[10.0][IMP] shopinvader: Allow to copy a previous sale

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,4 +6,4 @@ force_grid_wrap=0
 combine_as_imports=True
 use_parentheses=True
 line_length=79
-known_third_party = StringIO,mock,odoo,openupgradelib,psycopg2,requests,setuptools,urllib2,urlparse,vcr,vcr_unittest,werkzeug
+known_third_party = StringIO,cerberus,mock,odoo,openupgradelib,psycopg2,requests,setuptools,urllib2,urlparse,vcr,vcr_unittest,werkzeug

--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -3,9 +3,9 @@
 # Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 # pylint: disable=consider-merging-classes-inherited
-
 import logging
 
+from cerberus import Validator
 from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
 from odoo.exceptions import UserError
@@ -68,7 +68,85 @@ class CartService(Component):
         cart = self._clear_cart(cart)
         return self._to_json(cart)
 
+    def _get_validator_cart_by_id_domain(self, value):
+        """
+        Get cart by id domain. Limiting to session partner.
+        :param value:
+        :return:
+        """
+        return [("partner_id", "=", self.partner.id), ("id", "=", value)]
+
+    def _get_line_copy_vals(self, line):
+        """
+        Prepare copy values to be passed to _add_item
+        :param line: sale.order.line
+        :return: dict
+        """
+        return {
+            "product_id": line.product_id.id,
+            "item_qty": line.product_uom_qty,
+        }
+
+    def _get_lines_to_copy(self, cart):
+        return cart.order_line
+
+    # pylint: disable=W8102,W8106
+    def copy(self, **params):
+        """
+        This service allows
+        :param params:
+        :return:
+        """
+        return self._copy(**params)
+
+    def _copy(self, **params):
+        """
+        Copy the cart given by id without the lines
+        They will be re-added
+        :return: dict/json
+        """
+        cart = self.env["sale.order"].search(
+            self._get_validator_cart_by_id_domain(params.get("id"))
+        )
+        # Copy the existing cart
+        # Delete all lines and re-add them with 'shopinvader' flavour
+        new_cart = cart.copy({"order_line": False, "typology": "cart"})
+        for line in self._get_lines_to_copy(cart):
+            vals = self._get_line_copy_vals(line)
+            self._add_item(new_cart, vals)
+
+        return self._to_json(new_cart)
+
     # Validator
+    def _cart_validator_exists(self, field, value, error):
+        """
+        Implements 'check_with' validation
+        :param field:
+        :param value:
+        :param error:
+        :return:
+        """
+        cart = self.env["sale.order"].search(
+            self._get_validator_cart_by_id_domain(value)
+        )
+        if len(cart) != 1:
+            error(
+                field, _("The cart does not exists or does not belong to you!")
+            )
+
+    def _validator_copy(self):
+        return {
+            "id": {
+                "coerce": to_int,
+                "required": True,
+                "type": "integer",
+                "check_with": self._cart_validator_exists,
+            }
+        }
+
+    def _validator_return_copy(self):
+        return Validator({}, allow_unknown=True)
+
     def _validator_search(self):
         return {}
 

--- a/shopinvader/tests/__init__.py
+++ b/shopinvader/tests/__init__.py
@@ -3,6 +3,7 @@
 from . import test_controller
 from . import test_backend
 from . import test_cart
+from . import test_cart_copy
 from . import test_cart_item
 from . import test_address
 from . import test_product

--- a/shopinvader/tests/test_cart_copy.py
+++ b/shopinvader/tests/test_cart_copy.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.exceptions import UserError
+
+from .test_cart import CommonConnectedCartCase
+
+
+class TestCartCopy(CommonConnectedCartCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestCartCopy, cls).setUpClass()
+        cls.product_copy = cls.env.ref("product.product_product_24")
+        cls.product_copy.list_price = 500.0
+
+    def test_cart_copy(self):
+        # Copy existing cart
+        # Check if we return a new one with new values
+        result = self.service.dispatch("copy", params={"id": self.cart.id})
+        cart_data = result.get("data")
+        new_id = cart_data.get("id")
+        self.assertNotEquals(new_id, self.cart.id)
+        copy_cart = self.env["sale.order"].browse(new_id)
+        self.assertEquals("cart", copy_cart.typology)
+        line = copy_cart.order_line.filtered(
+            lambda l: l.product_id == self.product_copy
+        )
+        self.assertEquals(500.0, line.price_unit)
+
+    def test_cart_copy_does_not_exist(self):
+        cart_id = self.cart.id
+        self.cart.unlink()
+        # Check validator
+        with self.assertRaises(UserError):
+            self.service.dispatch("copy", params={"id": cart_id})

--- a/shopinvader_delivery_carrier/services/cart.py
+++ b/shopinvader_delivery_carrier/services/cart.py
@@ -123,3 +123,12 @@ class CartService(Component):
     def _unset_carrier(self, cart):
         cart.write({"carrier_id": False})
         cart._delivery_unset()
+
+    def _get_lines_to_copy(self, cart):
+        """
+        Don't copy delivery lines
+        :param cart:
+        :return:
+        """
+        res = super(CartService, self)._get_lines_to_copy(cart)
+        return res.filtered(lambda l: not l.is_delivery)


### PR DESCRIPTION
This allows to copy a previous confirmed cart to a new one.
If there is an existing cart, it will be replaced.