### PR TITLE
[10.0][FIX] Multi company: some fields computed as sudo

### DIFF
--- a/shopinvader/__manifest__.py
+++ b/shopinvader/__manifest__.py
@@ -76,6 +76,7 @@
         "demo/product_category_demo.xml",
         "demo/product_attribute_value_demo.xml",
         "demo/product_product_demo.xml",
+        "demo/res_users.xml",
     ],
     "qweb": [],
 }

--- a/shopinvader/demo/res_users.xml
+++ b/shopinvader/demo/res_users.xml
@@ -9,7 +9,7 @@
         <field name="email">user_1_liege@yourcompany.com</field>
         <field name="login">liege_user</field>
         <field name="password">liege_user</field>
-        <field name="groups_id" eval="[(4, ref('shopinvader.group_shopinvader_manager')), (4, ref('base.group_partner_manager'))]"/>
+        <field name="groups_id" eval="[(4, ref('shopinvader.group_shopinvader_manager')), (4, ref('base.group_partner_manager')), (4, ref('sales_team.group_sale_manager'))]"/>
         <field name="company_ids" eval="[(4, ref('shopinvader.res_company_liege'))]"/>
         <field name="company_id" ref="shopinvader.res_company_liege"/>
     </record>

--- a/shopinvader/demo/res_users.xml
+++ b/shopinvader/demo/res_users.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+
+    <!-- User Company Belgium-->
+    <record id="user_liege_shop" model="res.users" context="{'no_reset_password': True}">
+        <field name="name">Liege User 1</field>
+        <field name="email">user_1_liege@yourcompany.com</field>
+        <field name="login">liege_user</field>
+        <field name="password">liege_user</field>
+        <field name="groups_id" eval="[(4, ref('shopinvader.group_shopinvader_manager')), (4, ref('base.group_partner_manager'))]"/>
+        <field name="company_ids" eval="[(4, ref('shopinvader.res_company_liege'))]"/>
+        <field name="company_id" ref="shopinvader.res_company_liege"/>
+    </record>
+</odoo>

--- a/shopinvader/models/shopinvader_partner.py
+++ b/shopinvader/models/shopinvader_partner.py
@@ -17,7 +17,11 @@ class ShopinvaderPartner(models.Model):
         "res.partner", string="Partner", required=True, ondelete="restrict"
     )
     partner_email = fields.Char(
-        related="record_id.email", readonly=True, required=True, store=True
+        related="record_id.email",
+        readonly=True,
+        required=True,
+        store=True,
+        compute_sudo=True,
     )
 
     _sql_constraints = [

--- a/shopinvader/tests/test_shopinvader_partner.py
+++ b/shopinvader/tests/test_shopinvader_partner.py
@@ -15,6 +15,7 @@ class TestShopinvaderPartner(SavepointComponentCase):
         cls.backend = cls.env.ref("shopinvader.backend_1")
         cls.shopinvader_config = cls.env["shopinvader.config.settings"]
         cls.unique_email = datetime.now().isoformat() + "@test.com"
+        cls.user_liege = cls.env.ref("shopinvader.user_liege_shop")
 
     def test_unique_binding(self):
         self.env["shopinvader.partner"].create(
@@ -137,3 +138,31 @@ class TestShopinvaderPartner(SavepointComponentCase):
             [("email", "=", self.unique_email)]
         )
         self.assertEqual(len(res), 1)
+
+    def test_shopinvader_multi_company(self):
+        """
+        Test if modifications to a partner on a company A with a shopinvader.partner on a company B
+        work
+        """
+        self.shopinvader_config.create(
+            {"no_partner_duplicate": True}
+        ).execute()
+        self.assertFalse(
+            self.shopinvader_config.is_partner_duplication_allowed()
+        )
+        vals = {"email": "test+35@test.com", "name": "test  partner"}
+        # create a partner...
+        partner = self.env["res.partner"].create(vals)
+        # create a binding on company A
+        binding = self.env["shopinvader.partner"].create(
+            {
+                "email": "test+35@test.com",
+                "name": "test  partner",
+                "backend_id": self.backend.id,
+            }
+        )
+        # the binding must be linked to the partner
+        self.assertEqual(partner, binding.record_id)
+
+        # The user from company Liège is modifying partner
+        partner.sudo(self.user_liege).email = "test+36@test.com"

--- a/shopinvader_sale_profile/models/shopinvader_partner.py
+++ b/shopinvader_sale_profile/models/shopinvader_partner.py
@@ -14,6 +14,7 @@ class ShopinvaderPartner(models.Model):
         "shopinvader.sale.profile",
         "Sale profile",
         compute="_compute_sale_profile_id",
+        compute_sudo=True,
         store=True,
         help="Sale profile computed, depending every fields who make the "
         "fiscal position (country, zip, vat, account position,...)",


### PR DESCRIPTION
In a multi-company context, a partner can be linked to several backends
in several companies.

If a user authorized on company A and not on company B modifies a partner
linked to both backends, computed fields (and related too) should be computed as sudo

* [x] shopinvader: shopinvader.partner - partner_email
* [x] shopinvader_sale_profile: shopinvader.partner - sale_profile_id