### PR TITLE
s_locomotive: sync to site settings only visible filters

### DIFF
--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -54,7 +54,8 @@
                                 <field name="website_public_name"/>
                             </group>
                             <group name="search_filters" string="Filters" colspan="4">
-                                <field name="filter_ids" nolabel="1"/>
+                                <field name="filter_ids" nolabel="1"
+                                       context="{'tree_view_ref': 'shopinvader.product_filter_view_tree'}" />
                             </group>
                         </page>
                         <page name="sale" string="Sale">

--- a/shopinvader_locomotive/__manifest__.py
+++ b/shopinvader_locomotive/__manifest__.py
@@ -19,6 +19,7 @@
     ],
     "data": [
         "views/shopinvader_backend_view.xml",
+        "views/product_filter_view.xml",
         "data/ir_cron.xml",
         "data/queue_job_function_data.xml",
     ],

--- a/shopinvader_locomotive/component/shopinvader_site_export_mapper.py
+++ b/shopinvader_locomotive/component/shopinvader_site_export_mapper.py
@@ -47,11 +47,13 @@ class ShopinvaderSiteExportMapper(Component):
         }
 
     @mapping
-    @changed_by("filter_ids")
+    @changed_by("visible_filter_ids")
     def filters(self, record):
         return {
             "all_filters": self._m2m_to_external(
-                record, "filter_ids", ["name", "display_name:code", "help"]
+                record,
+                "visible_filter_ids",
+                ["name", "display_name:code", "help"],
             )
         }
 

--- a/shopinvader_locomotive/models/__init__.py
+++ b/shopinvader_locomotive/models/__init__.py
@@ -2,3 +2,4 @@ from . import res_partner
 from . import shopinvader_backend
 from . import locomotive_binding
 from . import shopinvader_partner
+from . import product_filter

--- a/shopinvader_locomotive/models/product_filter.py
+++ b/shopinvader_locomotive/models/product_filter.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ProductFilter(models.Model):
+    _inherit = "product.filter"
+
+    visible = fields.Boolean(
+        default=True,
+        help="* ON: the filter will be pushed to site settings, "
+        "therefore it is going to be visible in frontend faceted search;\n"
+        "* OFF: the filter will be usable for searching but invisible as filter.",
+    )

--- a/shopinvader_locomotive/models/shopinvader_backend.py
+++ b/shopinvader_locomotive/models/shopinvader_backend.py
@@ -31,6 +31,17 @@ class ShopinvaderBackend(models.Model):
     currency_ids = fields.Many2many(
         comodel_name="res.currency", string="Currency"
     )
+    visible_filter_ids = fields.Many2many(
+        comodel_name="product.filter", compute="_compute_visible_filter_ids"
+    )
+
+    @api.depends_context("lang")
+    @api.depends("filter_ids.visible")
+    def _compute_visible_filter_ids(self):
+        for rec in self:
+            rec.visible_filter_ids = rec.filter_ids.filtered(
+                lambda x: x.visible
+            )
 
     @property
     def _server_env_fields(self):

--- a/shopinvader_locomotive/tests/test_backend.py
+++ b/shopinvader_locomotive/tests/test_backend.py
@@ -377,3 +377,27 @@ class TestBackend(TestBackendCommonCase):
                     "api_url": self.api_url,
                 },
             )
+
+    def test_erp_synchronize_04(self):
+        """Test only visible filters are exported
+        """
+        self.backend.filter_ids.filtered(
+            lambda x: x.display_name == "variant_attributes.color"
+        ).visible = False
+        with mock_site_api(self.base_url, self.site) as mock:
+            self.backend.synchronize_metadata()
+            metafields = self._extract_metafields(
+                mock.request_history[0].json()["site"]["metafields"]
+            )
+            expected_filters = {
+                "en": [
+                    {
+                        "code": "variant_attributes.legs",
+                        "name": "Memory",
+                        "help": "<p>Memory of the product</p>",
+                    },
+                ]
+            }
+            self.assertDictEqual(
+                metafields["_store"]["all_filters"], expected_filters
+            )

--- a/shopinvader_locomotive/views/product_filter_view.xml
+++ b/shopinvader_locomotive/views/product_filter_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="product_filter_view_form" model="ir.ui.view">
+        <field name="model">product.filter</field>
+        <field name="inherit_id"
+               ref="shopinvader.product_filter_view_form"/>
+        <field name="arch" type="xml">
+          <field name="variant_attribute_id" position="after">
+            <field name="visible"/>
+          </field>
+        </field>
+    </record>
+
+    <record id="product_filter_view_tree" model="ir.ui.view">
+        <field name="model">product.filter</field>
+        <field name="inherit_id"
+               ref="shopinvader.product_filter_view_tree"/>
+        <field name="arch" type="xml">
+          <field name="name" position="after">
+            <field name="visible"/>
+          </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
New flag for product filter to be able to decide which filter
is used for normal search and which fields is visible as a specific filter
in frontend (eg: faceted search).