### PR TITLE
[13.0][ENH] shopinvader: Easier product configuration access

### DIFF
--- a/shopinvader/views/shopinvader_variant_view.xml
+++ b/shopinvader/views/shopinvader_variant_view.xml
@@ -42,6 +42,7 @@
                 <sheet>
                     <group name="variant">
                             <field name="name"/>
+                            <field name="shopinvader_product_id"/>
                             <field name="lang_id"/>
                             <field name="default_code"/>
                             <field name="backend_id"/>


### PR DESCRIPTION
Before this PR there was no possible way to access that model on the go, only is available looking for the product in Inventory Product tab.

This PR simply add the possibility to go toShopinvader Product where Product Name, SEO stuff and descriptions are configurable.

