### PR TITLE
[13.0] product.filter test coverage and fixes

### DIFF
--- a/shopinvader/__manifest__.py
+++ b/shopinvader/__manifest__.py
@@ -48,6 +48,7 @@
         "views/shopinvader_partner_view.xml",
         "views/shopinvader_backend_view.xml",
         "views/product_view.xml",
+        "views/product_filter_view.xml",
         "views/partner_view.xml",
         "views/product_category_view.xml",
         "views/sale_view.xml",

--- a/shopinvader/models/product_filter.py
+++ b/shopinvader/models/product_filter.py
@@ -35,7 +35,9 @@ class ProductFilter(models.Model):
         ],
     )
     variant_attribute_id = fields.Many2one(
-        string="Attribute", comodel_name="product.attribute"
+        string="Attribute",
+        comodel_name="product.attribute",
+        ondelete="cascade",
     )
     help = fields.Html(translate=True)
     name = fields.Char(translate=True, required=True)

--- a/shopinvader/models/product_filter.py
+++ b/shopinvader/models/product_filter.py
@@ -33,12 +33,14 @@ class ProductFilter(models.Model):
                 ("product.template", "product.product", "shopinvader.product"),
             )
         ],
+        ondelete="cascade",
     )
     variant_attribute_id = fields.Many2one(
         string="Attribute",
         comodel_name="product.attribute",
         ondelete="cascade",
     )
+    # TODO: rename to not clash w/ built-in
     help = fields.Html(translate=True)
     name = fields.Char(translate=True, required=True)
     display_name = fields.Char(compute="_compute_display_name")

--- a/shopinvader/tests/__init__.py
+++ b/shopinvader/tests/__init__.py
@@ -7,6 +7,7 @@ from . import test_address
 from . import test_partner_validation
 from . import test_partner_access_info
 from . import test_product
+from . import test_product_filter
 from . import test_sale
 from . import test_shopinvader_category
 from . import test_shopinvader_variant_binding_wizard

--- a/shopinvader/tests/test_product.py
+++ b/shopinvader/tests/test_product.py
@@ -35,33 +35,6 @@ class ProductCase(ProductCommonCase):
             self.shopinvader_variant.variant_attributes, attr_dict
         )
 
-    def test_product_filter(self):
-        field_id = self.env["ir.model.fields"].search(
-            [("model", "=", "shopinvader.product"), ("name", "=", "name")]
-        )
-        filter_on_field = self.env["product.filter"].create(
-            {
-                "name": "Test Filter on field name",
-                "based_on": "field",
-                "field_id": field_id.id,
-            }
-        )
-        self.assertEqual(filter_on_field.display_name, "name")
-
-        attribute_id = self.env["product.attribute"].search(
-            [("name", "=", "Legs")]
-        )
-        filter_on_attr = self.env["product.filter"].create(
-            {
-                "name": "Test Filter on field name",
-                "based_on": "variant_attribute",
-                "variant_attribute_id": attribute_id.id,
-            }
-        )
-        self.assertEqual(
-            filter_on_attr.display_name, "variant_attributes.legs"
-        )
-
     def test_product_price(self):
         self.assertEqual(
             self.shopinvader_variant.price,

--- a/shopinvader/tests/test_product_filter.py
+++ b/shopinvader/tests/test_product_filter.py
@@ -45,3 +45,17 @@ class TestProductFilter(CommonCase):
             self.filter_on_attr.with_context(lang="fr_FR").display_name,
             "variant_attributes.jambes",
         )
+
+    def test_delete_attribute_delete_filter_cascade(self):
+        product_attribute = self.env["product.attribute"].create(
+            {"name": "Test delete", "create_variant": "no_variant"}
+        )
+        filter1 = self.env["product.filter"].create(
+            {
+                "name": "Test Filter delete",
+                "based_on": "variant_attribute",
+                "variant_attribute_id": product_attribute.id,
+            }
+        )
+        product_attribute.unlink()
+        self.assertFalse(filter1.exists())

--- a/shopinvader/tests/test_product_filter.py
+++ b/shopinvader/tests/test_product_filter.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Camptocamp (http://www.camptocamp.com).
 # @author Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import exceptions
+
 from .common import CommonCase
 
 
@@ -59,3 +61,19 @@ class TestProductFilter(CommonCase):
         )
         product_attribute.unlink()
         self.assertFalse(filter1.exists())
+
+    def test_product_filter_constrains(self):
+        with self.assertRaises(exceptions.UserError) as err:
+            self.filter_on_field.write({"field_id": False})
+        self.assertEqual(
+            err.exception.name,
+            "Product filter ID=%d is based on field: "
+            "requires a field!" % self.filter_on_field.id,
+        )
+        with self.assertRaises(exceptions.UserError) as err:
+            self.filter_on_attr.write({"variant_attribute_id": False})
+        self.assertEqual(
+            err.exception.name,
+            "Product filter ID=%d is based on variant attribute: "
+            "requires an attribute!" % self.filter_on_attr.id,
+        )

--- a/shopinvader/tests/test_product_filter.py
+++ b/shopinvader/tests/test_product_filter.py
@@ -10,16 +10,26 @@ class TestProductFilter(CommonCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.shopinvader_product_field = cls.env["ir.model.fields"].search(
-            [("model", "=", "shopinvader.product"), ("name", "=", "name")],
-            limit=1,
-        )
-        cls.variant_attribute = cls.env["product.attribute"].search(
-            [("name", "=", "Legs")], limit=1
-        )
         cls._install_lang(cls, "base.lang_fr")
+        model = cls.env["ir.model"].search(
+            [("model", "=", "shopinvader.product")], limit=1
+        )
+        # add custom field so that we can delete it (cannot do it w/ modules' fields)
+        cls.shopinvader_product_field = cls.env["ir.model.fields"].create(
+            {
+                "model_id": model.id,
+                "name": "x_custom_field",
+                "field_description": "Custom field for testing",
+                "ttype": "char",
+            }
+        )
+        cls.variant_attribute = cls.env["product.attribute"].create(
+            {"name": "Test attribute", "create_variant": "no_variant"}
+        )
 
-        cls.variant_attribute.with_context(lang="fr_FR").name = "Jambes"
+        cls.variant_attribute.with_context(
+            lang="fr_FR"
+        ).name = "Test attribute FR"
 
         cls.filter_on_field = cls.env["product.filter"].create(
             {
@@ -37,32 +47,31 @@ class TestProductFilter(CommonCase):
         )
 
     def test_product_filter_field_name(self):
-        self.assertEqual(self.filter_on_field.display_name, "name")
+        self.assertEqual(self.filter_on_field.display_name, "x_custom_field")
+        self.assertEqual(
+            self.filter_on_field.with_context(lang="fr_FR").display_name,
+            "x_custom_field",
+        )
 
     def test_product_filter_attribute_name(self):
         self.assertEqual(
-            self.filter_on_attr.display_name, "variant_attributes.legs"
+            self.filter_on_attr.display_name,
+            "variant_attributes.test_attribute",
         )
         self.assertEqual(
             self.filter_on_attr.with_context(lang="fr_FR").display_name,
-            "variant_attributes.jambes",
+            "variant_attributes.test_attribute_fr",
         )
+
+    def test_delete_field_delete_filter_cascade(self):
+        self.shopinvader_product_field.unlink()
+        self.assertFalse(self.filter_on_field.exists())
 
     def test_delete_attribute_delete_filter_cascade(self):
-        product_attribute = self.env["product.attribute"].create(
-            {"name": "Test delete", "create_variant": "no_variant"}
-        )
-        filter1 = self.env["product.filter"].create(
-            {
-                "name": "Test Filter delete",
-                "based_on": "variant_attribute",
-                "variant_attribute_id": product_attribute.id,
-            }
-        )
-        product_attribute.unlink()
-        self.assertFalse(filter1.exists())
+        self.variant_attribute.unlink()
+        self.assertFalse(self.filter_on_attr.exists())
 
-    def test_product_filter_constrains(self):
+    def test_product_filter_field_constrains(self):
         with self.assertRaises(exceptions.UserError) as err:
             self.filter_on_field.write({"field_id": False})
         self.assertEqual(
@@ -70,6 +79,8 @@ class TestProductFilter(CommonCase):
             "Product filter ID=%d is based on field: "
             "requires a field!" % self.filter_on_field.id,
         )
+
+    def test_product_filter_attr_constrains(self):
         with self.assertRaises(exceptions.UserError) as err:
             self.filter_on_attr.write({"variant_attribute_id": False})
         self.assertEqual(

--- a/shopinvader/tests/test_product_filter.py
+++ b/shopinvader/tests/test_product_filter.py
@@ -1,0 +1,47 @@
+# Copyright 2020 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from .common import CommonCase
+
+
+class TestProductFilter(CommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.shopinvader_product_field = cls.env["ir.model.fields"].search(
+            [("model", "=", "shopinvader.product"), ("name", "=", "name")],
+            limit=1,
+        )
+        cls.variant_attribute = cls.env["product.attribute"].search(
+            [("name", "=", "Legs")], limit=1
+        )
+        cls._install_lang(cls, "base.lang_fr")
+
+        cls.variant_attribute.with_context(lang="fr_FR").name = "Jambes"
+
+        cls.filter_on_field = cls.env["product.filter"].create(
+            {
+                "name": "Product Name",
+                "based_on": "field",
+                "field_id": cls.shopinvader_product_field.id,
+            }
+        )
+        cls.filter_on_attr = cls.env["product.filter"].create(
+            {
+                "name": "Test Filter on field name",
+                "based_on": "variant_attribute",
+                "variant_attribute_id": cls.variant_attribute.id,
+            }
+        )
+
+    def test_product_filter_field_name(self):
+        self.assertEqual(self.filter_on_field.display_name, "name")
+
+    def test_product_filter_attribute_name(self):
+        self.assertEqual(
+            self.filter_on_attr.display_name, "variant_attributes.legs"
+        )
+        self.assertEqual(
+            self.filter_on_attr.with_context(lang="fr_FR").display_name,
+            "variant_attributes.jambes",
+        )

--- a/shopinvader/views/product_filter_view.xml
+++ b/shopinvader/views/product_filter_view.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="product_filter_view_form" model="ir.ui.view">
+        <field name="model">product.filter</field>
+        <field name="arch" type="xml">
+            <form string="Filter">
+                <group>
+                    <field name="name"/>
+                    <field name="based_on"/>
+                    <field name="field_id" attrs="{'invisible': [('based_on', '!=', 'field')],
+
+                                               'required': [('based_on', '=', 'field')]}"/>
+                    <field name="variant_attribute_id" attrs="{'invisible': [('based_on', '!=', 'variant_attribute')],
+                                                   'required': [('based_on', '=', 'variant_attribute')]}"/>
+                    <separator string="Help"/>
+                    <field name="help" colspan="4" nolabel="1"/>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record id="product_filter_view_tree" model="ir.ui.view">
+        <field name="model">product.filter</field>
+        <field name="arch" type="xml">
+            <tree string="Filter">
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="product_filter_action" model="ir.actions.act_window">
+        <field name="name">Product filter</field>
+        <field name="res_model">product.filter</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem
+            id="menu_product_filter_action"
+            action="product_filter_action"
+            parent="sale.prod_config_main"
+            sequence="15"/>
+
+</odoo>

--- a/shopinvader/views/product_view.xml
+++ b/shopinvader/views/product_view.xml
@@ -18,41 +18,6 @@
         </field>
     </record>
 
-    <record id="product_filter_view_form" model="ir.ui.view">
-        <field name="model">product.filter</field>
-        <field name="arch" type="xml">
-            <form string="Filter">
-                <group>
-                    <field name="name"/>
-                    <field name="based_on"/>
-                    <field name="field_id" attrs="{'invisible': [('based_on', '!=', 'field')],
-
-                                               'required': [('based_on', '=', 'field')]}"/>
-                    <field name="variant_attribute_id" attrs="{'invisible': [('based_on', '!=', 'variant_attribute')],
-                                                   'required': [('based_on', '=', 'variant_attribute')]}"/>
-                    <separator string="Help"/>
-                    <field name="help" colspan="4" nolabel="1"/>
-                </group>
-            </form>
-        </field>
-    </record>
-
-    <record id="product_filter_view_tree" model="ir.ui.view">
-        <field name="model">product.filter</field>
-        <field name="arch" type="xml">
-            <tree string="Filter">
-                <field name="sequence" widget="handle"/>
-                <field name="name"/>
-            </tree>
-        </field>
-    </record>
-
-    <record id="product_filter_action" model="ir.actions.act_window">
-        <field name="name">Product filter</field>
-        <field name="res_model">product.filter</field>
-        <field name="view_mode">tree,form</field>
-    </record>
-
     <record model="ir.ui.view" id="product_product_form_view">
         <field name="model">product.product</field>
         <field name="inherit_id" ref="product.product_normal_form_view"/>
@@ -68,11 +33,4 @@
             </field>
         </field>
     </record>
-
-    <menuitem
-            id="menu_product_filter_action"
-            action="product_filter_action"
-            parent="sale.prod_config_main"
-            sequence="15"/>
-
 </odoo>


### PR DESCRIPTION
~Includes https://github.com/shopinvader/odoo-shopinvader/pull/794~

Make sure the filter is deleted when the attribute/field is, **otherwise the whole sync is broken**.

In details:

* move views to their own file
* add complete test coverage for filters
* fix deletion of variant attribute w/ cascade
* fix deletion of fields w/ cascade
* add constrain on write

