### PR TITLE
[10.0][FIX] shopinvader: Allow to bind partner to different backends

### DIFF
--- a/shopinvader/__manifest__.py
+++ b/shopinvader/__manifest__.py
@@ -64,6 +64,7 @@
         "data/ir_cron.xml",
     ],
     "demo": [
+        "demo/res_company.xml",
         "demo/account_demo.xml",
         "demo/pricelist_demo.xml",
         "demo/backend_demo.xml",

--- a/shopinvader/demo/backend_demo.xml
+++ b/shopinvader/demo/backend_demo.xml
@@ -17,4 +17,13 @@
         <field name="account_analytic_id" ref="account_analytic_0"/>
     </record>
 
+    <record id="backend_liege" model="shopinvader.backend">
+        <field name="name">Demo Shopinvader Website Liege</field>
+        <field name="location">http://locomotive:3000</field>
+        <field name="lang_ids" eval="[(6, 0, [ref('base.lang_en')])]"/>
+        <field name="pricelist_id" ref="product.list0"/>
+        <field name="company_id" ref="shopinvader.res_company_liege"/>
+        <field name="account_analytic_id" ref="account_analytic_0"/>
+    </record>
+
 </odoo>

--- a/shopinvader/demo/res_company.xml
+++ b/shopinvader/demo/res_company.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <!-- Company Belgium-->
+    <record id="res_company_liege" model="res.company">
+        <field name="name">My Company, Liege</field>
+        <field name="parent_id" ref="base.main_company"/>
+        <field name="street">Place Cathedrale</field>
+        <field model="res.country" name="country_id" search="[('code','ilike','be')]"/>
+        <field name="zip">4000</field>
+        <field name="city">Liege</field>
+        <field name="email">liege@yourcompany.com</field>
+        <field name="phone">+32 4 222 00 00</field>
+        <field name="website">www.yourcompany.com</field>
+    </record>
+</odoo>

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -43,6 +43,8 @@ class CommonCase(SavepointCase, ComponentMixin):
             serv_config.set(cls.auth_api_key_name, "user", "admin")
             serv_config.set(cls.auth_api_key_name, "key", cls.api_key)
         cls.backend.auth_api_key_name = cls.auth_api_key_name
+        cls.backend_liege = cls.env.ref("shopinvader.backend_liege")
+        cls.company_liege = cls.env.ref("shopinvader.res_company_liege")
 
     @contextmanager
     def work_on_services(self, **params):

--- a/shopinvader/tests/test_shopinvader_partner_binding.py
+++ b/shopinvader/tests/test_shopinvader_partner_binding.py
@@ -105,3 +105,63 @@ class TestShopinvaderPartnerBinding(CommonCase):
         # Ensure the binding is done
         self.assertTrue(shopinv_partner)
         self.assertEquals(shopinv_partner.email, lower_email)
+
+    def test_binding_multicompany(self):
+        shopinv_partner = self._get_shopinvader_partner(
+            self.partner, self.backend
+        )
+        # This partner shouldn't be already binded
+        self.assertFalse(shopinv_partner)
+        context = self.env.context.copy()
+        context.update(
+            {
+                "active_id": self.partner.id,
+                "active_ids": self.partner.ids,
+                "active_model": self.partner._name,
+            }
+        )
+        wizard_obj = self.binding_wiz_obj.with_context(context)
+        fields_list = wizard_obj.fields_get().keys()
+        values = wizard_obj.default_get(fields_list)
+        values.update({"shopinvader_backend_id": self.backend.id})
+        wizard = wizard_obj.create(values)
+        wizard._onchange_shopinvader_backend_id()
+        wizard.binding_lines.write({"bind": True})
+        wizard.action_apply()
+        shopinv_partner = self._get_shopinvader_partner(
+            self.partner, self.backend
+        )
+        # But now we set bind = True so we check if it's done.
+        self.assertTrue(shopinv_partner)
+
+        # Switch to Company Liege
+        company_before = self.env.user.company_id
+        self.env.user.write({"company_id": self.company_liege.id})
+        shopinv_partner = self._get_shopinvader_partner(
+            self.partner, self.backend_liege
+        )
+        # This partner shouldn't be already binded to Liege
+        self.assertFalse(shopinv_partner)
+
+        context = self.env.context.copy()
+        context.update(
+            {
+                "active_id": self.partner.id,
+                "active_ids": self.partner.ids,
+                "active_model": self.partner._name,
+            }
+        )
+        wizard_obj = self.binding_wiz_obj.with_context(context)
+        fields_list = wizard_obj.fields_get().keys()
+        values = wizard_obj.default_get(fields_list)
+        values.update({"shopinvader_backend_id": self.backend_liege.id})
+        wizard = wizard_obj.create(values)
+        wizard._onchange_shopinvader_backend_id()
+        wizard.binding_lines.write({"bind": True})
+        wizard.action_apply()
+        shopinv_partner = self._get_shopinvader_partner(
+            self.partner, self.backend_liege
+        )
+        # But now we set bind = True so we check if it's done.
+        self.assertTrue(shopinv_partner)
+        self.env.user.write({"company_id": company_before.id})

--- a/shopinvader/wizards/shopinvader_partner_binding_line.py
+++ b/shopinvader/wizards/shopinvader_partner_binding_line.py
@@ -38,6 +38,7 @@ class ShopinvaderPartnerBindingLine(models.TransientModel):
         Bind selected partners
         :return: dict
         """
+        shopinvader_partner_obj = self.env["shopinvader.partner"]
         if self.filtered(lambda r: not r.bind):
             message = _(
                 "The unbind is not implemented.\n"
@@ -54,15 +55,16 @@ class ShopinvaderPartnerBindingLine(models.TransientModel):
                 lambda x, b=backend: x.backend_id == b
             )
             if not partner_binding:
-                bind_values = {"backend_id": backend.id}
-                partner_values = {
-                    "shopinvader_bind_ids": [(0, False, bind_values)]
+                bind_values = {
+                    "backend_id": backend.id,
+                    "record_id": record.partner_id.id,
                 }
                 # Locomotive doesn't work with uppercase.
                 # And we have to do the write before the binding
                 email_lower = (record.partner_id.email or "").lower()
                 # Do the update only if necessary
                 if record.partner_id.email != email_lower:
-                    partner_values.update({"email": email_lower})
-                record.partner_id.write(partner_values)
+                    bind_values.update({"email": email_lower})
+
+                shopinvader_partner_obj.create(bind_values)
         return {}


### PR DESCRIPTION
If some backends are defined onto several companies, it could happen that
some partners are shared between companies.

This allows to bind that kind of partners to several backends without
record rule trigger on shopinvader.partner.