### PR TITLE
[10.0] shopinvader_delivery_carrier: total_without_shipping is not computed on the right base

### DIFF
--- a/shopinvader_delivery_carrier/services/abstract_sale.py
+++ b/shopinvader_delivery_carrier/services/abstract_sale.py
@@ -39,7 +39,9 @@ class AbstractSaleService(AbstractComponent):
         shipping_amounts = self._convert_shipping(sale).get("amount", {})
         tax = result.get("tax", 0) - shipping_amounts.get("tax", 0)
         untaxed = result.get("untaxed", 0) - shipping_amounts.get("untaxed", 0)
-        total = result.get("total", 0) - shipping_amounts.get("total", 0)
+        total = result.get("total_without_discount", 0) - shipping_amounts.get(
+            "total", 0
+        )
         precision = sale.currency_id.decimal_places
         total_without_shipping_without_discount = total - sale.discount_total
         result.update(

--- a/shopinvader_delivery_carrier/tests/test_carrier.py
+++ b/shopinvader_delivery_carrier/tests/test_carrier.py
@@ -318,7 +318,8 @@ class CarrierCase(CommonCarrierCase):
         cart_ship = cart.get("shipping")
 
         total_without_shipping = (
-            cart_amount["total"] - cart_ship["amount"]["total"]
+            cart_amount["total_without_discount"]
+            - cart_ship["amount"]["total"]
         )
         untaxed_without_shipping = (
             cart_amount["untaxed"] - cart_ship["amount"]["untaxed"]


### PR DESCRIPTION
total_without_discount should contains gross total
total_without_shipping should contains (gross total - shipping cost)
total_without_shipping_without_discount should contains (gross total - shipping cost - discount)

Current behaviour:

From now total_without_shipping is computed (total_without_discount - shipping cost)

Expected behaviour

The discount should not be deducted from total_without_shipping
