### PR TITLE
[FIX] shopinvader_quotation: fix validator for search by using default one

### DIFF
--- a/shopinvader_quotation/services/quotation.py
+++ b/shopinvader_quotation/services/quotation.py
@@ -3,7 +3,6 @@
 # Benoît GUILLOT <benoit.guillot@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
 
 
@@ -28,12 +27,7 @@ class QuotationService(Component):
         return {}
 
     def _validator_search(self):
-        return {
-            "id": {"coerce": to_int},
-            "per_page": {"coerce": to_int, "nullable": True},
-            "page": {"coerce": to_int, "nullable": True},
-            "scope": {"type": "dict", "nullable": True},
-        }
+        return self._default_validator_search()
 
     # The following method are 'private' and should be never never NEVER call
     # from the controller.


### PR DESCRIPTION
The validator defined was a useless and an uncomplete override of the default one.