### PR TITLE
[10.0][FIX] shopinvader_promotion_rule fix promotions applied

### DIFF
--- a/shopinvader_promotion_rule/__init__.py
+++ b/shopinvader_promotion_rule/__init__.py
@@ -1,1 +1,2 @@
+from . import models
 from . import services

--- a/shopinvader_promotion_rule/models/__init__.py
+++ b/shopinvader_promotion_rule/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import sale_order

--- a/shopinvader_promotion_rule/models/sale_order.py
+++ b/shopinvader_promotion_rule/models/sale_order.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.multi
+    def reset_price_tax(self):
+        """
+        Inherit to apply the promotion rules when prices are updated
+        :return:
+        """
+        result = super(SaleOrder, self).reset_price_tax()
+        if self.has_promotion_rules:
+            self.apply_promotions()
+        return result


### PR DESCRIPTION
When the function `write_with_onchange(...)` is called, promotions are completely ignored (so prices doesn't include discounts etc).
It's an issue when an anonymous user create an account and the fiscal position is updated (so when `reset_price_tax()` is called (cfr shopinvader module)).

So the fix is just to call the apply_promotions() when we call `reset_price_tax()`.