### PR TITLE
[10.0][IMP] shopinvader: Allow to not embed the whole response

### DIFF
--- a/shopinvader/readme/CONTRIBUTORS.rst
+++ b/shopinvader/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Sebastien BEAU <sebastien.beau@akretion.com>
+* Denis Roussel <denis.roussel@acsone.eu>

--- a/shopinvader/shopinvader_response.py
+++ b/shopinvader/shopinvader_response.py
@@ -10,6 +10,20 @@ _test_mode = False
 threadLocal = threading.local()
 
 
+def shopinvader_agnostic(func):
+    """
+    Used to decorate methods that are used typically when they cannot contain
+    other information but the one returned by that method.
+
+    Typically, used for webhooks or...
+
+    :param func:
+    :return:
+    """
+    func.shopinvader_agnostic = True
+    return func
+
+
 class ShopinvaderResponse(object):
     """
     A response object used to enrich the response returned by a shopinvader

--- a/shopinvader/tests/__init__.py
+++ b/shopinvader/tests/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from . import test_controller
 from . import test_backend
 from . import test_cart

--- a/shopinvader/tests/test_backend.py
+++ b/shopinvader/tests/test_backend.py
@@ -38,3 +38,9 @@ class BackendCase(CommonCase):
         self._bind_all_category()
         self.env["shopinvader.category"].search([], limit=1).unlink()
         self.assertEqual(*self._bind_all_category())
+
+    def test_agnostic_response(self):
+        with self.work_on_services(partner=None) as work:
+            self.service = work.component(usage="cart")
+            res = self.service.dispatch("ping")
+            self.assertEquals("Hello World!", res)


### PR DESCRIPTION
In some useful cases, it is required that service methods return result that
should not embed shopinvader response keys.

e.g.: webhooks that wait specific response without store_cache and session