### PR TITLE
Fix odoo warning about _company_default_get deprecated

### DIFF
--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -190,9 +190,7 @@ class ShopinvaderBackend(models.Model):
 
     @api.model
     def _default_company_id(self):
-        return self.env["res.company"]._company_default_get(
-            "shopinvader.backend"
-        )
+        return self.env.company
 
     @api.model
     def _default_partner_title_ids(self):


### PR DESCRIPTION
Could have used `default=lambda self: self.env.company` directly in the field, but not sure if anyone may have a customization of `_default_company_id()` already.