### PR TITLE
[10.0][IMP] shopinvader: Use partner active state when bind

### DIFF
--- a/shopinvader/tests/test_shopinvader_partner_binding.py
+++ b/shopinvader/tests/test_shopinvader_partner_binding.py
@@ -70,6 +70,39 @@ class TestShopinvaderPartnerBinding(CommonCase):
         self.assertTrue(shopinv_partner)
         return
 
+    def test_binding_inactive(self):
+        """
+        Test the binding by using the shopinvader.partner.binding wizard.
+        :return:
+        """
+        shopinv_partner = self._get_shopinvader_partner(
+            self.partner, self.backend
+        )
+        # This partner shouldn't be already bound
+        self.assertFalse(shopinv_partner)
+        context = self.env.context.copy()
+        context.update(
+            {
+                "active_id": self.partner.id,
+                "active_ids": self.partner.ids,
+                "active_model": self.partner._name,
+            }
+        )
+        wizard_obj = self.binding_wiz_obj.with_context(context)
+        fields_list = wizard_obj.fields_get().keys()
+        values = wizard_obj.default_get(fields_list)
+        values.update({"shopinvader_backend_id": self.backend.id})
+        wizard = wizard_obj.create(values)
+        wizard._onchange_shopinvader_backend_id()
+        wizard.binding_lines.write({"bind": True})
+        # Set partner inactive
+        self.partner.active = False
+        wizard.action_apply()
+        shopinv_partner = self._get_shopinvader_partner(
+            self.partner, self.backend
+        )
+        self.assertFalse(shopinv_partner)
+
     def test_binding_email_uppercase(self):
         """
         Test the binding on a partner with an email in upper case.

--- a/shopinvader/wizards/shopinvader_partner_binding_line.py
+++ b/shopinvader/wizards/shopinvader_partner_binding_line.py
@@ -58,6 +58,7 @@ class ShopinvaderPartnerBindingLine(models.TransientModel):
                 bind_values = {
                     "backend_id": backend.id,
                     "record_id": record.partner_id.id,
+                    "active": record.partner_id.active,
                 }
                 # Locomotive doesn't work with uppercase.
                 # And we have to do the write before the binding


### PR DESCRIPTION
This is intended to synchronize 'active' field between 'shopinvader.partner' record at creation and 'res.partner' one.

As if res.partner is active = False at the moment the binding wizard is confirmed, the new shopinvader.partner record is created with active = True, which is wrong.

This was discovered when using partner_address_version module that create new partner with active = False and the shopinvader_customer_autobind module (https://github.com/shopinvader/odoo-shopinvader/pull/713).

* [x] add tests
