### PR TITLE
WIP [10.0][FIX] Fix incompatibility between shopinvader_promotion_rule and shopinvader_cart_expiry

### DIFF
--- a/setup/shopinvader_promotion_rule_cart_expiry/odoo/__init__.py
+++ b/setup/shopinvader_promotion_rule_cart_expiry/odoo/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/shopinvader_promotion_rule_cart_expiry/odoo/addons/__init__.py
+++ b/setup/shopinvader_promotion_rule_cart_expiry/odoo/addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/shopinvader_promotion_rule_cart_expiry/odoo/addons/shopinvader_promotion_rule_cart_expiry
+++ b/setup/shopinvader_promotion_rule_cart_expiry/odoo/addons/shopinvader_promotion_rule_cart_expiry
@@ -1,0 +1,1 @@
+../../../../shopinvader_promotion_rule_cart_expiry

--- a/setup/shopinvader_promotion_rule_cart_expiry/setup.py
+++ b/setup/shopinvader_promotion_rule_cart_expiry/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopinvader/readme/CONTRIBUTORS.rst
+++ b/shopinvader/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Sebastien BEAU <sebastien.beau@akretion.com>
+* François Honoré <francois.honore@acsone.eu>

--- a/shopinvader_promotion_rule_cart_expiry/README.rst
+++ b/shopinvader_promotion_rule_cart_expiry/README.rst
@@ -1,0 +1,26 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=========================================
+Shopinvader Promotion Rules - Cart Expiry
+=========================================
+
+This module fix the incompatibility between shopinvader_promotion_rule and
+shopinvader_cart_expiry.
+The shopinvader_cart_expiry use the write date to know the last modification done on a
+cart. But the shopinvader_promotion_rule update every days (depending on the cron)
+promotions applied on a cart. So even if nobody update the cart, the write_date is
+updated.
+
+So this module add a specific write_date (shopinvader_write_date) who has exactly the
+same behavior of the original field. Except that depending on the context, it's
+possible to don't update it (for this case: during the promotion's recompute).
+
+Credits
+=======
+
+Contributors
+------------
+
+* François Honoré <francois.honore@acsone.eu>

--- a/shopinvader_promotion_rule_cart_expiry/__init__.py
+++ b/shopinvader_promotion_rule_cart_expiry/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from .hooks import post_init_hook

--- a/shopinvader_promotion_rule_cart_expiry/__manifest__.py
+++ b/shopinvader_promotion_rule_cart_expiry/__manifest__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Akretion (http://www.akretion.com)
+# Benoît GUILLOT <benoit.guillot@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Shopvinvader Promotion Rule cart expiry",
+    "summary": "Module to fix incompatibility between shopinvader promotion rule "
+    "and shopinvader cart expiry.",
+    "version": "10.0.1.0.1",
+    "category": "Sale",
+    "website": "https://shopinvader.com",
+    "author": "ACSONE SA/NV",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "auto_install": True,
+    "depends": ["shopinvader_promotion_rule", "shopinvader_cart_expiry"],
+    "post_init_hook": "post_init_hook",
+}

--- a/shopinvader_promotion_rule_cart_expiry/hooks.py
+++ b/shopinvader_promotion_rule_cart_expiry/hooks.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def post_init_hook(cr, registry):
+    """
+    Set default value for shopinvader_write_date on sale.order with write_date.
+    """
+    _logger.info(
+        "Update every sale.order: set shopinvader_write_date with write_date."
+    )
+    query = """UPDATE sale_order SET shopinvader_write_date = write_date;"""
+    cr.execute(query)

--- a/shopinvader_promotion_rule_cart_expiry/models/__init__.py
+++ b/shopinvader_promotion_rule_cart_expiry/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import sale_order
+from . import sale_promotion_rule
+from . import shopinvader_backend

--- a/shopinvader_promotion_rule_cart_expiry/models/sale_order.py
+++ b/shopinvader_promotion_rule_cart_expiry/models/sale_order.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    shopinvader_write_date = fields.Datetime(
+        help="Specific write_date used for shopinvader."
+    )
+
+    def _fill_shopinvader_write_date(self, values):
+        """
+        During write, always update the shopinvader_write_date.
+        If the key skip_shopinvader_write_date in context is set to False OR if
+        values is empty, the field is not updated.
+        :param values: dict
+        :return: dict
+        """
+        if values and not self.env.context.get(
+            "skip_shopinvader_write_date", False
+        ):
+            values.update({"shopinvader_write_date": fields.Datetime.now()})
+        return values
+
+    @api.multi
+    def write(self, vals):
+        """
+        Inherit to manage the shopinvader_write_date
+        :param vals: dict
+        :return: bool
+        """
+        vals = self._fill_shopinvader_write_date(vals)
+        return super(SaleOrder, self).write(vals)

--- a/shopinvader_promotion_rule_cart_expiry/models/sale_promotion_rule.py
+++ b/shopinvader_promotion_rule_cart_expiry/models/sale_promotion_rule.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class SalePromotionRule(models.Model):
+    _inherit = "sale.promotion.rule"
+
+    @api.model
+    def compute_promotions(self, orders):
+        """
+        Inherit to add specific context to bypass shopinvader_write_date
+        """
+        self_ctx = self.with_context(skip_shopinvader_write_date=True)
+        orders = orders.with_context(skip_shopinvader_write_date=True)
+        return super(SalePromotionRule, self_ctx).compute_promotions(orders)

--- a/shopinvader_promotion_rule_cart_expiry/models/shopinvader_backend.py
+++ b/shopinvader_promotion_rule_cart_expiry/models/shopinvader_backend.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+from odoo.osv import expression
+
+
+class ShopinvaderBackend(models.Model):
+    _inherit = "shopinvader.backend"
+
+    @api.multi
+    def _get_expiry_cart_domain(self):
+        """
+        Inherit to add OR to use the shopinvader_write_date.
+        :return: list/domain
+        """
+        super_domain = expression.normalize_domain(
+            super(ShopinvaderBackend, self)._get_expiry_cart_domain()
+        )
+        expiry_date = self._get_expiry_date()
+        new_domain = expression.normalize_domain(
+            [
+                ("shopinvader_backend_id", "in", self.ids),
+                ("typology", "=", "cart"),
+                ("shopinvader_write_date", "<=", expiry_date),
+            ]
+        )
+        domain = expression.OR([super_domain, new_domain])
+        return domain

--- a/shopinvader_promotion_rule_cart_expiry/tests/__init__.py
+++ b/shopinvader_promotion_rule_cart_expiry/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import test_cart

--- a/shopinvader_promotion_rule_cart_expiry/tests/test_cart.py
+++ b/shopinvader_promotion_rule_cart_expiry/tests/test_cart.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import fields
+from odoo.addons.sale_promotion_rule.tests.test_promotion import (
+    AbstractCommonPromotionCase,
+)
+from odoo.addons.shopinvader.tests.test_cart import CommonConnectedCartCase
+
+
+class TestCart(CommonConnectedCartCase, AbstractCommonPromotionCase):
+    def setUp(self, *args, **kwargs):
+        super(TestCart, self).setUp(*args, **kwargs)
+        self.set_up("shopinvader.sale_order_2")
+        self.product_1 = self.env.ref("product.product_product_4b")
+        self.promo_rule_obj = self.env["sale.promotion.rule"]
+
+    def test_shopinvader_write_date_on_compute_promotions(self):
+        """
+        Ensure the shopinvader_write_date is not updated during compute_promotions
+        :return:
+        """
+        # Test when the field is empty
+        self.sale.with_context(skip_shopinvader_write_date=True).write(
+            {"shopinvader_write_date": False}
+        )
+        self.assertFalse(self.sale.shopinvader_write_date)
+        self.promo_rule_obj.compute_promotions(self.sale)
+        self.sale.refresh()
+        self.assertFalse(self.sale.shopinvader_write_date)
+        # Re-check with the field is set with a value
+        custom_date = "2020-01-01 00:00:00"
+        self.sale.with_context(skip_shopinvader_write_date=True).write(
+            {"shopinvader_write_date": custom_date}
+        )
+        self.assertEquals(self.sale.shopinvader_write_date, custom_date)
+        self.promo_rule_obj.compute_promotions(self.sale)
+        self.sale.refresh()
+        self.assertEquals(self.sale.shopinvader_write_date, custom_date)
+
+    def test_shopinvader_write_date_classic_write(self):
+        """
+        Ensure the shopinvader_write_date is correctly updated in case of normal write
+        :return:
+        """
+        self.sale.with_context(skip_shopinvader_write_date=True).write(
+            {"shopinvader_write_date": False}
+        )
+        self.assertFalse(self.sale.shopinvader_write_date)
+        self.sale.write({"note": "A text"})
+        self.assertTrue(self.sale.shopinvader_write_date)
+        # Now ensure it's correctly updated at each write. So do a second write
+        custom_date = "2020-01-01 00:00:00"
+        self.sale.with_context(skip_shopinvader_write_date=True).write(
+            {"shopinvader_write_date": custom_date}
+        )
+        self.sale.write({"note": "A new text"})
+        self.assertTrue(self.sale.shopinvader_write_date)
+        self.assertNotEquals(self.sale.shopinvader_write_date, custom_date)
+
+    def test_cart_expiry_delete(self):
+        """
+        Ensure the domain (_get_expiry_cart_domain on shopinvader backend) is correct
+        and the cart/SO is included into it.
+        :return:
+        """
+        # The cart shouldn't be deleted because it considered as a new one.
+        now = fields.Datetime.now()
+        self.sale.with_context(skip_shopinvader_write_date=True).write(
+            {"shopinvader_write_date": now}
+        )
+        self.backend.write(
+            {"cart_expiry_delay": 1, "cart_expiry_policy": "delete"}
+        )
+        self.backend.manage_cart_expiry()
+        self.assertTrue(self.sale.exists())
+        self.assertEqual(self.sale.state, "draft")
+        # Now set the shopinvader_write_date with an old date and it should be removed.
+        self.sale.with_context(skip_shopinvader_write_date=True).write(
+            {"shopinvader_write_date": "2020-01-01 00:00:00"}
+        )
+        self.backend.manage_cart_expiry()
+        self.assertFalse(self.sale.exists())


### PR DESCRIPTION
Because the promotion rule always update the write date of the cart (even if no real updated; due to implementation way) so every cart are considered as 'recently updated' and are never deleted/cancelled

**How to reproduce:**
- Install 2 concerned modules;
- Set the expiry delay to 1 day;
- Create a cart in draft;
- Every day, a cron about promotions rules should run (in case of a promotion is expired, the cart must be updated);
- After 2 days this cart should be deleted (but it's not the case. If you check write date, it's updated recently by the cron).

**Fix:**
- Create a dedicated field (exactly as `write_date`);
- Manage a context key (to avoid update this field in some case);
- Update the domain to get expired cart.

Fail due to Pylint error (not related to this MR). Fixed in https://github.com/shopinvader/odoo-shopinvader/pull/580