### PR TITLE
[10.0][IMP] shopinvader/guest_mode: Allows to update profile in guest mode

### DIFF
--- a/shopinvader/services/address.py
+++ b/shopinvader/services/address.py
@@ -9,6 +9,8 @@ from odoo.addons.base_rest.components.service import to_bool, to_int
 from odoo.addons.component.core import Component
 from odoo.exceptions import AccessError
 
+from .. import shopinvader_response
+
 
 class AddressService(Component):
     _inherit = "base.shopinvader.service"
@@ -40,7 +42,10 @@ class AddressService(Component):
         address.write(self._prepare_params(params))
         res = self.search()
         if address.address_type == "profile":
-            res["store_cache"] = {"customer": self._to_json(address)[0]}
+            customer = self.component(usage="customer")
+            response = shopinvader_response.get()
+            customer_data = customer._to_customer_info(address)
+            response.set_store_cache("customer", customer_data)
         return res
 
     def delete(self, _id):

--- a/shopinvader_guest_mode/services/__init__.py
+++ b/shopinvader_guest_mode/services/__init__.py
@@ -1,2 +1,3 @@
 from . import customer
 from . import guest_service
+from . import address

--- a/shopinvader_guest_mode/services/address.py
+++ b/shopinvader_guest_mode/services/address.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.addons.component.core import Component
+from odoo.addons.shopinvader import shopinvader_response
+
+
+class AddressService(Component):
+
+    _inherit = "shopinvader.address.service"
+
+    def update(self, _id, **params):
+        """
+        As the base update() modifies the store_cache["customer"],
+        we need to add email as it is used by locomotive with headers
+        to set partner
+        :param _id:
+        :param params:
+        :return:
+        """
+        address = self._get(_id)
+        res = super(AddressService, self).update(_id=_id, **params)
+        guest = self.component(usage="guest")
+        binding = guest._get_binding(address.email)
+        if binding.is_guest and binding.address_type == "profile":
+            response = shopinvader_response.get()
+            store_cache = response.store_cache
+            customer = store_cache["customer"]
+            customer.update({"email": address.email})
+            response.set_store_cache("customer", customer)
+        return res

--- a/shopinvader_guest_mode/tests/test_guest_service.py
+++ b/shopinvader_guest_mode/tests/test_guest_service.py
@@ -50,6 +50,19 @@ class TestGuestService(CommonCase):
         self.assertEqual(new_binding.is_guest, True)
         self.assertNotEquals(first_binding, new_binding)
 
+        # Update guest address
+        self.data.update({"phone": "012345"})
+        with self.work_on_services(
+            partner=new_partner, shopinvader_session=self.shopinvader_session
+        ) as work:
+            self.service = work.component(usage="addresses")
+        res = self.service.dispatch("update", new_partner.id, params=self.data)
+
+        self.assertEquals("012345", new_partner.phone)
+        self.assertDictContainsSubset(
+            {"email": new_partner.email}, res["store_cache"]["customer"]
+        )
+
     def test_search_guest(self):
         self._create_guest()
         res = self.service.search(email="toto")


### PR DESCRIPTION
If the profile address is updated, the email must be returned in store_cache
as it can leads to partner session inconsistency.

customer['email'] must be returned in store_cache. Due to https://github.com/shopinvader/locomotive-shopinvader/blob/d7cb7f14e9943699551e8eabd439e93c3d48c5e2/lib/shop_invader/services/erp_service.rb#L195