### PR TITLE
[FIX] 10.0 CI unittest2 requirement

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,3 +6,4 @@ cachetools<3  # TODO because of component
 requests_mock
 vcrpy
 vcrpy-unittest
+unittest2 # For shopinvader test_controller, which inherits component


### PR DESCRIPTION
Shopinvader controller test inherit from base_rest, which inherits from component, which needs unittest2