### PR TITLE
[13.0][IMP] shopinvader_delivery_carrier: Take shipping cost from carrier selected correctly

### DIFF
--- a/shopinvader_delivery_carrier/models/sale.py
+++ b/shopinvader_delivery_carrier/models/sale.py
@@ -49,10 +49,15 @@ class SaleOrder(models.Model):
         wizard = (
             self.env["choose.delivery.carrier"]
             .with_context(
-                {"default_order_id": self.id, "default_carrier_id": carrier_id}
+                {
+                    "default_order_id": self.id,
+                    "default_carrier_id": carrier_id,
+                    "carrier_recompute": True,
+                }
             )
             .create({})
         )
         wizard._onchange_carrier_id()
+        wizard.save()
         wizard.button_confirm()
-        return wizard.delivery_price
+        return True


### PR DESCRIPTION
Regarding https://github.com/odoo/odoo/blob/a3fdff3dd9cc38b432b93a7cd4387cb7c38b8d06/addons/delivery/models/sale_order.py#L54 I think carrier_recompute has to be set when creating the wizard in the backend for the correct computation of the shipping costs.

CC @rousseldenis 