### PR TITLE
shopinvader: fix services description

### DIFF
--- a/shopinvader/services/address.py
+++ b/shopinvader/services/address.py
@@ -12,6 +12,9 @@ from odoo.exceptions import AccessError
 
 
 class AddressService(Component):
+    """Shopinvader service to create and edit customers' addresses.
+    """
+
     _inherit = [
         "base.shopinvader.service",
         "shopinvader.partner.service.mixin",
@@ -19,6 +22,7 @@ class AddressService(Component):
     _name = "shopinvader.address.service"
     _usage = "addresses"
     _expose_model = "res.partner"
+    _description = __doc__
 
     # The following method are 'public' and can be called from the controller.
 

--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -15,9 +15,13 @@ _logger = logging.getLogger(__name__)
 
 
 class CartService(Component):
+    """Shopinvader service to provide e-commerce cart features.
+    """
+
     _inherit = "shopinvader.abstract.sale.service"
     _name = "shopinvader.cart.service"
     _usage = "cart"
+    _description = __doc__
 
     @property
     def cart_id(self):
@@ -26,8 +30,8 @@ class CartService(Component):
     # The following method are 'public' and can be called from the controller.
 
     def search(self):
-        """Return the cart that have been set in the session or
-           search an existing cart for the current partner"""
+        """Retrieve cart from session or existing cart for current customer.
+        """
         if not self.cart_id:
             return {}
         return self._to_json(self._get())

--- a/shopinvader/services/customer.py
+++ b/shopinvader/services/customer.py
@@ -9,12 +9,16 @@ from odoo.addons.component.core import Component
 
 
 class CustomerService(Component):
+    """Shopinvader service to create and edit customers.
+    """
+
     _inherit = [
         "base.shopinvader.service",
         "shopinvader.partner.service.mixin",
     ]
     _name = "shopinvader.customer.service"
     _usage = "customer"
+    _description = __doc__
 
     # The following method are 'public' and can be called from the controller.
     def get(self):

--- a/shopinvader/services/invoice.py
+++ b/shopinvader/services/invoice.py
@@ -5,6 +5,9 @@ from odoo.osv import expression
 
 
 class InvoiceService(Component):
+    """Shopinvader service to expose invoices.
+    """
+
     _inherit = [
         "shopinvader.abstract.mail.service",
         "abstract.shopinvader.download",
@@ -12,7 +15,7 @@ class InvoiceService(Component):
     _name = "shopinvader.invoice.service"
     _usage = "invoice"
     _expose_model = "account.move"
-    _description = "Service providing a method to download invoices"
+    _description = __doc__
 
     # The following method are 'public' and can be called from the controller.
     # All params are untrusted so please check it !

--- a/shopinvader/services/sale.py
+++ b/shopinvader/services/sale.py
@@ -7,6 +7,9 @@ from odoo.osv import expression
 
 
 class SaleService(Component):
+    """Shopinvader service to expose sale orders records.
+    """
+
     _inherit = [
         "shopinvader.abstract.sale.service",
         "abstract.shopinvader.download",
@@ -14,6 +17,7 @@ class SaleService(Component):
     _name = "shopinvader.sale.service"
     _usage = "sales"
     _expose_model = "sale.order"
+    _description = __doc__
 
     # The following method are 'public' and can be called from the controller.
     # All params are untrusted so please check it !

--- a/shopinvader_delivery_carrier/services/delivery_carrier.py
+++ b/shopinvader_delivery_carrier/services/delivery_carrier.py
@@ -8,13 +8,13 @@ from odoo.addons.component.core import Component
 
 
 class DeliveryCarrierService(Component):
+    """Shopinvader service to retrieve delivery carrier information.
+    """
+
     _inherit = "base.shopinvader.service"
     _name = "shopinvader.delivery.carrier.service"
     _usage = "delivery_carrier"
-    _description = """
-        This service allows you to retrieve the informations of available
-        delivery carriers.
-    """
+    _description = __doc__
 
     # Public services:
 

--- a/shopinvader_lead/services/lead.py
+++ b/shopinvader_lead/services/lead.py
@@ -8,10 +8,14 @@ from odoo.addons.component.core import Component
 
 
 class LeadService(Component):
+    """Shopinvader service to expose crm.lead features.
+    """
+
     _inherit = "base.shopinvader.service"
     _name = "shopinvader.lead.service"
     _usage = "lead"
     _expose_model = "crm.lead"
+    _description = __doc__
 
     # The following methods are 'public' and can be called from the controller.
     # All params are untrusted so please check it by using the decorator

--- a/shopinvader_wishlist/services/wishlist.py
+++ b/shopinvader_wishlist/services/wishlist.py
@@ -12,10 +12,14 @@ from werkzeug.exceptions import NotFound
 
 
 class WishlistService(Component):
+    """Shopinvader service to manage current user's wishlists.
+    """
+
     _name = "shopinvader.wishlist.service"
     _inherit = "base.shopinvader.service"
     _usage = "wishlist"
     _expose_model = "product.set"
+    _description = __doc__
 
     # The following method are 'public' and can be called from the controller.
     # All params are untrusted so please check it !


### PR DESCRIPTION
openapi are broken without this change.

```
  File "/odoo/external-src/rest-framework/base_rest/apispec/base_rest_service_apispec.py", line 27, in __init__
    getattr(self._service, "_description", "")
  File "/usr/lib/python3.7/textwrap.py", line 430, in dedent
    text = _whitespace_only_re.sub('', text)
TypeError: expected string or bytes-like object - - -
```
In any case is good to have proper docstrings.