### PR TITLE
[12.0][IMP] shopinvader_delivery_carrier change args order

### DIFF
--- a/shopinvader_delivery_carrier/services/abstract_sale.py
+++ b/shopinvader_delivery_carrier/services/abstract_sale.py
@@ -51,7 +51,7 @@ class AbstractSaleService(AbstractComponent):
         )
         return result
 
-    def _prepare_carrier(self, cart, carrier):
+    def _prepare_carrier(self, carrier, cart):
         return {
             "id": carrier.id,
             "name": carrier.name,
@@ -61,7 +61,7 @@ class AbstractSaleService(AbstractComponent):
 
     def _get_available_carrier(self, cart):
         return [
-            self._prepare_carrier(cart, carrier)
+            self._prepare_carrier(carrier, cart)
             for carrier in cart._get_available_carrier()
         ]
 


### PR DESCRIPTION
Change args order to be consistent with  ./delivery_carrier.py/_perpare_carrier 
https://github.com/shopinvader/odoo-shopinvader/blob/12.0/shopinvader_delivery_carrier/services/delivery_carrier.py#L113