### PR TITLE
s_sale_packaging: adapt filter to changes sale_by_packaging

### DIFF
--- a/shopinvader_sale_packaging/models/shopinvader_variant.py
+++ b/shopinvader_sale_packaging/models/shopinvader_variant.py
@@ -35,7 +35,7 @@ class ShopinvaderVariant(models.Model):
         return {
             "lang": self.lang_id.code,
             # consider only packaging that can be sold
-            "_packaging_filter": lambda x: x.packaging_type_id.can_be_sold,
+            "_packaging_filter": lambda x: x.can_be_sold,
             # to support multilang shop we rely on packaging type's name
             # which is already translatable.
             "_packaging_name_getter": lambda x: x.packaging_type_id.name,

--- a/shopinvader_sale_packaging/services/packaging_mixin.py
+++ b/shopinvader_sale_packaging/services/packaging_mixin.py
@@ -32,7 +32,7 @@ class PackagingServiceMixin(AbstractComponent):
     def _packaging_info_ctx(self):
         return {
             # consider only packaging that can be sold
-            "_packaging_filter": lambda x: x.packaging_type_id.can_be_sold,
+            "_packaging_filter": lambda x: x.can_be_sold,
             # to support multilang shop we rely on packaging type's name
             # which is already translatable.
             "_packaging_name_getter": lambda x: x.packaging_type_id.name,


### PR DESCRIPTION
The flag is now independent from the pkg type.

See https://github.com/OCA/sale-workflow/pull/1375