### PR TITLE
[13.0][FWD] shopinvader - Document generate/download (pdf)

### DIFF
--- a/shopinvader/controllers/main.py
+++ b/shopinvader/controllers/main.py
@@ -20,11 +20,11 @@ class InvaderController(main.RestController):
     _collection_name = "shopinvader.backend"
     _default_auth = "api_key"
 
-    @route(["/shopinvader/invoice/<int:_id>/download"], methods=["GET"])
-    def invoice_download(self, _id=None, **params):
+    @route(["/shopinvader/<service>/<int:_id>/download"], methods=["GET"])
+    def service_download(self, service, _id=None, **params):
         params["id"] = _id
         return self._process_method(
-            "invoice", "download", _id=_id, params=params
+            service, "download", _id=_id, params=params
         )
 
     @classmethod

--- a/shopinvader/services/__init__.py
+++ b/shopinvader/services/__init__.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import service
+from . import abstract_download
 from . import abstract_mail
 from . import abstract_sale
 from . import cart

--- a/shopinvader/services/abstract_download.py
+++ b/shopinvader/services/abstract_download.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import mimetypes
+
+from odoo import _
+from odoo.addons.base_rest.components.service import (
+    skip_secure_response,
+    to_int,
+)
+from odoo.addons.component.core import AbstractComponent
+from odoo.exceptions import MissingError
+from odoo.http import content_disposition, request
+
+
+class AbstractDownload(AbstractComponent):
+    """
+    Class used to define behaviour to generate and download a document.
+    You only have to inherit this AbstractComponent and implement the function
+    _get_report_action(...).
+
+    Example for invoice service:
+    Class InvoiceService(Component):
+        _inherit = [
+            "base.shopinvader.service",
+            "abstract.shopinvader.download",
+        ]
+        _name = "shopinvader.invoice.service"
+
+        def _get_report_action(self, target, params):
+            return target.invoice_print()
+    """
+
+    _name = "abstract.shopinvader.download"
+
+    # This function should be overwritten
+    def _get_report_action(self, target, params=None):
+        """
+        Get the action/dict to generate the report
+        :param target: recordset
+        :param params: dict
+        :return: dict/action
+        """
+        raise NotImplementedError()
+
+    def _validator_download(self):
+        """
+        Validate the input of download function
+        :return: dict
+        """
+        return {"id": {"type": "integer", "required": True, "coerce": to_int}}
+
+    @skip_secure_response
+    def download(self, _id, **params):
+        """
+        Get target file. This method is also callable by HTTP GET
+        """
+        params = params or {}
+        target = self._get(_id)
+        headers, content = self._get_binary_content(target, params=params)
+        if not content:
+            raise MissingError(_("No content found for %s") % _id)
+        response = request.make_response(content, headers)
+        response.status_code = 200
+        return response
+
+    def _get_binary_content(self, target, params=None):
+        """
+        Generate the report for the given target
+        :param target:
+        :param params: dict
+        :returns: (headers, content)
+        """
+        # Ensure the report is generated
+        target_report_def = self._get_report_action(target, params=params)
+        report_name = target_report_def.get("report_name")
+        report_type = target_report_def.get("report_type")
+        content, file_format = self.env["ir.actions.report.xml"].render_report(
+            res_ids=target.ids,
+            name=report_name,
+            data={"report_type": report_type},
+        )
+        report = self._get_report(report_name, report_type, params=params)
+        filename = self._get_binary_content_filename(
+            target, report, file_format, params=params
+        )
+        mimetype = mimetypes.guess_type(filename)
+        if mimetype:
+            mimetype = mimetype[0]
+        headers = [
+            ("Content-Type", mimetype),
+            ("X-Content-Type-Options", "nosniff"),
+            ("Content-Disposition", content_disposition(filename)),
+            ("Content-Length", len(content)),
+        ]
+        return headers, content
+
+    def _get_report(self, report_name, report_type, params=None):
+        """
+        Load the report recordset
+        :param report_name: str
+        :param report_type: str
+        :param params: dict
+        :return: ir.actions.report.xml recordset
+        """
+        domain = [
+            ("report_type", "=", report_type),
+            ("report_name", "=", report_name),
+        ]
+        return self.env["ir.actions.report.xml"].search(domain, limit=1)
+
+    def _get_binary_content_filename(
+        self, target, report, format, params=None
+    ):
+        """
+        Build the filename
+        :param target: recordset
+        :param report: ir.actions.report.xml recordset
+        :param format: str
+        :param params: dict
+        :return: str
+        """
+        return "{}.{}".format(report.name, format)

--- a/shopinvader/services/invoice.py
+++ b/shopinvader/services/invoice.py
@@ -1,16 +1,14 @@
 # Copyright 2019 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-import mimetypes
-import time
-
-from odoo import _
 from odoo.addons.component.core import Component
 from odoo.osv import expression
-from odoo.tools.safe_eval import safe_eval
 
 
 class InvoiceService(Component):
-    _inherit = ["base.shopinvader.service", "abstract.shopinvader.download"]
+    _inherit = [
+        "shopinvader.abstract.mail.service",
+        "abstract.shopinvader.download",
+    ]
     _name = "shopinvader.invoice.service"
     _usage = "invoice"
     _expose_model = "account.move"
@@ -50,7 +48,7 @@ class InvoiceService(Component):
         Get every invoice states allowed to return on the service.
         :return: list of str
         """
-        return ["paid"]
+        return ["posted"]
 
     def _get_base_search_domain(self):
         """
@@ -88,4 +86,6 @@ class InvoiceService(Component):
         :param target: recordset
         :return: dict/action
         """
-        return target.invoice_print()
+        return self.env.ref("account.account_invoices").report_action(
+            target, config=False
+        )

--- a/shopinvader/services/invoice.py
+++ b/shopinvader/services/invoice.py
@@ -4,19 +4,13 @@ import mimetypes
 import time
 
 from odoo import _
-from odoo.addons.base_rest.components.service import (
-    skip_secure_response,
-    to_int,
-)
 from odoo.addons.component.core import Component
-from odoo.exceptions import MissingError
-from odoo.http import content_disposition, request
 from odoo.osv import expression
 from odoo.tools.safe_eval import safe_eval
 
 
 class InvoiceService(Component):
-    _inherit = "shopinvader.abstract.mail.service"
+    _inherit = ["base.shopinvader.service", "abstract.shopinvader.download"]
     _name = "shopinvader.invoice.service"
     _usage = "invoice"
     _expose_model = "account.move"
@@ -24,19 +18,6 @@ class InvoiceService(Component):
 
     # The following method are 'public' and can be called from the controller.
     # All params are untrusted so please check it !
-
-    @skip_secure_response
-    def download(self, _id, **params):
-        """
-        Get invoice file. This method is also callable by HTTP GET
-        """
-        invoice = self._get(_id)
-        headers, content = self._get_binary_content(invoice)
-        if not content:
-            raise MissingError(_("No invoice found with id %s") % _id)
-        response = request.make_response(content, headers)
-        response.status_code = 200
-        return response
 
     def to_openapi(self):
         res = super(InvoiceService, self).to_openapi()
@@ -62,12 +43,14 @@ class InvoiceService(Component):
         }
         return res
 
-    # Validator
-
-    def _validator_download(self):
-        return {"id": {"type": "integer", "required": True, "coerce": to_int}}
-
     # Private implementation
+
+    def _get_allowed_invoice_states(self):
+        """
+        Get every invoice states allowed to return on the service.
+        :return: list of str
+        """
+        return ["paid"]
 
     def _get_base_search_domain(self):
         """
@@ -94,49 +77,15 @@ class InvoiceService(Component):
         # and check if the invoice_id is into the list of sale.invoice_ids
         sales = self.env["sale.order"].search(so_domain)
         invoice_ids = sales.mapped("invoice_ids").ids
+        states = self._get_allowed_invoice_states()
         return expression.normalize_domain(
-            [("id", "in", invoice_ids), ("invoice_payment_state", "=", "paid")]
+            [("id", "in", invoice_ids), ("state", "in", states)]
         )
 
-    def _get_binary_content(self, invoice):
+    def _get_report_action(self, target, params=None):
         """
-        Generate the invoice report....
-        :param invoice:
-          :returns: (headers, content)
+        Get the action/dict to generate the report
+        :param target: recordset
+        :return: dict/action
         """
-        # ensure the report is generated
-        invoice_report_def = invoice.action_invoice_print()
-        report_name = invoice_report_def["report_name"]
-        report_type = invoice_report_def["report_type"]
-        report = self._get_report(report_name, report_type)
-        content, extension = report.render(
-            invoice.ids, data={"report_type": report_type}
-        )
-        filename = self._get_binary_content_filename(
-            invoice, report, extension
-        )
-        mimetype = mimetypes.guess_type(filename)
-        if mimetype:
-            mimetype = mimetype[0]
-        headers = [
-            ("Content-Type", mimetype),
-            ("X-Content-Type-Options", "nosniff"),
-            ("Content-Disposition", content_disposition(filename)),
-            ("Content-Length", len(content)),
-        ]
-        return headers, content
-
-    def _get_report(self, report_name, report_type):
-        domain = [
-            ("report_type", "=", report_type),
-            ("report_name", "=", report_name),
-        ]
-        return self.env["ir.actions.report"].search(domain)
-
-    def _get_binary_content_filename(self, invoice, report, extension):
-        if report.print_report_name and not len(invoice) > 1:
-            report_name = safe_eval(
-                report.print_report_name, {"object": invoice, "time": time}
-            )
-            return "{}.{}".format(report_name, extension)
-        return "{}.{}".format(report.name, extension)
+        return target.invoice_print()

--- a/shopinvader/services/sale.py
+++ b/shopinvader/services/sale.py
@@ -1,14 +1,16 @@
 # Copyright 2017 Akretion (http://www.akretion.com).
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
 from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
 from odoo.osv import expression
 
 
 class SaleService(Component):
-    _inherit = "shopinvader.abstract.sale.service"
+    _inherit = [
+        "shopinvader.abstract.sale.service",
+        "abstract.shopinvader.download",
+    ]
     _name = "shopinvader.sale.service"
     _usage = "sales"
     _expose_model = "sale.order"
@@ -22,6 +24,15 @@ class SaleService(Component):
 
     def search(self, **params):
         return self._paginate_search(**params)
+
+    def _get_report_action(self, target, params=None):
+        """
+        Get the action/dict to generate the report
+        :param target: recordset
+        :param params: dict
+        :return: dict/action
+        """
+        return target.print_quotation()
 
     def ask_email_invoice(self, _id):
         """

--- a/shopinvader/services/sale.py
+++ b/shopinvader/services/sale.py
@@ -32,7 +32,9 @@ class SaleService(Component):
         :param params: dict
         :return: dict/action
         """
-        return target.print_quotation()
+        return self.env.ref("sale.action_report_saleorder").report_action(
+            target, config=False
+        )
 
     def ask_email_invoice(self, _id):
         """

--- a/shopinvader/services/sale.py
+++ b/shopinvader/services/sale.py
@@ -64,7 +64,7 @@ class SaleService(Component):
     def _get_base_search_domain(self):
         return expression.normalize_domain(
             [
-                ("partner_id", "=", self.partner.id),
+                ("partner_id", "child_of", self.partner.id),
                 ("shopinvader_backend_id", "=", self.shopinvader_backend.id),
                 ("typology", "=", "sale"),
             ]

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -11,7 +11,6 @@ from odoo.addons.base_rest.tests.common import BaseRestCase
 from odoo.addons.component.core import WorkContext
 from odoo.addons.component.tests.common import ComponentMixin
 from odoo.addons.queue_job.job import Job
-from odoo.addons.server_environment import serv_config
 from odoo.exceptions import MissingError
 from odoo.tests import SavepointCase
 
@@ -149,19 +148,6 @@ class ShopinvaderRestCase(BaseRestCase):
         # To ensure multi-backend works correctly, we just have to create
         # a new one on the same company.
         self.backend_copy = self.env.ref("shopinvader.backend_2")
-        self.api_key = "myApiKey"
-        self.api_key2 = "myApiKey2"
-        self.auth_api_key_name = self.AUTH_API_KEY_NAME
-        self.auth_api_key_name2 = self.AUTH_API_KEY_NAME2
-        if self.auth_api_key_name not in serv_config.sections():
-            serv_config.add_section(self.auth_api_key_name)
-            serv_config.set(self.auth_api_key_name, "user", "admin")
-            serv_config.set(self.auth_api_key_name, "key", self.api_key)
-        if self.auth_api_key_name2 not in serv_config.sections():
-            serv_config.add_section(self.auth_api_key_name2)
-            serv_config.set(self.auth_api_key_name2, "user", "admin")
-            serv_config.set(self.auth_api_key_name2, "key", self.api_key2)
-        self.backend.auth_api_key_name = self.auth_api_key_name2
 
 
 class CommonTestDownload(object):

--- a/shopinvader/tests/test_invoice.py
+++ b/shopinvader/tests/test_invoice.py
@@ -1,8 +1,6 @@
 # Copyright 2019 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-import mock
 from odoo import fields
-from odoo.exceptions import MissingError
 
 from .common import CommonCase, CommonTestDownload
 

--- a/shopinvader_delivery_carrier/tests/test_delivery_service.py
+++ b/shopinvader_delivery_carrier/tests/test_delivery_service.py
@@ -1,13 +1,14 @@
 # Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from uuid import uuid4
 
 from dateutil import parser
 from odoo import fields
-from odoo.addons.shopinvader.tests.common import CommonCase
+from odoo.addons.shopinvader.tests.common import CommonCase, CommonTestDownload
 
 
-class TestDeliveryService(CommonCase):
+class TestDeliveryService(CommonCase, CommonTestDownload):
 
     maxDiff = None
 
@@ -236,3 +237,37 @@ class TestDeliveryService(CommonCase):
         data = result.get("data", [])
         self._check_data_content(data, pickings)
         return
+
+    def test_picking_download(self):
+        """
+        Data
+            * A target with a valid state
+        Case:
+            * Try to download the document
+        Expected result:
+            * An http response with the file to download
+        :param service: shopinvader service
+        :param target: recordset
+        :return:
+        """
+        picking = self._create_picking(partner=self.service.partner, sale=True)
+        self.assertEqual(picking.state, "confirmed")
+        self._test_download_allowed(self.service, picking)
+
+    def test_picking_download_failed(self):
+        """
+        Data
+            * A picking into an invalid/not allowed state
+        Case:
+            * Try to download the document
+        Expected result:
+            * MissingError should be raised
+        :param service: shopinvader service
+        :param target: recordset
+        :return:
+        """
+        picking = self._create_picking(
+            partner=self.service.partner, sale=False
+        )
+        self.assertEqual(picking.state, "draft")
+        self._test_download_not_allowed(self.service, picking)

--- a/shopinvader_quotation/models/sale.py
+++ b/shopinvader_quotation/models/sale.py
@@ -29,7 +29,6 @@ class SaleOrder(models.Model):
             return "estimated"
         return super()._get_shopinvader_state()
 
-    @api.multi
     def action_request_quotation(self):
         for cart in self:
             if cart.state == "draft" and cart.typology == "cart":

--- a/shopinvader_quotation/services/quotation.py
+++ b/shopinvader_quotation/services/quotation.py
@@ -7,7 +7,10 @@ from odoo.addons.component.core import Component
 
 
 class QuotationService(Component):
-    _inherit = "shopinvader.abstract.sale.service"
+    _inherit = [
+        "shopinvader.abstract.sale.service",
+        "abstract.shopinvader.download",
+    ]
     _name = "shopinvader.quotation.service"
     _usage = "quotations"
     _expose_model = "sale.order"
@@ -21,6 +24,15 @@ class QuotationService(Component):
 
     def search(self, **params):
         return self._paginate_search(**params)
+
+    def _get_report_action(self, target, params=None):
+        """
+        Get the action/dict to generate the report
+        :param target: recordset
+        :param params: dict
+        :return: dict/action
+        """
+        return target.print_quotation()
 
     # Validator
     def _validator_get(self):

--- a/shopinvader_quotation/services/quotation.py
+++ b/shopinvader_quotation/services/quotation.py
@@ -32,7 +32,9 @@ class QuotationService(Component):
         :param params: dict
         :return: dict/action
         """
-        return target.print_quotation()
+        return self.env.ref("sale.action_report_saleorder").report_action(
+            target, config=False
+        )
 
     # Validator
     def _validator_get(self):

--- a/shopinvader_quotation/tests/__init__.py
+++ b/shopinvader_quotation/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_quotation
 from . import test_notification
+from . import test_quotation_download

--- a/shopinvader_quotation/tests/test_quotation_download.py
+++ b/shopinvader_quotation/tests/test_quotation_download.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.shopinvader.tests.common import CommonCase, CommonTestDownload
+
+
+class QuotationDownloadCase(CommonCase, CommonTestDownload):
+    def setUp(self, *args, **kwargs):
+        super(QuotationDownloadCase, self).setUp(*args, **kwargs)
+        self.quotation = self.env.ref("shopinvader.sale_order_2")
+        self.quotation.write({"typology": "quotation"})
+        self.partner = self.env.ref("shopinvader.partner_1")
+        with self.work_on_services(partner=self.partner) as work:
+            self.service = work.component(usage="quotations")
+
+    def test_quotation_download(self):
+        self.assertEqual(self.quotation.typology, "quotation")
+        self._test_download_allowed(self.service, self.quotation)

--- a/shopinvader_quotation/tests/test_quotation_download.py
+++ b/shopinvader_quotation/tests/test_quotation_download.py
@@ -6,13 +6,14 @@ from odoo.addons.shopinvader.tests.common import CommonCase, CommonTestDownload
 
 
 class QuotationDownloadCase(CommonCase, CommonTestDownload):
-    def setUp(self, *args, **kwargs):
-        super(QuotationDownloadCase, self).setUp(*args, **kwargs)
-        self.quotation = self.env.ref("shopinvader.sale_order_2")
-        self.quotation.write({"typology": "quotation"})
-        self.partner = self.env.ref("shopinvader.partner_1")
-        with self.work_on_services(partner=self.partner) as work:
-            self.service = work.component(usage="quotations")
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super().setUpClass(*args, **kwargs)
+        cls.quotation = cls.env.ref("shopinvader.sale_order_2")
+        cls.quotation.write({"typology": "quotation"})
+        cls.partner = cls.env.ref("shopinvader.partner_1")
+        with cls.work_on_services(partner=cls.partner) as work:
+            cls.service = work.component(usage="quotations")
 
     def test_quotation_download(self):
         self.assertEqual(self.quotation.typology, "quotation")


### PR DESCRIPTION
forward port of #570 

Create an abstract component to generate and download a report from the front side.

- Extract the download part of invoice service;
- Create an abstract component;
- Apply it on invoice service;
- Apply it on sale service;
- Extract tests about download (and make a new class);
- Apply this test class on invoice + sale tests.

forward  https://github.com/shopinvader/odoo-shopinvader/pull/621