### PR TITLE
[10.0][FIX] fix incorrect api return

### DIFF
--- a/shopinvader_delivery_carrier/readme/USAGE.rst
+++ b/shopinvader_delivery_carrier/readme/USAGE.rst
@@ -1,0 +1,4 @@
+This module will give you several endpoint for interacting with delivery carrier.
+You can play with it with swagger.
+
+Becarefull the key "rows" and "count" in the endpoint "delivery_carrier" are deprecated.

--- a/shopinvader_delivery_carrier/services/delivery_carrier.py
+++ b/shopinvader_delivery_carrier/services/delivery_carrier.py
@@ -31,10 +31,14 @@ class DeliveryCarrierService(Component):
         provides some specialized functionalities
         """
         delivery_carriers = self._search(**params)
-        return {
-            "count": len(delivery_carriers),
-            "rows": [self._prepare_carrier(dc) for dc in delivery_carriers],
+        vals = {
+            "size": len(delivery_carriers),
+            "data": [self._prepare_carrier(dc) for dc in delivery_carriers],
         }
+        # TODO DEPRECATED this old API is deprecated
+        #  keep returing the result but this should be not used anymore
+        vals.update({"count": vals["size"], "rows": vals["data"]})
+        return vals
 
     # Validators
 
@@ -54,9 +58,9 @@ class DeliveryCarrierService(Component):
         }
 
     def _validator_return_search(self):
-        return {
-            "count": {"type": "integer", "required": True},
-            "rows": {
+        schema = {
+            "size": {"type": "integer", "required": True},
+            "data": {
                 "type": "list",
                 "required": True,
                 "schema": {
@@ -84,6 +88,9 @@ class DeliveryCarrierService(Component):
                 },
             },
         }
+        # TODO DEPRECATED this old API is deprecated
+        schema.update({"count": schema["size"], "rows": schema["data"]})
+        return schema
 
     # Services implementation
 

--- a/shopinvader_delivery_carrier/tests/test_delivery_carrier.py
+++ b/shopinvader_delivery_carrier/tests/test_delivery_carrier.py
@@ -10,11 +10,15 @@ class TestDeliveryCarrier(CommonCarrierCase):
         super(CommonCarrierCase, self).setUp()
         self.carrier_service = self.service.component("delivery_carrier")
 
+    def _check_response(self, res, expected):
+        expected.update({"count": expected["size"], "rows": expected["data"]})
+        self.assertDictEqual(res, expected)
+
     def test_search_all(self):
         res = self.carrier_service.search()
         expected = {
-            "count": 2,
-            "rows": [
+            "size": 2,
+            "data": [
                 {
                     "price": 0.0,
                     "description": self.free_carrier.description or None,
@@ -31,13 +35,13 @@ class TestDeliveryCarrier(CommonCarrierCase):
                 },
             ],
         }
-        self.assertDictEqual(res, expected)
+        self._check_response(res, expected)
 
     def test_search_current_cart(self):
         res = self.carrier_service.search(target="current_cart")
         expected = {
-            "count": 2,
-            "rows": [
+            "size": 2,
+            "data": [
                 {
                     "price": 0.0,
                     "description": self.free_carrier.description or None,
@@ -54,4 +58,4 @@ class TestDeliveryCarrier(CommonCarrierCase):
                 },
             ],
         }
-        self.assertDictEqual(res, expected)
+        self._check_response(res, expected)


### PR DESCRIPTION
delivery_carrier search return is not consistent (rows, count) instead
of (data, size). This make this service incompatible with the "tag"
store on locomotive side.
fix return but keep the old key for compatibility reason

@lmignon @Cedric-Pigeon @rousseldenis 