### PR TITLE
[10.0] shopinvader.partner: switch to ondelete=restrict

### DIFF
--- a/shopinvader/models/shopinvader_partner.py
+++ b/shopinvader/models/shopinvader_partner.py
@@ -14,7 +14,7 @@ class ShopinvaderPartner(models.Model):
     _inherits = {"res.partner": "record_id"}
 
     record_id = fields.Many2one(
-        "res.partner", required=True, ondelete="cascade"
+        "res.partner", required=True, ondelete="restrict"
     )
     partner_email = fields.Char(
         related="record_id.email", readonly=True, required=True, store=True


### PR DESCRIPTION
I propose to switch the link between res.partner and shopinvader.partner to ondelete='restrict' instead of 'cascade', to avoid the situation where someone deletes a partner that has an account on shopinvader without being conscious of it.