### PR TITLE
[10.0][IMP][ADD] shopinvader - Document generate/download (pdf)

### DIFF
--- a/shopinvader/controllers/main.py
+++ b/shopinvader/controllers/main.py
@@ -19,11 +19,11 @@ class InvaderController(main.RestController):
     _collection_name = "shopinvader.backend"
     _default_auth = "api_key"
 
-    @route(["/shopinvader/invoice/<int:_id>/download"], methods=["GET"])
-    def invoice_download(self, _id=None, **params):
+    @route(["/shopinvader/<service>/<int:_id>/download"], methods=["GET"])
+    def service_download(self, service, _id=None, **params):
         params["id"] = _id
         return self._process_method(
-            "invoice", "download", _id=_id, params=params
+            service, "download", _id=_id, params=params
         )
 
     @classmethod

--- a/shopinvader/services/__init__.py
+++ b/shopinvader/services/__init__.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import service
+from . import abstract_download
 from . import abstract_mail
 from . import abstract_sale
 from . import cart

--- a/shopinvader/services/abstract_download.py
+++ b/shopinvader/services/abstract_download.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import mimetypes
+
+from odoo import _
+from odoo.addons.base_rest.components.service import (
+    skip_secure_response,
+    to_int,
+)
+from odoo.addons.component.core import AbstractComponent
+from odoo.exceptions import MissingError
+from odoo.http import content_disposition, request
+
+
+class AbstractDownload(AbstractComponent):
+    """
+    Class used to define behaviour to generate and download a document.
+    You only have to inherit this AbstractComponent and implement the function
+    _get_report_action(...).
+
+    Example for invoice service:
+    Class InvoiceService(Component):
+        _inherit = [
+            "base.shopinvader.service",
+            "abstract.shopinvader.download",
+        ]
+        _name = "shopinvader.invoice.service"
+
+        def _get_report_action(self, target, params):
+            return target.invoice_print()
+    """
+
+    _name = "abstract.shopinvader.download"
+
+    # This function should be overwritten
+    def _get_report_action(self, target, params=None):
+        """
+        Get the action/dict to generate the report
+        :param target: recordset
+        :param params: dict
+        :return: dict/action
+        """
+        raise NotImplementedError()
+
+    def _validator_download(self):
+        """
+        Validate the input of download function
+        :return: dict
+        """
+        return {"id": {"type": "integer", "required": True, "coerce": to_int}}
+
+    @skip_secure_response
+    def download(self, _id, **params):
+        """
+        Get target file. This method is also callable by HTTP GET
+        """
+        params = params or {}
+        target = self._get(_id)
+        headers, content = self._get_binary_content(target, params=params)
+        if not content:
+            raise MissingError(_("No content found for %s") % _id)
+        response = request.make_response(content, headers)
+        response.status_code = 200
+        return response
+
+    def _get_binary_content(self, target, params=None):
+        """
+        Generate the report for the given target
+        :param target:
+        :param params: dict
+        :returns: (headers, content)
+        """
+        # Ensure the report is generated
+        target_report_def = self._get_report_action(target, params=params)
+        report_name = target_report_def.get("report_name")
+        report_type = target_report_def.get("report_type")
+        content, file_format = self.env["ir.actions.report.xml"].render_report(
+            res_ids=target.ids,
+            name=report_name,
+            data={"report_type": report_type},
+        )
+        report = self._get_report(report_name, report_type, params=params)
+        filename = self._get_binary_content_filename(
+            target, report, file_format, params=params
+        )
+        mimetype = mimetypes.guess_type(filename)
+        if mimetype:
+            mimetype = mimetype[0]
+        headers = [
+            ("Content-Type", mimetype),
+            ("X-Content-Type-Options", "nosniff"),
+            ("Content-Disposition", content_disposition(filename)),
+            ("Content-Length", len(content)),
+        ]
+        return headers, content
+
+    def _get_report(self, report_name, report_type, params=None):
+        """
+        Load the report recordset
+        :param report_name: str
+        :param report_type: str
+        :param params: dict
+        :return: ir.actions.report.xml recordset
+        """
+        domain = [
+            ("report_type", "=", report_type),
+            ("report_name", "=", report_name),
+        ]
+        return self.env["ir.actions.report.xml"].search(domain, limit=1)
+
+    def _get_binary_content_filename(
+        self, target, report, format, params=None
+    ):
+        """
+        Build the filename
+        :param target: recordset
+        :param report: ir.actions.report.xml recordset
+        :param format: str
+        :param params: dict
+        :return: str
+        """
+        return "{}.{}".format(report.name, format)

--- a/shopinvader/services/invoice.py
+++ b/shopinvader/services/invoice.py
@@ -1,21 +1,12 @@
 # -*- coding: utf-8 -*-
 # Copyright 2019 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-import mimetypes
-
-from odoo import _
-from odoo.addons.base_rest.components.service import (
-    skip_secure_response,
-    to_int,
-)
 from odoo.addons.component.core import Component
-from odoo.exceptions import MissingError
-from odoo.http import content_disposition, request
 from odoo.osv import expression
 
 
 class InvoiceService(Component):
-    _inherit = "base.shopinvader.service"
+    _inherit = ["base.shopinvader.service", "abstract.shopinvader.download"]
     _name = "shopinvader.invoice.service"
     _usage = "invoice"
     _expose_model = "account.invoice"
@@ -23,19 +14,6 @@ class InvoiceService(Component):
 
     # The following method are 'public' and can be called from the controller.
     # All params are untrusted so please check it !
-
-    @skip_secure_response
-    def download(self, _id, **params):
-        """
-        Get invoice file. This method is also callable by HTTP GET
-        """
-        invoice = self._get(_id)
-        headers, content = self._get_binary_content(invoice)
-        if not content:
-            raise MissingError(_("No content found for invoice %s") % _id)
-        response = request.make_response(content, headers)
-        response.status_code = 200
-        return response
 
     def to_openapi(self):
         res = super(InvoiceService, self).to_openapi()
@@ -61,12 +39,14 @@ class InvoiceService(Component):
         }
         return res
 
-    # Validator
-
-    def _validator_download(self):
-        return {"id": {"type": "integer", "required": True, "coerce": to_int}}
-
     # Private implementation
+
+    def _get_allowed_invoice_states(self):
+        """
+        Get every invoice states allowed to return on the service.
+        :return: list of str
+        """
+        return ["paid"]
 
     def _get_base_search_domain(self):
         """
@@ -93,46 +73,15 @@ class InvoiceService(Component):
         # and check if the invoice_id is into the list of sale.invoice_ids
         sales = self.env["sale.order"].search(so_domain)
         invoice_ids = sales.mapped("invoice_ids").ids
+        states = self._get_allowed_invoice_states()
         return expression.normalize_domain(
-            [("id", "in", invoice_ids), ("state", "=", "paid")]
+            [("id", "in", invoice_ids), ("state", "in", states)]
         )
 
-    def _get_binary_content(self, invoice):
+    def _get_report_action(self, target, params=None):
         """
-        Generate the invoice report....
-        :param invoice:
-          :returns: (headers, content)
+        Get the action/dict to generate the report
+        :param target: recordset
+        :return: dict/action
         """
-        # ensure the report is generated
-        invoice_report_def = invoice.invoice_print()
-        report_name = invoice_report_def["report_name"]
-        report_type = invoice_report_def["report_type"]
-        content, file_format = self.env["ir.actions.report.xml"].render_report(
-            res_ids=invoice.ids,
-            name=report_name,
-            data={"report_type": report_type},
-        )
-        report = self._get_report(report_name, report_type)
-        filename = self._get_binary_content_filename(
-            invoice, report, file_format
-        )
-        mimetype = mimetypes.guess_type(filename)
-        if mimetype:
-            mimetype = mimetype[0]
-        headers = [
-            ("Content-Type", mimetype),
-            ("X-Content-Type-Options", "nosniff"),
-            ("Content-Disposition", content_disposition(filename)),
-            ("Content-Length", len(content)),
-        ]
-        return headers, content
-
-    def _get_report(self, report_name, report_type):
-        domain = [
-            ("report_type", "=", report_type),
-            ("report_name", "=", report_name),
-        ]
-        return self.env["ir.actions.report.xml"].search(domain)
-
-    def _get_binary_content_filename(self, invoice, report, file_format):
-        return "{}.{}".format(report.name, file_format)
+        return target.invoice_print()

--- a/shopinvader/services/sale.py
+++ b/shopinvader/services/sale.py
@@ -2,14 +2,16 @@
 # Copyright 2017 Akretion (http://www.akretion.com).
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
 from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
 from odoo.osv import expression
 
 
 class SaleService(Component):
-    _inherit = "shopinvader.abstract.sale.service"
+    _inherit = [
+        "shopinvader.abstract.sale.service",
+        "abstract.shopinvader.download",
+    ]
     _name = "shopinvader.sale.service"
     _usage = "sales"
     _expose_model = "sale.order"
@@ -23,6 +25,15 @@ class SaleService(Component):
 
     def search(self, **params):
         return self._paginate_search(**params)
+
+    def _get_report_action(self, target, params=None):
+        """
+        Get the action/dict to generate the report
+        :param target: recordset
+        :param params: dict
+        :return: dict/action
+        """
+        return target.print_quotation()
 
     def ask_email_invoice(self, _id):
         """

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -5,12 +5,14 @@
 # pylint: disable=method-required-super
 from contextlib import contextmanager
 
+import mock
 from odoo.addons.base_rest.controllers.main import _PseudoCollection
 from odoo.addons.base_rest.tests.common import BaseRestCase
 from odoo.addons.component.core import WorkContext
 from odoo.addons.component.tests.common import ComponentMixin
 from odoo.addons.queue_job.job import Job
 from odoo.addons.server_environment import serv_config
+from odoo.exceptions import MissingError
 from odoo.tests import SavepointCase
 
 from .. import shopinvader_response
@@ -121,3 +123,70 @@ class ShopinvaderRestCase(BaseRestCase):
             serv_config.set(self.auth_api_key_name2, "user", "admin")
             serv_config.set(self.auth_api_key_name2, "key", self.api_key2)
         self.backend.auth_api_key_name = self.auth_api_key_name2
+
+
+class CommonTestDownload(object):
+    """
+    Dedicated class to test the download service.
+    Into your test class, just inherit this one (python mode) and call
+    correct function.
+    """
+
+    def _test_download_not_allowed(self, service, target):
+        """
+        Data
+            * A target into an invalid/not allowed state
+        Case:
+            * Try to download the document
+        Expected result:
+            * MissingError should be raised
+        :param service: shopinvader service
+        :param target: recordset
+        :return:
+        """
+        with self.assertRaises(MissingError):
+            service.download(target.id)
+
+    def _test_download_allowed(self, service, target):
+        """
+        Data
+            * A target with a valid state
+        Case:
+            * Try to download the document
+        Expected result:
+            * An http response with the file to download
+        :param service: shopinvader service
+        :param target: recordset
+        :return:
+        """
+        with mock.patch(
+            "odoo.addons.shopinvader.services."
+            "abstract_download.content_disposition"
+        ) as mocked_cd, mock.patch(
+            "odoo.addons.shopinvader.services.abstract_download.request"
+        ) as mocked_request:
+            mocked_cd.return_value = "attachment; filename=test"
+            make_response = mock.MagicMock()
+            mocked_request.make_response = make_response
+            service.download(target.id)
+            self.assertEqual(1, make_response.call_count)
+            content, headers = make_response.call_args[0]
+            self.assertTrue(content)
+            self.assertIn(
+                ("Content-Disposition", "attachment; filename=test"), headers
+            )
+
+    def _test_download_not_owner(self, service, target):
+        """
+        Data
+            * A target into a valid state but doesn't belong to the connected
+            user (from the service).
+        Case:
+            * Try to download the document
+        Expected result:
+            * MissingError should be raised
+        :param service: shopinvader service
+        :param target: recordset
+        :return:
+        """
+        self._test_download_not_allowed(service, target)

--- a/shopinvader/tests/test_invoice.py
+++ b/shopinvader/tests/test_invoice.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 # Copyright 2019 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-import mock
 from odoo import fields
-from odoo.exceptions import MissingError
 
-from .common import CommonCase
+from .common import CommonCase, CommonTestDownload
 
 
-class TestInvoice(CommonCase):
+class TestInvoice(CommonCase, CommonTestDownload):
     def setUp(self, *args, **kwargs):
         super(TestInvoice, self).setUp(*args, **kwargs)
         self.register_payments_obj = self.env["account.register.payments"]
@@ -62,8 +60,7 @@ class TestInvoice(CommonCase):
         Expected result:
             * MissingError should be raised
         """
-        with self.assertRaises(MissingError):
-            self.invoice_service.download(self.invoice.id)
+        self._test_download_not_allowed(self.invoice_service, self.invoice)
 
     def test_02(self):
         """
@@ -75,21 +72,7 @@ class TestInvoice(CommonCase):
             * An http response with the file to download
         """
         self._make_payment(self.invoice)
-        with mock.patch(
-            "openerp.addons.shopinvader.services.invoice.content_disposition"
-        ) as mocked_cd, mock.patch(
-            "openerp.addons.shopinvader.services.invoice.request"
-        ) as mocked_request:
-            mocked_cd.return_value = "attachment; filename=test"
-            make_response = mock.MagicMock()
-            mocked_request.make_response = make_response
-            self.invoice_service.download(self.invoice.id)
-            self.assertEqual(1, make_response.call_count)
-            content, headers = make_response.call_args[0]
-            self.assertTrue(content)
-            self.assertIn(
-                ("Content-Disposition", "attachment; filename=test"), headers
-            )
+        self._test_download_allowed(self.invoice_service, self.invoice)
 
     def test_03(self):
         """
@@ -106,5 +89,4 @@ class TestInvoice(CommonCase):
         self.assertNotEqual(sale.partner_id, self.partner)
         invoice = self._confirm_and_invoice_sale(sale)
         self._make_payment(invoice)
-        with self.assertRaises(MissingError):
-            self.invoice_service.download(invoice.id)
+        self._test_download_not_owner(self.invoice_service, self.invoice)

--- a/shopinvader/tests/test_sale.py
+++ b/shopinvader/tests/test_sale.py
@@ -6,10 +6,10 @@
 from odoo import fields
 from odoo.exceptions import MissingError
 
-from .common import CommonCase
+from .common import CommonCase, CommonTestDownload
 
 
-class SaleCase(CommonCase):
+class SaleCase(CommonCase, CommonTestDownload):
     def setUp(self, *args, **kwargs):
         super(SaleCase, self).setUp(*args, **kwargs)
         self.sale = self.env.ref("shopinvader.sale_order_2")
@@ -148,3 +148,41 @@ class SaleCase(CommonCase):
                 }
             ],
         )
+
+    def test_download01(self):
+        """
+        Data
+            * A draft sale order
+        Case:
+            * Try to download the document
+        Expected result:
+            * MissingError should be raised
+        """
+        self._test_download_not_allowed(self.service, self.sale)
+
+    def test_download02(self):
+        """
+        Data
+            * A confirmed sale order
+        Case:
+            * Try to download the document
+        Expected result:
+            * An http response with the file to download
+        """
+        self.sale.action_confirm_cart()
+        self._test_download_allowed(self.service, self.sale)
+
+    def test_download03(self):
+        """
+        Data
+            * A confirmed sale order but not for the current customer
+        Case:
+            * Try to download the document
+        Expected result:
+            * MissingError should be raised
+        """
+        sale = self.env.ref("sale.sale_order_1")
+        sale.action_confirm_cart()
+        sale.shopinvader_backend_id = self.backend
+        self.assertNotEqual(sale.partner_id, self.service.partner)
+        self._test_download_not_owner(self.service, sale)


### PR DESCRIPTION
Add possibility to download the sale order (pdf).
As the behavior is similar to invoice, it's better to extract the code and re-use it.

- Extract the download part of invoice service;
- Create an abstract component;
- Apply it on invoice service;
- Apply it on sale service;
- Extract tests about download (and make a new class);
- Apply this test class on invoice + sale tests.