### PR TITLE
[10.0][IMP] shopinvader: Minimum Cerberus version

### DIFF
--- a/setup/shopinvader/setup.py
+++ b/setup/shopinvader/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        "external_dependencies_override": {
+            "python": {
+                "cerberus": "Cerberus>=1.3.2",
+            },
+        },
+    }
 )


### PR DESCRIPTION
As we use check_with in validator, we need at least
Cerberus 1.3.2 library version