### PR TITLE
[12.0][FIX] shopinvader wrong variable was used for categories

### DIFF
--- a/shopinvader/models/shopinvader_product.py
+++ b/shopinvader/models/shopinvader_product.py
@@ -99,7 +99,7 @@ class ShopinvaderProduct(models.Model):
                 domain = record._get_parent_category_domain(product_category)
                 parents = self.env["shopinvader.category"].search(domain)
                 categories |= parents
-            record.shopinvader_categ_ids = parents
+            record.shopinvader_categ_ids = categories
 
     def _prepare_shopinvader_variant(self, variant):
         values = {"record_id": variant.id, "shopinvader_product_id": self.id}


### PR DESCRIPTION
Introduced here : https://github.com/shopinvader/odoo-shopinvader/commit/1730e41c1dedbd410dd91a6e50e7cd04effa74ee#diff-51b6e38619a937a8d16e5ce2e8a58090R102
v10 not concerned.