### PR TITLE
[10.0][ADD] shopinvader Add the real level on the shopinvader.categor…

### DIFF
--- a/shopinvader/data/ir_export_category.xml
+++ b/shopinvader/data/ir_export_category.xml
@@ -67,6 +67,11 @@
         <field name="export_id" ref="ir_exp_shopinvader_category"/>
     </record>
 
+    <record id="ir_exp_shopinvader_category_real_level" model="ir.exports.line">
+        <field name="name">real_level</field>
+        <field name="export_id" ref="ir_exp_shopinvader_category"/>
+    </record>
+
     <record id="ir_exp_shopinvader_category_shopinvader_parent_id" model="ir.exports.line">
         <field name="name">shopinvader_parent_id/object_id</field>
         <field name="alias">shopinvader_parent_id:parent/object_id:id</field>

--- a/shopinvader/models/shopinvader_category.py
+++ b/shopinvader/models/shopinvader_category.py
@@ -38,6 +38,7 @@ class ShopinvaderCategory(models.Model):
         "shopinvader.category", inverse_name="shopinvader_parent_id"
     )
     level = fields.Integer(compute="_compute_level")
+    real_level = fields.Char(compute="_compute_real_level")
     redirect_url_key = fields.Serialized(
         compute="_compute_redirect_url_key", string="Redirect Url Keys"
     )
@@ -66,6 +67,41 @@ class ShopinvaderCategory(models.Model):
     def _compute_object_id(self):
         for record in self:
             record.object_id = record.record_id.id
+
+    @api.multi
+    @api.depends(
+        "level",
+        "sequence",
+        "shopinvader_parent_id",
+        "shopinvader_parent_id.level",
+        "shopinvader_parent_id.real_level",
+        "shopinvader_parent_id.sequence",
+        "shopinvader_parent_id.active",
+    )
+    def _compute_real_level(self):
+        """
+        Compute the real_level.
+        This function is recursive (depth depends on category depth).
+        Each category real_sequence is based on the real_sequence of his
+        parent (by removing the level of the parent to use the current level).
+        So the pattern is:
+        LEVEL.PARENT_SEQ.SEQUENCE
+        Every number are on 3 digits to simplify the order.
+        :return:
+        """
+        separator = "."
+        for record in self:
+            seq = "{seq:03d}".format(seq=record.sequence)
+            if record.shopinvader_parent_id:
+                seq_split = record.shopinvader_parent_id.real_level.split(
+                    separator, 1
+                )
+                if seq_split:
+                    seq = separator.join([seq_split[1], seq])
+            real_level = "{level:03d}{sep}{seq}".format(
+                level=record.level, sep=separator, seq=seq
+            )
+            record.real_level = real_level
 
     @api.depends(
         "parent_id.shopinvader_bind_ids.shopinvader_parent_id",

--- a/shopinvader/tests/__init__.py
+++ b/shopinvader/tests/__init__.py
@@ -7,6 +7,7 @@ from . import test_cart_copy
 from . import test_cart_item
 from . import test_address
 from . import test_product
+from . import test_shopinvader_category
 from . import test_sale
 from . import test_shopinvader_variant_binding_wizard
 from . import test_shopinvader_category_binding_wizard

--- a/shopinvader/tests/test_shopinvader_category.py
+++ b/shopinvader/tests/test_shopinvader_category.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from .common import ProductCommonCase
+
+
+class TestShopinvaderCategory(ProductCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestShopinvaderCategory, cls).setUpClass()
+        cls.shopinvader_categ_obj = cls.env["shopinvader.category"]
+        cls.product_category = cls.env.ref("product.product_category_4")
+        cls.categ_parent = cls.product_category.parent_id
+        cls.lang = cls.env["res.lang"]._lang_get("en_US")
+
+    def test_real_level1(self):
+        """
+        Ensure the real_level is correctly computed.
+        For this case, the category don't have any parent.
+        :return:
+        """
+        shop_categ = self.shopinvader_categ_obj.create(
+            {
+                "name": self.product_category.name,
+                "lang_id": self.lang.id,
+                "backend_id": self.backend.id,
+                "record_id": self.product_category.id,
+            }
+        )
+        self.assertEquals("000.000", shop_categ.real_level)
+        shop_categ.sequence = 17
+        self.assertEquals("000.017", shop_categ.real_level)
+
+    def test_real_level2(self):
+        """
+        Ensure the real_level is correctly computed.
+        For this case, the category have a parent.
+        :return:
+        """
+        self.shopinvader_categ_obj.create(
+            {
+                "name": self.categ_parent.name,
+                "lang_id": self.lang.id,
+                "backend_id": self.backend.id,
+                "record_id": self.categ_parent.id,
+                "sequence": 10,
+            }
+        )
+        shop_categ = self.shopinvader_categ_obj.create(
+            {
+                "name": self.product_category.name,
+                "lang_id": self.lang.id,
+                "backend_id": self.backend.id,
+                "record_id": self.product_category.id,
+                "sequence": 20,
+            }
+        )
+        self.assertEquals("001.010.020", shop_categ.real_level)
+        shop_categ.sequence = 30
+        self.assertEquals("001.010.030", shop_categ.real_level)


### PR DESCRIPTION
Add the real level on the `shopinvader.category`.
This new field (`real_level`) is used to correctly ordered (on front side) categories.
As the sequence doesn't take care of the category's level.