### PR TITLE
[13.0][ADD] shopinvader-customer-special-product

### DIFF
--- a/shopinvader_customer_special_product/__init__.py
+++ b/shopinvader_customer_special_product/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import tests

--- a/shopinvader_customer_special_product/__manifest__.py
+++ b/shopinvader_customer_special_product/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Shopinvader Customer Special Product",
     "summary": "Manage Product Made Specificly For Some Customers",
-    "version": "13.0.1.2.0",
+    "version": "13.0.1.0.0",
     "category": "e-commerce",
     "website": "https://github.com/shopinvader/odoo-shopinvader",
     "author": "Campotcamp",

--- a/shopinvader_customer_special_product/__manifest__.py
+++ b/shopinvader_customer_special_product/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+{
+    "name": "Shopinvader Customer Special Product",
+    "summary": "Manage Product Made Specificly For Some Customers",
+    "version": "13.0.1.2.0",
+    "category": "e-commerce",
+    "website": "https://github.com/shopinvader/odoo-shopinvader",
+    "author": "Campotcamp",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["shopinvader"],
+    "data": ["data/ir_export_product.xml", "views/product_template.xml"],
+}

--- a/shopinvader_customer_special_product/data/ir_export_product.xml
+++ b/shopinvader_customer_special_product/data/ir_export_product.xml
@@ -2,7 +2,7 @@
 <odoo>
 
     <record id="ir_exp_shopinvader_variant_partner_ids" model="ir.exports.line">
-        <field name="name">manufactured_for_partners</field>
+        <field name="name">procured_for_partners</field>
         <field name="export_id" ref="shopinvader.ir_exp_shopinvader_variant"/>
     </record>
 

--- a/shopinvader_customer_special_product/data/ir_export_product.xml
+++ b/shopinvader_customer_special_product/data/ir_export_product.xml
@@ -2,8 +2,7 @@
 <odoo>
 
     <record id="ir_exp_shopinvader_variant_partner_ids" model="ir.exports.line">
-        <field name="name">export_manufactured_for_partner_ids</field>
-        <field name="alias">export_manufactured_for_partner_ids:partners</field>
+        <field name="name">manufactured_for_partners</field>
         <field name="export_id" ref="shopinvader.ir_exp_shopinvader_variant"/>
     </record>
 

--- a/shopinvader_customer_special_product/data/ir_export_product.xml
+++ b/shopinvader_customer_special_product/data/ir_export_product.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="ir_exp_shopinvader_variant_partner_ids" model="ir.exports.line">
+        <field name="name">export_manufactured_for_partner_ids</field>
+        <field name="alias">export_manufactured_for_partner_ids:partners</field>
+        <field name="export_id" ref="shopinvader.ir_exp_shopinvader_variant"/>
+    </record>
+
+</odoo>

--- a/shopinvader_customer_special_product/models/__init__.py
+++ b/shopinvader_customer_special_product/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product
+from . import shopinvader_variant

--- a/shopinvader_customer_special_product/models/product.py
+++ b/shopinvader_customer_special_product/models/product.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    manufactured_for_partner_ids = fields.Many2many(
+        comodel_name="res.partner",
+        domain=[("customer_rank", ">", 0)],
+        string="Manufactured for",
+    )

--- a/shopinvader_customer_special_product/models/product.py
+++ b/shopinvader_customer_special_product/models/product.py
@@ -7,8 +7,8 @@ from odoo import fields, models
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    manufactured_for_partner_ids = fields.Many2many(
+    procured_for_partner_ids = fields.Many2many(
         comodel_name="res.partner",
         domain=[("customer_rank", ">", 0)],
-        string="Manufactured for",
+        string="Procured for",
     )

--- a/shopinvader_customer_special_product/models/shopinvader_variant.py
+++ b/shopinvader_customer_special_product/models/shopinvader_variant.py
@@ -1,0 +1,18 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+from odoo.addons.base_sparse_field.models.fields import Serialized
+
+
+class ShopinvaderVariant(models.Model):
+    _inherit = "shopinvader.variant"
+
+    export_manufactured_for_partner_ids = Serialized(compute="_compute_export_manufactured_for_partner_ids")
+
+    def _compute_export_manufactured_for_partner_ids(self):
+        for record in self:
+            if record.manufactured_for_partner_ids:
+                record.export_manufactured_for_partner_ids = record.manufactured_for_partner_ids.ids
+            else:
+                record.export_manufactured_for_partner_ids = False

--- a/shopinvader_customer_special_product/models/shopinvader_variant.py
+++ b/shopinvader_customer_special_product/models/shopinvader_variant.py
@@ -8,11 +8,10 @@ from odoo.addons.base_sparse_field.models.fields import Serialized
 class ShopinvaderVariant(models.Model):
     _inherit = "shopinvader.variant"
 
-    manufactured_for_partners = Serialized(compute="_compute_manufactured_for_partners")
+    procured_for_partners = Serialized(
+        compute="_compute_procured_for_partners"
+    )
 
-    def _compute_export_manufactured_for_partner_ids(self):
+    def _compute_procured_for_partners(self):
         for record in self:
-            if record.manufactured_for_partner_ids:
-                record.export_manufactured_for_partner_ids = record.manufactured_for_partner_ids.ids
-            else:
-                record.export_manufactured_for_partner_ids = False
+            record.procured_for_partners = record.procured_for_partner_ids.ids

--- a/shopinvader_customer_special_product/models/shopinvader_variant.py
+++ b/shopinvader_customer_special_product/models/shopinvader_variant.py
@@ -8,7 +8,7 @@ from odoo.addons.base_sparse_field.models.fields import Serialized
 class ShopinvaderVariant(models.Model):
     _inherit = "shopinvader.variant"
 
-    export_manufactured_for_partner_ids = Serialized(compute="_compute_export_manufactured_for_partner_ids")
+    manufactured_for_partners = Serialized(compute="_compute_manufactured_for_partners")
 
     def _compute_export_manufactured_for_partner_ids(self):
         for record in self:

--- a/shopinvader_customer_special_product/readme/CONTRIBUTORS.rst
+++ b/shopinvader_customer_special_product/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/shopinvader_customer_special_product/readme/CONTRIBUTORS.rst
+++ b/shopinvader_customer_special_product/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Thierry Ducrest <thierry.ducrest@camptocamp.com>
+* Simone Orsi <simahawk@gmail.com>

--- a/shopinvader_customer_special_product/readme/DESCRIPTION.rst
+++ b/shopinvader_customer_special_product/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module adds the possibility to flag some products to be sold only to
+specific customers.

--- a/shopinvader_customer_special_product/tests/test_customer_special_product.py
+++ b/shopinvader_customer_special_product/tests/test_customer_special_product.py
@@ -12,10 +12,10 @@ class TestCustomerSpecialProduct(ProductCommonCase):
         cls.ir_export = cls.env.ref("shopinvader.ir_exp_shopinvader_variant")
         cls.parser = cls.ir_export.get_json_parser()
         cls.customer = cls.env.ref("base.res_partner_2")
-        cls.shopinvader_variant.record_id.manufactured_for_partner_ids = [
+        cls.shopinvader_variant.record_id.procured_for_partner_ids = [
             (6, 0, cls.customer.ids)
         ]
 
     def test_extra_fields(self):
         data = self.shopinvader_variant.jsonify(self.parser)[0]
-        self.assertEqual(data["partners"], self.customer.ids)
+        self.assertEqual(data["procured_for_partners"], self.customer.ids)

--- a/shopinvader_customer_special_product/tests/test_customer_special_product.py
+++ b/shopinvader_customer_special_product/tests/test_customer_special_product.py
@@ -1,0 +1,21 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.addons.shopinvader.tests.common import ProductCommonCase
+
+
+class TestCustomerSpecialProduct(ProductCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.ir_export = cls.env.ref("shopinvader.ir_exp_shopinvader_variant")
+        cls.parser = cls.ir_export.get_json_parser()
+        cls.customer = cls.env.ref("base.res_partner_2")
+        cls.shopinvader_variant.record_id.manufactured_for_partner_ids = [
+            (6, 0, cls.customer.ids)
+        ]
+
+    def test_extra_fields(self):
+        data = self.shopinvader_variant.jsonify(self.parser)[0]
+        self.assertEqual(data["partners"], self.customer.ids)

--- a/shopinvader_customer_special_product/views/product_template.xml
+++ b/shopinvader_customer_special_product/views/product_template.xml
@@ -8,7 +8,7 @@
     <field name="inherit_id" ref="product.product_template_form_view"/>
     <field name="arch" type="xml">
       <xpath expr="//page[@name='sales']/group[@name='shopinvader']" position="inside">
-        <field name="manufactured_for_partner_ids" widget="many2many_tags" options="{'no_create_edit': True}"/>
+        <field name="procured_for_partner_ids" widget="many2many_tags" options="{'no_create_edit': True}"/>
       </xpath>
     </field>
   </record>

--- a/shopinvader_customer_special_product/views/product_template.xml
+++ b/shopinvader_customer_special_product/views/product_template.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 Camptocamp
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+  <record model="ir.ui.view" id="product_template_form_view">
+    <field name="name">view.product.form.customer.special.product</field>
+    <field name="model">product.template</field>
+    <field name="inherit_id" ref="product.product_template_form_view"/>
+    <field name="arch" type="xml">
+      <xpath expr="//page[@name='sales']/group[@name='shopinvader']" position="inside">
+        <field name="manufactured_for_partner_ids" widget="many2many_tags" options="{'no_create_edit': True}"/>
+      </xpath>
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
This module adds the possibility to flag some products to be sold only to
specific customers on the website.

A new field accessible on the product form in the Sale tab allows to
select multiple customer by product.
This field is exported to the search engine metadata