### PR TITLE
shopinvader: cart create rely on onchanges for addresses

### DIFF
--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -459,14 +459,8 @@ class CartService(Component):
         vals = {
             "typology": "cart",
             "partner_id": partner.id,
-            "partner_shipping_id": partner.id,
             "shopinvader_backend_id": self.shopinvader_backend.id,
         }
-        if (
-            self.shopinvader_backend.cart_checkout_address_policy
-            == "invoice_defaults_to_shipping"
-        ):
-            vals["partner_invoice_id"] = vals["partner_shipping_id"]
         vals.update(self.env["sale.order"].play_onchanges(vals, vals.keys()))
         if self.shopinvader_backend.account_analytic_id.id:
             vals[


### PR DESCRIPTION
Passing a default for shipping/invoice address makes any onchange ignore them
which breaks the rule of having the same behavior in normal Odoo backend.

Likely to be fwd/back ported everywhere.