### PR TITLE
[13.0] s_customer_multi_user: refactor is_invader_user

### DIFF
--- a/shopinvader_customer_multi_user/__manifest__.py
+++ b/shopinvader_customer_multi_user/__manifest__.py
@@ -5,10 +5,14 @@
     "name": "Shopinvader Customer Multi User",
     "summary": """
         Enable registration of multiple users per each company customer.""",
-    "version": "13.0.1.0.1",
+    "version": "13.0.1.1.0",
     "license": "AGPL-3",
     "author": "Camptocamp SA",
     "website": "https://github.com/shopinvader/odoo-shopinvader",
     "depends": ["shopinvader"],
-    "data": ["views/shopinvader_backend.xml", "views/partner_view.xml"],
+    "data": [
+        "views/shopinvader_backend.xml",
+        "views/partner_view.xml",
+        "views/shopinvader_partner_view.xml",
+    ],
 }

--- a/shopinvader_customer_multi_user/controllers/main.py
+++ b/shopinvader_customer_multi_user/controllers/main.py
@@ -8,7 +8,7 @@ from odoo.addons.shopinvader.controllers import main
 class InvaderController(main.InvaderController):
     def _get_component_context(self):
         res = super(InvaderController, self)._get_component_context()
-        if res["partner"] and res["partner"].is_invader_user():
+        if res["partner"] and res["partner"].is_invader_user:
             # just a user of the same main account:
             # override partner w/ its parent
             # The original partner is already into `res['partner_user']`

--- a/shopinvader_customer_multi_user/migrations/13.0.1.1.0/pre-migrate.py
+++ b/shopinvader_customer_multi_user/migrations/13.0.1.1.0/pre-migrate.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Camptocamp SA (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    # Rollback partner type to default `contact`
+    cr.execute(
+        "UPDATE res_partner SET type = 'contact' WHERE type = 'invalid_client_user'"
+    )
+    _logger.info(
+        "Replace res_partner.type = 'invalid_client_user' w/ 'contact'"
+    )

--- a/shopinvader_customer_multi_user/models/shopinvader_partner.py
+++ b/shopinvader_customer_multi_user/models/shopinvader_partner.py
@@ -2,16 +2,43 @@
 # @author Simone Orsi <simone.orsi@camptocamp.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class ShopinvaderPartner(models.Model):
 
     _inherit = "shopinvader.partner"
 
+    is_invader_user = fields.Boolean(
+        compute="_compute_is_invader_user", store=True
+    )
+
+    @api.depends("parent_id", "parent_id.shopinvader_bind_ids")
+    def _compute_is_invader_user(self):
+        for rec in self:
+            rec.is_invader_user = rec._check_is_invader_user()
+
+    def _check_is_invader_user(self):
+        """Check if current partner is a bound shopinvader user.
+
+        You have only 2 ways to make a partner a shop customer:
+
+        1. register new account from the client
+        2. create a binding for the partner
+
+        If we have a binding on both records (child partner and parent partner)
+        this is an invader user.
+        """
+        return bool(
+            self.parent_id.shopinvader_bind_ids.filtered(
+                lambda x: x.backend_id == self.backend_id
+            )
+        )
+
     @api.model
     def create(self, vals):
         binding = super().create(vals)
+        # Generate company's invader user token when creating a binding
         partner = binding.record_id
         if (
             binding.backend_id.customer_multi_user
@@ -20,7 +47,3 @@ class ShopinvaderPartner(models.Model):
         ):
             partner.assign_invader_user_token()
         return binding
-
-    def is_invader_user(self):
-        self.ensure_one()
-        return self.record_id.is_invader_user()

--- a/shopinvader_customer_multi_user/services/customer.py
+++ b/shopinvader_customer_multi_user/services/customer.py
@@ -22,16 +22,24 @@ class CustomerService(Component):
                 vals.update(
                     {
                         "parent_id": company.id,
-                        "type": self.env[
-                            "res.partner"
-                        ]._invader_client_user_type,
+                        "type": vals.get(
+                            "type",
+                            self._default_simple_user_partner_type(company),
+                        ),
                     }
                 )
         return vals
 
+    def _default_simple_user_partner_type(self, company):
+        return "contact"
+
     def _validator_create(self):
         schema = super()._validator_create()
         schema.update({"company_token": {"type": "string", "required": False}})
+        # TODO: address fields should not be required
+        # when you register a new user for a company
+        # hence when the company token is there address fields should be
+        # non required.
         return schema
 
     def _to_customer_info(self, partner):

--- a/shopinvader_customer_multi_user/tests/test_multi_user.py
+++ b/shopinvader_customer_multi_user/tests/test_multi_user.py
@@ -60,7 +60,7 @@ class TestCustomer(TestCustomerCommon):
         res = self.service.dispatch("create", params=params)["data"]
         partner = self.env["res.partner"].browse(res["id"])
         self.assertFalse(partner.parent_id)
-        self.assertNotEqual(partner.type, "invader_client_user")
+        self.assertFalse(partner.is_invader_user)
         self._test_partner_data(partner, self.data)
 
     def test_create_customer_multi_user(self):
@@ -73,7 +73,8 @@ class TestCustomer(TestCustomerCommon):
         res = self.service.dispatch("create", params=params)["data"]
         partner1 = self.env["res.partner"].browse(res["id"])
         self.assertEqual(partner1.parent_id, self.company)
-        self.assertEqual(partner1.type, "invader_client_user")
+        self.assertEqual(partner1.type, "contact")
+        self.assertTrue(partner1.is_invader_user)
         self._test_partner_data(partner1, data)
         # customer 2
         data = dict(
@@ -83,11 +84,14 @@ class TestCustomer(TestCustomerCommon):
         res = self.service.dispatch("create", params=params)["data"]
         partner2 = self.env["res.partner"].browse(res["id"])
         self.assertEqual(partner2.parent_id, self.company)
-        self.assertEqual(partner2.type, "invader_client_user")
+        self.assertEqual(partner2.type, "contact")
+        self.assertTrue(partner2.is_invader_user)
         self._test_partner_data(partner2, data)
         # both are there
         self.assertIn(partner1, self.company.child_ids)
         self.assertIn(partner2, self.company.child_ids)
+        # the company is not an invader user
+        self.assertFalse(self.company.is_invader_user)
 
     def test_create_customer_multi_user_wrong_token(self):
         self.data.update({"external_id": "cust1"})
@@ -96,9 +100,10 @@ class TestCustomer(TestCustomerCommon):
         partner = self.env["res.partner"].browse(res["id"])
         # partner is created normally, no relation w/ the company
         self.assertFalse(partner.parent_id)
-        self.assertNotEqual(partner.type, "invader_client_user")
+        self.assertFalse(partner.is_invader_user)
         self._test_partner_data(partner, self.data)
         self.assertNotIn(partner, self.company.child_ids)
+        self.assertFalse(self.company.is_invader_user)
 
     def test_controller_service_context(self):
         self.backend.customer_multi_user = True

--- a/shopinvader_customer_multi_user/views/partner_view.xml
+++ b/shopinvader_customer_multi_user/views/partner_view.xml
@@ -6,6 +6,7 @@
     <field name="inherit_id" ref="shopinvader.res_partner_view_form"/>
     <field name="arch" type="xml">
       <group name="extras" position="inside">
+        <field name="is_invader_user"/>
         <field name="invader_user_token"/>
         <button name="action_regenerate_invader_user_token" type="object"
                 string="Re-generate token" attrs="{'invisible': [('invader_user_token','=',False)]}"/>

--- a/shopinvader_customer_multi_user/views/shopinvader_partner_view.xml
+++ b/shopinvader_customer_multi_user/views/shopinvader_partner_view.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+  <record id="shopinvader_partner_view_form" model="ir.ui.view">
+    <field name="model">shopinvader.partner</field>
+    <field name="inherit_id" ref="shopinvader.shopinvader_partner_view_form"/>
+    <field name="arch" type="xml">
+      <field name="external_id" position="after">
+        <field name="is_invader_user"/>
+      </field>
+    </field>
+  </record>
+
+  <record id="shopinvader_partner_view_tree" model="ir.ui.view">
+    <field name="model">shopinvader.partner</field>
+    <field name="inherit_id" ref="shopinvader.shopinvader_partner_view_tree"/>
+    <field name="arch" type="xml">
+      <field name="external_id" position="after">
+        <field name="is_invader_user"/>
+      </field>
+    </field>
+  </record>
+
+  <record id="shopinvader_partner_view_search" model="ir.ui.view">
+    <field name="model">shopinvader.partner</field>
+    <field name="inherit_id" ref="shopinvader.shopinvader_partner_view_search"/>
+    <field name="arch" type="xml">
+      <field name="external_id" position="after">
+        <field name="is_invader_user"/>
+      </field>
+      <filter name="group_by_backend_id" position="after">
+        <filter name="group_by_is_invader_user" string="Is invader user" domain="[]" context="{'group_by':'is_invader_user'}"/>
+      </filter>
+    </field>
+  </record>
+
+  </odoo>


### PR DESCRIPTION
Before this change the check was done
based on a new partner type 'invader_client_user'.

This was a limitation because:

1. you could not use other partner types for the same record

2. invader users created via backend and not having the special type
   (like most of the cases when you have an existing set of partners)
   were not acknowledged as invader user and they couldn't see
   all the addresses from the main account

Now the flag is computed at binding level
and the default type for the partner is 'contact'.

No migration step required since the selection value will be
automatically deleted from db when upgrading the module,
and the new value will be computed the 1st time is required.