### PR TITLE
[10.0][FIX] shopinvader: the pricelist shouldn't be updated during sign-in

### DIFF
--- a/shopinvader/services/customer.py
+++ b/shopinvader/services/customer.py
@@ -82,6 +82,9 @@ class CustomerService(Component):
                         "partner_id": self.partner.id,
                         "partner_shipping_id": self.partner.id,
                         "partner_invoice_id": self.partner.id,
+                        # We have to repeat the pricelist to avoid
+                        # unexpected update by onchange
+                        "pricelist_id": cart.pricelist_id.id,
                     }
                 )
             return cart_service._to_json(cart)["data"]

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -162,6 +162,35 @@ class AnonymousCartCase(CartCase, CartClearTest):
             cart.pricelist_id, cart.shopinvader_backend_id.pricelist_id
         )
 
+    def test_anonymous_cart_then_sign_with_different_pricelist1(self):
+        """
+        Ensure the pricelist set on the cart is not updated by the one
+        set on the customer during sign-in.
+        The pricelist shouldn't be updated during sign-in!
+        :return:
+        """
+        cart = self.cart
+        partner = self.env.ref("shopinvader.partner_1")
+        new_pricelist = cart.pricelist_id.copy({"name": "New pricelist!"})
+        partner.write({"property_product_pricelist": new_pricelist.id})
+        save_pricelist = cart.pricelist_id
+        self._sign_with(partner)
+        self.assertEqual(cart.pricelist_id, save_pricelist)
+
+    def test_anonymous_cart_then_sign_with_different_pricelist2(self):
+        """
+        Ensure the pricelist set on the cart is not updated by the one
+        set on the backend (if updated manually or by another module)
+        The pricelist shouldn't be updated during sign-in!
+        :return:
+        """
+        cart = self.cart
+        partner = self.env.ref("shopinvader.partner_1")
+        new_pricelist = cart.pricelist_id.copy({"name": "New pricelist!"})
+        cart.write({"pricelist_id": new_pricelist.id})
+        self._sign_with(partner)
+        self.assertEqual(cart.pricelist_id, new_pricelist)
+
     def test_ask_email(self):
         """
         Test the ask_email when not logged.


### PR DESCRIPTION
**Current behavior:**
During the creation of the cart with an anonymous customer, the pricelist of the shopinvader backend is set (it's ok).
Then if the user log-in, it's the customer's pricelist who is applied on the cart (not ok).

**Fix:**
During the onchange, set the pricelist with the one set on the cart to don't let the onchange update it.

After validation, this PR should be applied in v12.0