### PR TITLE
[13.0] shopinvader: fix category automatic url compute

### DIFF
--- a/base_url/models/abstract_url.py
+++ b/base_url/models/abstract_url.py
@@ -81,6 +81,7 @@ class AbstractUrl(models.AbstractModel):
         Note the self already include in the context the lang of the record
         """
         self.ensure_one()
+        # TODO: IMO we should add the ID here by default to make sure the URL is always unique
         return [self.name]
 
     def _post_process_url_key(self, key):

--- a/base_url/models/abstract_url.py
+++ b/base_url/models/abstract_url.py
@@ -115,6 +115,10 @@ class AbstractUrl(models.AbstractModel):
             else:
                 record.automatic_url_key = False
 
+    def _compute_automatic_url_key_depends(self):
+        return ["lang_id", "record_id.name"]
+
+    @api.depends(lambda self: self._compute_automatic_url_key_depends())
     def _compute_automatic_url_key(self):
         raise NotImplementedError(
             "Automatic url key must be computed in concrete model"

--- a/shopinvader/models/shopinvader_category.py
+++ b/shopinvader/models/shopinvader_category.py
@@ -16,6 +16,7 @@ class ShopinvaderCategory(models.Model):
     record_id = fields.Many2one(
         "product.category", required=True, ondelete="cascade", index=True
     )
+    # TODO: Is this really needed? Both fields are indexed.
     object_id = fields.Integer(
         compute="_compute_object_id", store=True, index=True
     )

--- a/shopinvader/tests/__init__.py
+++ b/shopinvader/tests/__init__.py
@@ -8,6 +8,7 @@ from . import test_partner_validation
 from . import test_partner_access_info
 from . import test_product
 from . import test_sale
+from . import test_shopinvader_category
 from . import test_shopinvader_variant_binding_wizard
 from . import test_shopinvader_category_binding_wizard
 from . import test_customer

--- a/shopinvader/tests/test_notification.py
+++ b/shopinvader/tests/test_notification.py
@@ -1,5 +1,7 @@
 # Copyright 2017 Akretion (http://www.akretion.com).
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
+# Copyright 2019 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simone.orsi@camptocamp.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from .common import CommonCase

--- a/shopinvader/tests/test_salesman_notification.py
+++ b/shopinvader/tests/test_salesman_notification.py
@@ -1,5 +1,5 @@
-# Copyright 2017 Akretion (http://www.akretion.com).
-# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# Copyright 2019 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simone.orsi@camptocamp.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from .common import CommonCase

--- a/shopinvader/tests/test_shopinvader_category.py
+++ b/shopinvader/tests/test_shopinvader_category.py
@@ -1,0 +1,64 @@
+# Copyright 2020 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
+from odoo.addons.component.tests.common import SavepointComponentCase
+
+from .common import CommonMixin
+
+
+class TestShopinvaderCategoryBase(SavepointComponentCase, CommonMixin):
+    @classmethod
+    def setUpClass(cls):
+        super(TestShopinvaderCategoryBase, cls).setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.backend = cls.env.ref("shopinvader.backend_1")
+        cls.backend2 = cls.env.ref("shopinvader.backend_2")
+        cls.product_category = cls.env.ref("product.product_category_4")
+        cls.category_bind_model = cls.env["shopinvader.category"]
+        cat_obj = cls.env["product.category"]
+
+        cls.cat_level1 = cat_obj.create({"name": "Category Level 1"})
+        cls.cat_level2 = cat_obj.create(
+            {"name": "Category Level 2", "parent_id": cls.cat_level1.id}
+        )
+        cls.cat_level3 = cat_obj.create(
+            {"name": "Category Level 3", "parent_id": cls.cat_level2.id}
+        )
+        cls.cat_level1._parent_store_compute()
+
+
+class TestShopinvaderCategory(TestShopinvaderCategoryBase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestShopinvaderCategory, cls).setUpClass()
+        cls.binding_l1 = cls._create_binding(cls.cat_level1)
+        cls.binding_l2 = cls._create_binding(cls.cat_level2)
+        cls.binding_l3 = cls._create_binding(cls.cat_level3)
+
+    @classmethod
+    def _create_binding(cls, product_category, **kw):
+        vals = {
+            "backend_id": cls.backend.id,
+            "record_id": product_category.id,
+            "lang_id": cls.env.ref("base.lang_en").id,
+        }
+        vals.update(kw)
+        return cls.category_bind_model.create(vals)
+
+    def test_category_url(self):
+        self.assertEqual(self.binding_l1.url_key, "category-level-1")
+        self.assertEqual(
+            self.binding_l2.url_key, "category-level-1/category-level-2"
+        )
+        self.assertEqual(
+            self.binding_l3.url_key,
+            "category-level-1/category-level-2/category-level-3",
+        )
+
+    def test_category_url_inactive_parent(self):
+        self.binding_l1.active = False
+        self.assertEqual(self.binding_l2.url_key, "category-level-2")
+        self.assertEqual(
+            self.binding_l3.url_key, "category-level-2/category-level-3"
+        )
+        self.binding_l2.active = False
+        self.assertEqual(self.binding_l3.url_key, "category-level-3")

--- a/shopinvader/tests/test_shopinvader_category_binding_wizard.py
+++ b/shopinvader/tests/test_shopinvader_category_binding_wizard.py
@@ -1,35 +1,17 @@
 # Copyright 2016 Cédric Pigeon
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo.addons.component.tests.common import SavepointComponentCase
 
-from .common import CommonMixin
+from .test_shopinvader_category import TestShopinvaderCategoryBase
 
 
-class TestShopinvaderCategoryBindingWizard(
-    SavepointComponentCase, CommonMixin
-):
+class TestShopinvaderCategoryBindingWizard(TestShopinvaderCategoryBase):
     @classmethod
     def setUpClass(cls):
         super(TestShopinvaderCategoryBindingWizard, cls).setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.backend = cls.env.ref("shopinvader.backend_1")
-        cls.backend2 = cls.env.ref("shopinvader.backend_2")
-        cls.product_category = cls.env.ref("product.product_category_4")
         cls.bind_wizard_model = cls.env["shopinvader.category.binding.wizard"]
         cls.unbind_wizard_model = cls.env[
             "shopinvader.category.unbinding.wizard"
         ]
-        cls.category_bind_model = cls.env["shopinvader.category"]
-        cat_obj = cls.env["product.category"]
-
-        cls.cat_level1 = cat_obj.create({"name": "Category Level 1"})
-        cls.cat_level2 = cat_obj.create(
-            {"name": "Category Level 2", "parent_id": cls.cat_level1.id}
-        )
-        cls.cat_level3 = cat_obj.create(
-            {"name": "Category Level 3", "parent_id": cls.cat_level2.id}
-        )
-        cls.cat_level1._parent_store_compute()
 
     def test_category_binding(self):
         """


### PR DESCRIPTION
Computation was broken when the parent binding was archived.
Moreover this commit eases overrides of depends for the computation.

@sebastienbeau this should fix the issue w/ debugged some weeks ago.