### PR TITLE
[13.0][FIX] shopinvader_delivery_carrier: Fix simulation + wrong compute

### DIFF
--- a/shopinvader_delivery_carrier/models/sale.py
+++ b/shopinvader_delivery_carrier/models/sale.py
@@ -15,8 +15,10 @@ class SaleOrder(models.Model):
 
     @api.depends("shopinvader_backend_id")
     def _compute_shopinvader_available_carrier_ids(self):
+        carrier = self.env["delivery.carrier"]
         for order in self:
             if not order.shopinvader_backend_id:
+                order.shopinvader_available_carrier_ids = carrier
                 continue
             order.shopinvader_available_carrier_ids = (
                 order._available_carriers()

--- a/shopinvader_delivery_carrier/tests/test_delivery_carrier.py
+++ b/shopinvader_delivery_carrier/tests/test_delivery_carrier.py
@@ -54,3 +54,76 @@ class TestDeliveryCarrier(CommonCarrierCase):
             ],
         }
         self.assertDictEqual(res, expected)
+
+    def test_search_current_cart_country(self):
+        partner_country = self.cart.partner_id.country_id
+        self.poste_carrier.country_ids = self.env.ref("base.be")
+        self.params = {
+            "target": "current_cart",
+            "country_id": self.env.ref("base.us").id,
+        }
+        res = self.carrier_service.dispatch("search", params=self.params)
+        expected = {
+            "count": 1,
+            "rows": [
+                {
+                    "price": 0.0,
+                    "description": self.free_carrier.name or None,
+                    "id": self.free_carrier.id,
+                    "name": self.free_carrier.name,
+                    "type": None,
+                }
+            ],
+        }
+        self.assertDictEqual(res, expected)
+        # Check if partner country hasn't been modified
+        self.assertEquals(partner_country, self.cart.partner_id.country_id)
+
+    def test_search_current_cart_no_zip(self):
+        # Limit both carriers to countries, one to BE, one to FR
+        # First limit FR carrier to 75000 zip, test on 75100
+        # No carrier should be available
+        partner_zip = self.cart.partner_id.zip
+        self.free_carrier.country_ids = self.env.ref("base.be")
+        self.poste_carrier.country_ids = self.env.ref("base.fr")
+        self.poste_carrier.zip_from = "75000"
+        self.poste_carrier.zip_to = "75000"
+        self.params = {
+            "target": "current_cart",
+            "zip_code": "75100",
+            "country_id": self.env.ref("base.fr").id,
+        }
+        res = self.carrier_service.dispatch("search", params=self.params)
+        expected = {"count": 0, "rows": []}
+        self.assertDictEqual(res, expected)
+        # Check if partner zip hasn't been modified
+        self.assertEquals(partner_zip, self.cart.partner_id.zip)
+
+    def test_search_current_cart_zip(self):
+        # Limit both carriers to countries, one to BE, one to FR
+        # Change carrier zips to 75000 > 75200
+        self.free_carrier.country_ids = self.env.ref("base.be")
+        self.poste_carrier.country_ids = self.env.ref("base.fr")
+
+        # Change carrier zips
+        self.poste_carrier.zip_from = "75000"
+        self.poste_carrier.zip_to = "75200"
+        self.params = {
+            "target": "current_cart",
+            "zip_code": "75100",
+            "country_id": self.env.ref("base.fr").id,
+        }
+        res = self.carrier_service.dispatch("search", params=self.params)
+        expected = {
+            "count": 1,
+            "rows": [
+                {
+                    "price": 0.0,
+                    "description": self.poste_carrier.name or None,
+                    "id": self.poste_carrier.id,
+                    "name": self.poste_carrier.name,
+                    "type": None,
+                }
+            ],
+        }
+        self.assertDictEqual(res, expected)


### PR DESCRIPTION
As in v13, Odoo removed 'do_in_draft()' method from Environment class,
we need to look for another method.

Following Odoo code comments, it seems that replacing that by
'with self.env.protecting():' should do the job to avoid recomputations.

See fields __set__method : https://github.com/odoo/odoo/blob/13.0/odoo/fields.py#L1063

Added a wrong compute fix too (separate commit)