### PR TITLE
s_locomotive_algolia: do not expose private key

### DIFF
--- a/shopinvader_locomotive_algolia/__init__.py
+++ b/shopinvader_locomotive_algolia/__init__.py
@@ -1,1 +1,2 @@
 from . import component
+from . import models

--- a/shopinvader_locomotive_algolia/__manifest__.py
+++ b/shopinvader_locomotive_algolia/__manifest__.py
@@ -12,4 +12,5 @@
     "author": "Camptcamp SA",
     "website": "https://github.com/shopinvader/odoo-shopinvader",
     "depends": ["component", "shopinvader_locomotive", "shopinvader_algolia"],
+    "data": ["views/se_backend_algolia.xml"],
 }

--- a/shopinvader_locomotive_algolia/component/shopinvader_site_export_mapper.py
+++ b/shopinvader_locomotive_algolia/component/shopinvader_site_export_mapper.py
@@ -19,7 +19,7 @@ class ShopinvaderSiteExportMapper(Component):
             config.update(
                 {
                     "application_id": spec_backend.algolia_app_id,
-                    "api_key": spec_backend.algolia_api_key,
+                    "api_key": spec_backend.algolia_api_key_public,
                 }
             )
         return config

--- a/shopinvader_locomotive_algolia/models/__init__.py
+++ b/shopinvader_locomotive_algolia/models/__init__.py
@@ -1,0 +1,1 @@
+from . import se_backend_algolia

--- a/shopinvader_locomotive_algolia/models/se_backend_algolia.py
+++ b/shopinvader_locomotive_algolia/models/se_backend_algolia.py
@@ -1,0 +1,25 @@
+# Copyright 2020 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo import fields, models
+
+
+class SeBackendAlgolia(models.Model):
+    _inherit = "se.backend.algolia"
+
+    # change help msg
+    algolia_api_key = fields.Char(
+        help="Admin API key with rights to write on indexes"
+    )
+    algolia_api_key_public = fields.Char(
+        string="Public API KEY",
+        help="Readonly API key with rights to search only",
+    )
+
+    @property
+    def _server_env_fields(self):
+        env_fields = super()._server_env_fields
+        env_fields.update({"algolia_api_key_public": {}})
+        return env_fields

--- a/shopinvader_locomotive_algolia/tests/test_search_engine_site_export.py
+++ b/shopinvader_locomotive_algolia/tests/test_search_engine_site_export.py
@@ -31,7 +31,10 @@ class TestSiteSearchEngineExport(Base):
     def _setup_search_engine(cls):
         cls.specific_backend = cls.env.ref("connector_algolia.se_algolia_demo")
         cls.specific_backend.write(
-            {"algolia_app_id": "ABCDEFG", "algolia_api_key": "123456789"}
+            {
+                "algolia_app_id": "ABCDEFG",
+                "algolia_api_key_public": "123456789",
+            }
         )
         cls.backend.se_backend_id = cls.specific_backend.se_backend_id
         cls.search_engine_name = cls.backend.se_backend_id.search_engine_name

--- a/shopinvader_locomotive_algolia/views/se_backend_algolia.xml
+++ b/shopinvader_locomotive_algolia/views/se_backend_algolia.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+  <record model="ir.ui.view" id="se_backend_algolia_form_view">
+    <field name="model">se.backend.algolia</field>
+    <field name="inherit_id" ref="connector_algolia.se_backend_algolia_form_view" />
+    <field name="arch" type="xml">
+      <field name="algolia_api_key" position="after">
+        <field name="algolia_api_key_public" />
+      </field>
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
Prior to this change the private API key was sent to Locomotive frontend
which exposes it into pages source code (!!!).

In any case, Locomotive does not need any admin access to the indexes.

This change fixes the security breach.