### PR TITLE
Checkout address: do not wipe invoice address by default

### DIFF
--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -125,6 +125,25 @@ class ShopinvaderBackend(models.Model):
         "statistics reasons. A new cart is created automatically when the "
         "customer will add a new item.",
     )
+    cart_checkout_address_policy = fields.Selection(
+        selection=[
+            ("no_defaults", "No defaults"),
+            (
+                "invoice_defaults_to_shipping",
+                "Invoice address defaults to shipping",
+            ),
+        ],
+        default="no_defaults",
+        required=True,
+        string="Cart address behavior",
+        help="Define how the cart address will be handled in the checkout step:\n"
+        "- No defaults: client will pass shipping and invoicing address"
+        " together or in separated calls."
+        " No automatic value for non passed addresses will be set;\n"
+        "- Invoice address defaults to shipping:"
+        " if the client does not pass the invoice address explicitly "
+        " the shipping one will be used as invoice address as well.\n",
+    )
     validate_customers = fields.Boolean(
         default=False,  # let's be explicit here :)
         help="Turn on this flag to block non validated customers. "

--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -370,7 +370,11 @@ class CartService(Component):
             # shipping address, if you want a different invoice address
             # just pass it
             params["partner_shipping_id"] = address["id"]
-            params["partner_invoice_id"] = params["partner_shipping_id"]
+            if (
+                self.shopinvader_backend.cart_checkout_address_policy
+                == "invoice_defaults_to_shipping"
+            ):
+                params["partner_invoice_id"] = params["partner_shipping_id"]
 
     def _prepare_invoicing(self, invoicing, params):
         if "address" in invoicing:

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -60,6 +60,7 @@
                         <page name="sale" string="Sale">
                             <group name="cart_conf" string="Cart configuration">
                                 <field name="clear_cart_options"/>
+                                <field name="cart_checkout_address_policy"/>
                                 <field name="pricelist_id" required="1"/>
                             </group>
                             <group name="sale_conf" string="Sale configuration">


### PR DESCRIPTION
Before this change if the client sent a delivery address alone
the invoicing address was changed automatically.
This is a not expected behavior.

Now by default the service preserves the invoicing address.
You can still change the policy in the backend by setting

   'Cart address behavior' = 'Invoice address defaults to shipping'