### PR TITLE
[10.0][IMP] shopinvader: Improve add item service

### DIFF
--- a/shopinvader/models/sale.py
+++ b/shopinvader/models/sale.py
@@ -51,6 +51,17 @@ class SaleOrder(models.Model):
         "to be recomputed du to a modification (asynchronous)"
     )
 
+    def _shopinvader_fields_recompute(self):
+        """
+        Call recompute_todo to build the list of fields to recompute
+        TODO: Limit the real changed fields and built the job identity_key
+            with them to ensure we forget no field
+        :return:
+        """
+        for name, field in self._fields.iteritems():
+            if field.compute and field.store:
+                self._recompute_todo(field)
+
     @job(default_channel="root.shopinvader")
     def _shopinvader_delayed_recompute(self):
         self.shopinvader_recompute()
@@ -59,6 +70,7 @@ class SaleOrder(models.Model):
     def shopinvader_recompute(self):
         self.ensure_one()
         if self.shopinvader_to_be_recomputed:
+            self._shopinvader_fields_recompute()
             self.recompute()
             self.shopinvader_to_be_recomputed = False
 

--- a/shopinvader/models/sale.py
+++ b/shopinvader/models/sale.py
@@ -48,7 +48,7 @@ class SaleOrder(models.Model):
     )
     shopinvader_to_be_recomputed = fields.Boolean(
         help="Technical field that will intend to check if the sale order has"
-        "to be recomputed du to a modification (asynchronous)"
+        "to be recomputed due to a modification (asynchronous)"
     )
 
     def _shopinvader_fields_recompute(self):

--- a/shopinvader/models/sale.py
+++ b/shopinvader/models/sale.py
@@ -67,12 +67,21 @@ class SaleOrder(models.Model):
         self.shopinvader_recompute()
 
     @api.multi
+    def _shopinvader_recompute(self):
+        """
+        Method called if shopinvader_to_be_recomputed is True
+        Can be inherited
+        :return:
+        """
+        self._shopinvader_fields_recompute()
+        self.recompute()
+        self.shopinvader_to_be_recomputed = False
+
+    @api.multi
     def shopinvader_recompute(self):
         self.ensure_one()
         if self.shopinvader_to_be_recomputed:
-            self._shopinvader_fields_recompute()
-            self.recompute()
-            self.shopinvader_to_be_recomputed = False
+            self._shopinvader_recompute()
 
     def _get_shopinvader_state(self):
         self.ensure_one()

--- a/shopinvader/models/sale.py
+++ b/shopinvader/models/sale.py
@@ -46,10 +46,21 @@ class SaleOrder(models.Model):
         compute="_compute_shopinvader_state",
         store=True,
     )
+    shopinvader_to_be_recomputed = fields.Boolean(
+        help="Technical field that will intend to check if the sale order has"
+        "to be recomputed du to a modification (asynchronous)"
+    )
 
     @job(default_channel="root.shopinvader")
     def _shopinvader_delayed_recompute(self):
         self.shopinvader_recompute()
+
+    @api.multi
+    def shopinvader_recompute(self):
+        self.ensure_one()
+        if self.shopinvader_to_be_recomputed:
+            self.recompute()
+            self.shopinvader_to_be_recomputed = False
 
     def _get_shopinvader_state(self):
         self.ensure_one()
@@ -128,13 +139,6 @@ class SaleOrder(models.Model):
         if reset_price:
             self.reset_price_tax()
         return True
-
-    @api.multi
-    def shopinvader_recompute(self):
-        self.ensure_one()
-        if self.shopinvader_to_be_recomputed:
-            self.recompute()
-            self.shopinvader_to_be_recomputed = False
 
 
 class SaleOrderLine(models.Model):

--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -100,6 +100,10 @@ class ShopinvaderBackend(models.Model):
         "statistics reasons. A new cart is created automatically when the "
         "customer will add a new item.",
     )
+    simple_cart_service = fields.Boolean(
+        help="Technical field to change cart service behaviour. Change this"
+        "only if you know what you are doing"
+    )
 
     _sql_constraints = [
         (

--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -101,8 +101,12 @@ class ShopinvaderBackend(models.Model):
         "customer will add a new item.",
     )
     simple_cart_service = fields.Boolean(
-        help="Technical field to change cart service behaviour. Change this"
-        "only if you know what you are doing"
+        help="If this option is checked, the add item action on frontend will"
+        " either add a new line either increase qty but promotion, taxes,"
+        " subtotal computations will be delegated to an asynchronous job."
+        " It the customer wants to see his cart before its execution,"
+        " the computation will be done on the fly to ensure data"
+        " integrity"
     )
 
     _sql_constraints = [

--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -244,7 +244,7 @@ class CartService(Component):
             # Recompute cart asynchronously to avoid latencies on frontend
             description = "Recompute cart %s" % (existing_item.id)
             existing_item.order_id.with_delay(
-                description=description
+                description=description, priority=1
             )._shopinvader_delayed_recompute()
         else:
             cart.recompute()

--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
 from odoo.exceptions import UserError
+from odoo.tools import float_round
 from odoo.tools.translate import _
 from werkzeug.exceptions import NotFound
 
@@ -43,12 +44,41 @@ class CartService(Component):
         else:
             return self._to_json(cart)
 
+    def _get_simple_cart_items(self, cart):
+        """
+        Returns fast
+        :return:
+        """
+        cart_simple = cart.with_context(prefetch_fields=False)
+        qty = sum(
+            float_round(
+                line.product_uom_qty,
+                precision_rounding=line.product_uom.rounding,
+            )
+            for line in cart_simple.order_line
+        )
+        return {
+            "data": {"id": cart.id, "qty": qty},
+            "set_session": {"cart_id": cart.id},
+            "store_cache": {"cart": {"id": cart.id, "qty": qty}},
+        }
+
     def add_item(self, **params):
+        """
+        Add item to cart.
+        Don't recompute immediately to keep this action smooth and quick.
+        Just return some limited information (e.g.: quantity)
+        Don't browse cart as ORM could launch recomputation!
+        The cart has to be recomputed
+        :param params:
+        :return:
+        """
         cart = self._get()
         if not cart:
             cart = self._create_empty_cart()
         self._add_item(cart, params)
-        return self._to_json(cart)
+        res = self._get_simple_cart_items(cart)
+        return res
 
     def update_item(self, **params):
         cart = self._get()
@@ -149,7 +179,6 @@ class CartService(Component):
             cart._cache["order_line"] = tuple(real_line_ids)
             vals.update(new_values)
             item.write(vals)
-        cart.recompute()
 
     def _do_clear_cart_cancel(self, cart):
         """
@@ -206,7 +235,6 @@ class CartService(Component):
                 new_values = self._sale_order_line_onchange(vals)
                 vals.update(new_values)
                 self._create_sale_order_line(vals)
-            cart.recompute()
 
     @contextmanager
     def _ensure_ctx_lang(self, values):

--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -436,6 +436,8 @@ class CartService(Component):
             # criteria on the cart but in this case, each time the _get method
             # would have been called, a new SQL query would have been done
             cart = self.env["sale.order"].browse(self.cart_id).exists()
+            # Recompute cart if needed (in case of simple service call)
+            cart.shopinvader_recompute()
         if (
             cart.shopinvader_backend_id == self.shopinvader_backend
             and cart.typology == "cart"

--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -23,6 +23,10 @@ class CartService(Component):
     _usage = "cart"
 
     @property
+    def cart_recompute_identify_key(self):
+        return "sale.order._shopinvader_delayed_recompute.%s" % self.cart_id
+
+    @property
     def cart_id(self):
         return self.shopinvader_session.get("cart_id", 0)
 
@@ -244,7 +248,9 @@ class CartService(Component):
             # Recompute cart asynchronously to avoid latencies on frontend
             description = "Recompute cart %s" % (existing_item.id)
             existing_item.order_id.with_delay(
-                description=description, priority=1
+                description=description,
+                priority=1,
+                identity_key=self.cart_recompute_identify_key,
             )._shopinvader_delayed_recompute()
         else:
             cart.recompute()

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -70,6 +70,7 @@ class CommonCase(SavepointCase, ComponentMixin):
         ComponentMixin.setUp(self)
 
         shopinvader_response.set_testmode(True)
+        shopinvader_response.get().reset()
 
         @self.addCleanup
         def cleanupShopinvaderResponseTestMode():

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -263,7 +263,12 @@ class AnonymousCartCase(CartCase, CartClearTest):
         self.backend.write({"pricelist_id": second_pricelist.id})
         params = {"product_id": self.product_1.id, "item_qty": 1}
         self.service.shopinvader_session.clear()
-        response = self.service.dispatch("add_item", params=params)
+        add_item_response = self.service.dispatch("add_item", params=params)
+        self.service.shopinvader_session.update(
+            add_item_response.get("set_session")
+        )
+
+        response = self.service.search()
         data = response.get("data")
         sale_id = response.get("set_session", {}).get("cart_id")
         sale_order = self.sale_obj.browse(sale_id)

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields
+from odoo.addons.shopinvader import shopinvader_response
 
 from .common import CommonCase
 
@@ -268,7 +269,7 @@ class AnonymousCartCase(CartCase, CartClearTest):
             add_item_response.get("set_session")
         )
 
-        response = self.service.search()
+        response = self.service.dispatch("search")
         data = response.get("data")
         sale_id = response.get("set_session", {}).get("cart_id")
         sale_order = self.sale_obj.browse(sale_id)
@@ -371,13 +372,14 @@ class AnonymousCartCase(CartCase, CartClearTest):
           result must be empty
         """
         self.assertTrue(self.service.shopinvader_session.get("cart_id"))
-        search_result = self.service.search()
+        search_result = self.service.dispatch("search")
         self.assertEqual(
             search_result["store_cache"]["cart"]["name"], self.cart.name
         )
         # reset cart_id parameter
+        shopinvader_response.get().reset()
         self.service.shopinvader_session.update({"cart_id": False})
-        search_result = self.service.search()
+        search_result = self.service.dispatch("search")
         self.assertDictEqual(search_result, {})
 
 
@@ -578,7 +580,7 @@ class ConnectedCartCase(CommonConnectedCartCase, CartClearTest):
         cart.unlink()
         self.assertFalse(cart.exists())
         nb_sale_order_before = self.cart.search_count([])
-        result = self.service.search()
+        result = self.service.dispatch("search")
         nb_sale_order_after = self.cart.search_count([])
         self.assertDictEqual(result.get("data", {}), {})
         # Ensure no new SO has been created

--- a/shopinvader/tests/test_cart_item.py
+++ b/shopinvader/tests/test_cart_item.py
@@ -94,7 +94,8 @@ class AbstractItemCase(object):
             job.identity_key,
         )
         self.assertEquals(
-            {"id": cart["id"], "qty": qty_before + 2.0}, cart_simple
+            {"id": cart["id"], "lines": {"count": qty_before + 2.0}},
+            cart_simple,
         )
         cart = self.service.search()["data"]
         self.assertEqual(cart["id"], self.cart.id)

--- a/shopinvader/tests/test_cart_item.py
+++ b/shopinvader/tests/test_cart_item.py
@@ -88,6 +88,11 @@ class AbstractItemCase(object):
         self._init_job_counter()
         cart_simple = self.add_item(self.product_1.id, 2)
         self._check_nbr_job_created(1)
+        job = self.created_jobs
+        self.assertEquals(
+            "sale.order._shopinvader_delayed_recompute.%s" % cart.get("id"),
+            job.identity_key,
+        )
         self.assertEquals(
             {"id": cart["id"], "qty": qty_before + 2.0}, cart_simple
         )
@@ -98,6 +103,9 @@ class AbstractItemCase(object):
             cart["lines"]["items"][-1], self.product_1.id, 2
         )
         self.check_partner(cart)
+        self._init_job_counter()
+        self.add_item(self.product_1.id, 2)
+        self._check_nbr_job_created(0)
         self._perform_created_job()
 
     def test_update_item(self):

--- a/shopinvader/tests/test_cart_item.py
+++ b/shopinvader/tests/test_cart_item.py
@@ -72,7 +72,9 @@ class AbstractItemCase(object):
             for line in sale.order_line
         )
         nbr_line = len(cart["lines"]["items"])
+        self._init_job_counter()
         cart_simple = self.add_item(self.product_1.id, 2)
+        self._check_nbr_job_created(1)
         self.assertEquals(
             {"id": cart["id"], "qty": qty_before + 2.0}, cart_simple
         )
@@ -83,6 +85,7 @@ class AbstractItemCase(object):
             cart["lines"]["items"][-1], self.product_1.id, 2
         )
         self.check_partner(cart)
+        self._perform_created_job()
 
     def test_update_item(self):
         line_id = self.cart.order_line[0].id

--- a/shopinvader/tests/test_cart_item.py
+++ b/shopinvader/tests/test_cart_item.py
@@ -63,6 +63,19 @@ class AbstractItemCase(object):
 
     def test_add_item_with_an_existing_cart(self):
         cart = self.service.search()["data"]
+        nbr_line = len(cart["lines"]["items"])
+
+        cart = self.add_item(self.product_1.id, 2)
+        self.assertEqual(cart["id"], self.cart.id)
+        self.assertEqual(len(cart["lines"]["items"]), nbr_line + 1)
+        self.check_product_and_qty(
+            cart["lines"]["items"][-1], self.product_1.id, 2
+        )
+        self.check_partner(cart)
+
+    def test_add_item_with_an_existing_cart_simple(self):
+        self.backend.simple_cart_service = True
+        cart = self.service.search()["data"]
         sale = self.env["sale.order"].browse(cart["id"])
         qty_before = sum(
             float_round(

--- a/shopinvader/tests/test_cart_item.py
+++ b/shopinvader/tests/test_cart_item.py
@@ -3,6 +3,8 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.tools import float_round
+
 from .common import CommonCase
 
 
@@ -49,7 +51,8 @@ class AbstractItemCase(object):
         last_order = self.env["sale.order"].search(
             [], limit=1, order="id desc"
         )
-        cart = self.add_item(self.product_1.id, 2)
+        self.add_item(self.product_1.id, 2)
+        cart = self.service.search()["data"]
         self.assertGreater(cart["id"], last_order.id)
         self.assertEqual(len(cart["lines"]["items"]), 1)
         self.assertEqual(cart["lines"]["count"], 2)
@@ -60,9 +63,20 @@ class AbstractItemCase(object):
 
     def test_add_item_with_an_existing_cart(self):
         cart = self.service.search()["data"]
+        sale = self.env["sale.order"].browse(cart["id"])
+        qty_before = sum(
+            float_round(
+                line.product_uom_qty,
+                precision_rounding=line.product_uom.rounding,
+            )
+            for line in sale.order_line
+        )
         nbr_line = len(cart["lines"]["items"])
-
-        cart = self.add_item(self.product_1.id, 2)
+        cart_simple = self.add_item(self.product_1.id, 2)
+        self.assertEquals(
+            {"id": cart["id"], "qty": qty_before + 2.0}, cart_simple
+        )
+        cart = self.service.search()["data"]
         self.assertEqual(cart["id"], self.cart.id)
         self.assertEqual(len(cart["lines"]["items"]), nbr_line + 1)
         self.check_product_and_qty(
@@ -116,12 +130,14 @@ class AbstractItemCase(object):
 
     def test_add_item_with_same_product_without_cart(self):
         self.remove_cart()
-        cart = self.add_item(self.product_1.id, 1)
+        self.add_item(self.product_1.id, 1)
+        cart = self.service.search()["data"]
         self.assertEqual(len(cart["lines"]["items"]), 1)
         self.check_product_and_qty(
             cart["lines"]["items"][0], self.product_1.id, 1
         )
-        cart = self.add_item(self.product_1.id, 1)
+        self.add_item(self.product_1.id, 1)
+        cart = self.service.search()["data"]
         self.assertEqual(len(cart["lines"]["items"]), 1)
         self.check_product_and_qty(
             cart["lines"]["items"][0], self.product_1.id, 2
@@ -153,7 +169,8 @@ class AbstractItemCase(object):
                 "product_id": self.product_3.id,
             }
         )
-        cart_data = self.add_item(self.product_3.id, 1)
+        self.add_item(self.product_3.id, 1)
+        cart_data = self.service.search()["data"]
         cart = self.env["sale.order"].browse(cart_data["id"])
         self.assertEqual(cart.pricelist_id, self.pricelist)
         return cart_data["lines"]["items"][0]["amount"]

--- a/shopinvader/views/sale_view.xml
+++ b/shopinvader/views/sale_view.xml
@@ -6,6 +6,14 @@
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="priority" eval="20"/>
         <field name="arch" type="xml">
+            <button name="action_done"
+                    position="after">
+                <field name="shopinvader_to_be_recomputed" invisible="1"/>
+                <button name="shopinvader_recompute"
+                        attrs="{'invisible': [('shopinvader_to_be_recomputed', '=', False)]}"
+                        string="Recompute"
+                        type="object"/>
+            </button>
             <field name="partner_id" position="after">
                 <field name="typology" invisible="True"/>
                 <field name="current_step_id" attrs="{'invisible': [('typology', '!=', 'cart')]}"/>

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -117,6 +117,9 @@
                                             string="Bind all category"
                                             type="object"/>
                                 </group>
+                                <group name="service" string="Service" col="10" colspan="4">
+                                    <field name="simple_cart_service"/>
+                                </group>
                             </group>
                         </page>
                     </notebook>

--- a/shopinvader_delivery_carrier/tests/test_carrier.py
+++ b/shopinvader_delivery_carrier/tests/test_carrier.py
@@ -62,7 +62,8 @@ class CarrierCase(CommonCarrierCase):
 
     def test_reset_carrier_on_add_item(self):
         self._apply_carrier_and_assert_set()
-        cart = self.add_item(self.product_1.id, 2)
+        self.add_item(self.product_1.id, 2)
+        cart = self.service.search()["data"]
         self.assertEqual(cart["shipping"]["amount"]["total"], 0)
         self.assertFalse(cart["shipping"]["selected_carrier"])
 

--- a/shopinvader_delivery_carrier/tests/test_carrier.py
+++ b/shopinvader_delivery_carrier/tests/test_carrier.py
@@ -62,8 +62,7 @@ class CarrierCase(CommonCarrierCase):
 
     def test_reset_carrier_on_add_item(self):
         self._apply_carrier_and_assert_set()
-        self.add_item(self.product_1.id, 2)
-        cart = self.service.search()["data"]
+        cart = self.add_item(self.product_1.id, 2)
         self.assertEqual(cart["shipping"]["amount"]["total"], 0)
         self.assertFalse(cart["shipping"]["selected_carrier"])
 

--- a/shopinvader_promotion_rule/models/sale_order.py
+++ b/shopinvader_promotion_rule/models/sale_order.py
@@ -17,3 +17,14 @@ class SaleOrder(models.Model):
         if self.has_promotion_rules:
             self.apply_promotions()
         return result
+
+    @api.multi
+    def shopinvader_recompute(self):
+        """
+        Call apply_promotion() after the recompute (called when we use the
+        simple add item service)
+        :return:
+        """
+        res = super(SaleOrder, self).shopinvader_recompute()
+        self.apply_promotions()
+        return res

--- a/shopinvader_promotion_rule/models/sale_order.py
+++ b/shopinvader_promotion_rule/models/sale_order.py
@@ -19,12 +19,12 @@ class SaleOrder(models.Model):
         return result
 
     @api.multi
-    def shopinvader_recompute(self):
+    def _shopinvader_recompute(self):
         """
         Call apply_promotion() after the recompute (called when we use the
         simple add item service)
         :return:
         """
-        res = super(SaleOrder, self).shopinvader_recompute()
+        res = super(SaleOrder, self)._shopinvader_recompute()
         self.apply_promotions()
         return res

--- a/shopinvader_promotion_rule/services/cart.py
+++ b/shopinvader_promotion_rule/services/cart.py
@@ -51,14 +51,9 @@ class CartService(Component):
 
     def _add_item(self, cart, params):
         res = super(CartService, self)._add_item(cart, params)
+        if not self.shopinvader_backend.simple_cart_service:
+            cart.apply_promotions()
         return res
-
-    def _get(self, create_if_not_found=True):
-        cart = super(CartService, self)._get(
-            create_if_not_found=create_if_not_found
-        )
-        cart.apply_promotions()
-        return cart
 
     def _update_item(self, cart, params, item=False):
         res = super(CartService, self)._update_item(cart, params, item)

--- a/shopinvader_promotion_rule/services/cart.py
+++ b/shopinvader_promotion_rule/services/cart.py
@@ -51,8 +51,14 @@ class CartService(Component):
 
     def _add_item(self, cart, params):
         res = super(CartService, self)._add_item(cart, params)
-        cart.apply_promotions()
         return res
+
+    def _get(self, create_if_not_found=True):
+        cart = super(CartService, self)._get(
+            create_if_not_found=create_if_not_found
+        )
+        cart.apply_promotions()
+        return cart
 
     def _update_item(self, cart, params, item=False):
         res = super(CartService, self)._update_item(cart, params, item)

--- a/shopinvader_promotion_rule/tests/test_cart.py
+++ b/shopinvader_promotion_rule/tests/test_cart.py
@@ -122,12 +122,11 @@ class TestCart(CommonConnectedCartCase, AbstractCommonPromotionCase):
         self.assertEquals(count_existing_lines + 1, len(self.cart.order_line))
         new_line = self.cart.order_line - old_lines
         self.assertFalse(new_line.coupon_promotion_rule_id)
-        cart_data = self.service.search()["data"]
+        cart_data = self.service.dispatch("search")["data"]
         cart = self.env["sale.order"].browse(cart_data["id"])
         new_line = cart.order_line - old_lines
-        self.check_discount_rule_set(
-            new_line, self.env["sale.promotion.rule"].browse()
-        )
+        # As a search has been done, the cart computation has been forced
+        self.check_discount_rule_set(new_line, self.promotion_rule_coupon)
         # the promotion is applied on all lines
         for line in self.cart.order_line - new_line:
             self.check_discount_rule_set(line, self.promotion_rule_coupon)

--- a/shopinvader_promotion_rule/tests/test_cart.py
+++ b/shopinvader_promotion_rule/tests/test_cart.py
@@ -99,6 +99,20 @@ class TestCart(CommonConnectedCartCase, AbstractCommonPromotionCase):
     def test_promotion_on_item(self):
         self.add_coupon_code(self.promotion_rule_coupon.code)
         count_existing_lines = len(self.cart.order_line)
+        # each time we add an item the promotion is recomputed and the coupon
+        # code is preserved
+        self.service.dispatch(
+            "add_item", params={"product_id": self.product_1.id, "item_qty": 2}
+        )
+        self.assertEquals(count_existing_lines + 1, len(self.cart.order_line))
+        # the promotion is applied on all lines
+        for line in self.cart.order_line:
+            self.check_discount_rule_set(line, self.promotion_rule_coupon)
+
+    def test_promotion_on_item_simple(self):
+        self.backend.simple_cart_service = True
+        self.add_coupon_code(self.promotion_rule_coupon.code)
+        count_existing_lines = len(self.cart.order_line)
         old_lines = self.cart.order_line
         # each time we add an item the promotion is recomputed and the coupon
         # code is preserved
@@ -111,7 +125,9 @@ class TestCart(CommonConnectedCartCase, AbstractCommonPromotionCase):
         cart_data = self.service.search()["data"]
         cart = self.env["sale.order"].browse(cart_data["id"])
         new_line = cart.order_line - old_lines
-        self.check_discount_rule_set(new_line, self.promotion_rule_coupon)
+        self.check_discount_rule_set(
+            new_line, self.env["sale.promotion.rule"].browse()
+        )
         # the promotion is applied on all lines
         for line in self.cart.order_line - new_line:
             self.check_discount_rule_set(line, self.promotion_rule_coupon)


### PR DESCRIPTION
If there are many things to compute on a sale order,
the item addition to cart could become quite long.

This prevent recomputing cart at each addition.

Adds an option on the backend to enable that behaviour.

To let the cart in a consistent state, recompute
at each time we call get() if needed.

In 'simple' mode, the add_item() service will return :

```python
{"data": {"id": <cart_id>, "lines": {"count" : <cart qty>}}}
```

We keep the format used in normal behaviour to limit the impact on frontend modifications.

Modifications in :
* [x] shopinvader
* [x] shopinvader_promotion_rule