### PR TITLE
[10.0][FIX] shopinvader: sale service should return so linked to child partners

### DIFF
--- a/shopinvader/services/sale.py
+++ b/shopinvader/services/sale.py
@@ -63,7 +63,7 @@ class SaleService(Component):
     def _get_base_search_domain(self):
         return expression.normalize_domain(
             [
-                ("partner_id", "=", self.partner.id),
+                ("partner_id", "child_of", self.partner.id),
                 ("shopinvader_backend_id", "=", self.shopinvader_backend.id),
                 ("typology", "=", "sale"),
             ]


### PR DESCRIPTION
TO secure delivery address, it is recommended to use partner_address_version and sale_partner_version addons which will archive the address used on confirmed version.

If the customer has only one address and updates, the address will be copied and set as a child of a new one (with updates). Without this pull request, the customer won't be able to see its order anymore because the partner_id on the confirmed So has been changed.