### PR TITLE
[12.0][IMP] shopinvader_elasticsearch - change demo index

### DIFF
--- a/shopinvader_elasticsearch/demo/index_config_demo.xml
+++ b/shopinvader_elasticsearch/demo/index_config_demo.xml
@@ -99,8 +99,8 @@
             {
               "settings" : {
                 "index" : {
-                  "sort.field" : ["id"],
-                  "sort.order" : ["asc"]
+                  "sort.field" : ["sequence", "name"],
+                  "sort.order" : ["asc", "asc"]
                 }
               },
               "mappings": {
@@ -113,6 +113,12 @@
                   },
                   "id": {
                     "type":  "integer"
+                  },
+                  "sequence": {
+                     "type": "integer"
+                  },
+                  "name": {
+                     "type": "keyword"
                   }
                 }
               }


### PR DESCRIPTION
Change the demo sort by { sequence, name } instead of { id}.

IMO it makes more sense than sorting by id.
