### PR TITLE
[12.0][FIX] shopinvader_cart_expiry: Set cron state to'code'

### DIFF
--- a/shopinvader_cart_expiry/data/ir_cron.xml
+++ b/shopinvader_cart_expiry/data/ir_cron.xml
@@ -10,6 +10,7 @@
         <field name="interval_type">days</field>
         <field name="numbercall" eval="-1"/>
         <field eval="False" name="doall"/>
+        <field name="state">code</field>
         <field name="model_id" ref="model_shopinvader_backend"/>
         <field name="code">model._scheduler_manage_cart_expiry()</field>
     </record>


### PR DESCRIPTION
As the default is 'object_write', the cron does not execute at
install

See: https://github.com/odoo/odoo/blob/12.0/odoo/addons/base/models/ir_actions.py#L373