### PR TITLE
[10.0][FIX] - shopinvader_delivery_carrier - flake8 fix

### DIFF
--- a/shopinvader_delivery_carrier/models/stock_picking.py
+++ b/shopinvader_delivery_carrier/models/stock_picking.py
@@ -31,11 +31,10 @@ class StockPicking(models.Model):
         all_move_lines = picking_outgoing.mapped("move_lines")
         backends = picking_outgoing._get_related_backends()
 
-        def filter_line(l, b):
-            lbackend = (
-                l.procurement_id.sale_line_id.order_id.shopinvader_backend_id
-            )
-            return lbackend == b
+        def filter_line(line, backend):
+            order = line.procurement_id.sale_line_id.order_id
+            lbackend = order.shopinvader_backend_id
+            return lbackend == backend
 
         for backend in backends:
             move_lines = all_move_lines.filtered(


### PR DESCRIPTION
Trying to address this flake8 fail:
[shopinvader_delivery_carrier/models/stock_picking.py:34:25: E741 ambiguous variable name 'l'](https://travis-ci.org/github/shopinvader/odoo-shopinvader/jobs/686033918#L281)
to make https://github.com/shopinvader/odoo-shopinvader/pull/631 pass