### PR TITLE
[13.0][FIX] Fix typo in "developper"

### DIFF
--- a/shopinvader/i18n/shopinvader.pot
+++ b/shopinvader/i18n/shopinvader.pot
@@ -619,7 +619,7 @@ msgstr ""
 
 #. module: shopinvader
 #: view:shopinvader.backend:shopinvader.shopinvader_backend_view_form
-msgid "Developper"
+msgid "Developer"
 msgstr ""
 
 #. module: shopinvader

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -124,8 +124,8 @@
                                 <field name="invoice_report_id" options="{'no_create': True, 'no_open': True}"/>
                             </group>
                         </page>
-                        <page name="developper" string="Developper">
-                            <group name="developper" colspan="4">
+                        <page name="developer" string="Developer">
+                            <group name="developer" colspan="4">
                                 <group name="product" string="Product" col="10" colspan="4">
                                     <field name="nbr_product"/>
                                     <button

--- a/shopinvader_locomotive/views/shopinvader_backend_view.xml
+++ b/shopinvader_locomotive/views/shopinvader_backend_view.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id"
                ref="shopinvader.shopinvader_backend_view_form"/>
         <field name="arch" type="xml">
-            <page name="developper" position="inside">
+            <page name="developer" position="inside">
                 <group name="locomotive" string="LocomotiveCMS">
                     <span>Synchronize metadata push data managed by odoo and used into locomotive.
                         For ex: countries, currencies. If some required metadata


### PR DESCRIPTION
Spelling fix.  I changed the typo in the XML as well, making the (possibly incorrect) assumption that there are no external references to those names.