### PR TITLE
[10.0][FIX] shopinvader: Shopinvader Manager inherits from queue manager

### DIFF
--- a/shopinvader/migrations/10.0.2.7.1/post-migrate.py
+++ b/shopinvader/migrations/10.0.2.7.1/post-migrate.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    """Group Queue Job Manager should be updated"""
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    job_manager = env.ref("queue_job.group_queue_job_manager")
+    shop_manager = env.ref("shopinvader.group_shopinvader_manager")
+    job_manager.implied_ids -= shop_manager

--- a/shopinvader/security/shopinvader_security.xml
+++ b/shopinvader/security/shopinvader_security.xml
@@ -10,10 +10,7 @@
         <field name="name">Shopinvader Manager</field>
         <field name="category_id" ref="module_category_shopinvader"/>
         <field name="users" eval="[(4, ref('base.user_root'))]"/>
-    </record>
-
-    <record id="queue_job.group_queue_job_manager" model="res.groups">
-        <field name="implied_ids" eval="[(4, ref('group_shopinvader_manager'))]"/>
+        <field name="implied_ids" eval="[(4, ref('queue_job.group_queue_job_manager'))]"/>
     </record>
 
 </odoo>


### PR DESCRIPTION
The implied group was inversed.

Shopinvader manager must inherits from queue job manager, not the inverse.