### PR TITLE
[13.0][FIX] notification job access rights

### DIFF
--- a/shopinvader/models/shopinvader_notification.py
+++ b/shopinvader/models/shopinvader_notification.py
@@ -107,9 +107,11 @@ class ShopinvaderNotification(models.Model):
     @job(default_channel="root.shopinvader.notification")
     def send(self, record_id):
         self.ensure_one()
-        return self.template_id.with_context(
-            **self._get_template_context()
-        ).send_mail(record_id)
+        return (
+            self.sudo()
+            .template_id.with_context(**self._get_template_context())
+            .send_mail(record_id)
+        )
 
     def _get_template_context(self):
         return {


### PR DESCRIPTION
The job for the notification can be indirectly created by a user that do
not have the access rights to the model related.
By example a picking done by a user in the stock will lead to the
invoicing of a sale order.