### PR TITLE
[10.0][FIX] Fix missing parameters into some search validator

### DIFF
--- a/shopinvader/services/address.py
+++ b/shopinvader/services/address.py
@@ -56,7 +56,9 @@ class AddressService(Component):
 
     # Validator
     def _validator_search(self):
-        return {"scope": {"type": "dict", "nullable": True}}
+        validator = self._default_validator_search()
+        validator.pop("domain", {})
+        return validator
 
     def _validator_create(self):
         res = {

--- a/shopinvader/services/sale.py
+++ b/shopinvader/services/sale.py
@@ -35,16 +35,12 @@ class SaleService(Component):
 
     # Validator
     def _validator_search(self):
-        return {
-            "id": {"coerce": to_int, "type": "integer"},
-            "per_page": {
-                "coerce": to_int,
-                "nullable": True,
-                "type": "integer",
-            },
-            "page": {"coerce": to_int, "nullable": True, "type": "integer"},
-            "scope": {"type": "dict", "nullable": True},
-        }
+        default_search_validator = self._default_validator_search()
+        default_search_validator.pop("domain", {})
+        default_search_validator.update(
+            {"id": {"coerce": to_int, "type": "integer"}}
+        )
+        return default_search_validator
 
     def _validator_ask_email_invoice(self):
         return self._validator_ask_email()

--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -5,6 +5,7 @@
 
 
 from odoo import _
+from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import AbstractComponent
 from odoo.exceptions import MissingError, UserError
 from odoo.osv import expression
@@ -55,6 +56,26 @@ class BaseShopinvaderService(AbstractComponent):
             return expression.normalize_domain(domain)
         except Exception as e:
             raise UserError(_("Invalid scope %s, error : %s"), scope, e)
+
+    # Validator
+    def _default_validator_search(self):
+        """
+        Get a default validator for search service.
+        This search include every parameters used for pagination, scope and domain.
+        This directly used a _validator_search in case of an existing service
+        doesn't allow all of these parameters (backward compatibility).
+        :return: dict
+        """
+        return {
+            "page": {"coerce": to_int, "nullable": True, "type": "integer"},
+            "per_page": {
+                "coerce": to_int,
+                "nullable": True,
+                "type": "integer",
+            },
+            "domain": {"type": "list", "nullable": True},
+            "scope": {"type": "dict", "nullable": True},
+        }
 
     def _paginate_search(self, default_page=1, default_per_page=5, **params):
         """

--- a/shopinvader/tests/test_address.py
+++ b/shopinvader/tests/test_address.py
@@ -88,6 +88,17 @@ class AddressTestCase(object):
         expected_ids = {self.partner.id, self.address.id, self.address_2.id}
         self.assertEqual(ids, expected_ids)
 
+    def test_search_per_page(self):
+        # Ensure the 'per_page' is working into search.
+        res = self.service.dispatch("search", params={"per_page": 2})["data"]
+        self.assertEqual(len(res), 2)
+        # Ensure the 'page' is working. As there is 3 address for logged user, we
+        # should have only 1 remaining result on the second page.
+        res = self.service.dispatch(
+            "search", params={"per_page": 2, "page": 2}
+        )["data"]
+        self.assertEqual(len(res), 1)
+
     def test_delete_address(self):
         address_id = self.address.id
         self.service.delete(address_id)

--- a/shopinvader_delivery_carrier/services/delivery.py
+++ b/shopinvader_delivery_carrier/services/delivery.py
@@ -2,7 +2,6 @@
 # Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import fields
-from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
 from odoo.osv import expression
 
@@ -26,15 +25,10 @@ class DeliveryService(Component):
         Validator for the search
         :return: dict
         """
-        schema = {
-            "per_page": {
-                "coerce": to_int,
-                "nullable": True,
-                "type": "integer",
-            },
-            "page": {"coerce": to_int, "nullable": True, "type": "integer"},
-        }
-        return schema
+        validator = self._default_validator_search()
+        validator.pop("domain", {})
+        validator.pop("scope", {})
+        return validator
 
     def _get_picking_schema(self):
         """

--- a/shopinvader_invoice/services/invoice.py
+++ b/shopinvader_invoice/services/invoice.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
 
 
@@ -21,15 +20,10 @@ class InvoiceService(Component):
         Validator for the search
         :return: dict
         """
-        schema = {
-            "per_page": {
-                "coerce": to_int,
-                "nullable": True,
-                "type": "integer",
-            },
-            "page": {"coerce": to_int, "nullable": True, "type": "integer"},
-        }
-        return schema
+        default_validator = self._default_validator_search()
+        default_validator.pop("scope", {})
+        default_validator.pop("domain", {})
+        return default_validator
 
     def _validator_return_search(self):
         """


### PR DESCRIPTION
Due to this missing parameters, it was not possible to use the pagination (`per_page` + `page`).

To fix this, I just create a default search validator in `service.py`. This validator is not loaded into every service by default to stay compatible (about security) with existing parameters available.

I already did some changes into existing services to allow the pagination.

**How to reproduce:**
- Just create some contact (more than 5 by default) to your logged user;
- Do a search (swagger) on your email;
- You will have only 5 results by default;
- Now add the `'per_page': 10` to allow more;
- You will have only 5 results (the issue).
