### PR TITLE
s_wishlist: add new endpoint 'add_items_to_cart'

### DIFF
--- a/shopinvader_sale_packaging_wishlist/tests/test_wishlist_packaging.py
+++ b/shopinvader_sale_packaging_wishlist/tests/test_wishlist_packaging.py
@@ -40,7 +40,7 @@ class WishlistCase(CommonWishlistCase):
         self.assertIn(prod, self.prod_set.mapped("set_line_ids.product_id"))
         self._bind_products(prod)
         # This line has no package
-        line = self.prod_set.get_line_by_product(product_id=prod.id)
+        line = self.prod_set.get_lines_by_products(product_ids=prod.ids)
         self.assertEqual(line.quantity, 1)
         # Add package and package qty
         params = {

--- a/shopinvader_wishlist/models/product_set.py
+++ b/shopinvader_wishlist/models/product_set.py
@@ -1,7 +1,11 @@
 # Copyright 2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
+
 from odoo import _, api, exceptions, fields, models
+
+_logger = logging.getLogger(__name__)
 
 
 class ProductSet(models.Model):
@@ -22,17 +26,32 @@ class ProductSet(models.Model):
     )
 
     def get_line_by_product(self, product_id=None, invader_variant_id=None):
-        if not product_id and not invader_variant_id:
-            raise exceptions.ValidationError(
-                _("Provide `product_id` or `invader_variant_id`")
-            )
+        # Backward compat
+        _logger.info(
+            "DEPRECATED `get_line_by_product`. Use `get_lines_by_products`"
+        )
         if product_id:
+            product_id = [product_id]
+        if invader_variant_id:
+            invader_variant_id = [invader_variant_id]
+        return self.get_lines_by_products(
+            product_ids=product_id, invader_variant_ids=invader_variant_id
+        )
+
+    def get_lines_by_products(
+        self, product_ids=None, invader_variant_ids=None
+    ):
+        if not product_ids and not invader_variant_ids:
+            raise exceptions.ValidationError(
+                _("Provide `product_ids` or `invader_variant_id`")
+            )
+        if product_ids:
             return self.set_line_ids.filtered(
-                lambda x: x.product_id.id == product_id
+                lambda x: x.product_id.id in product_ids
             )
         else:
             return self.set_line_ids.filtered(
-                lambda x: x.shopinvader_variant_id.id == invader_variant_id
+                lambda x: x.shopinvader_variant_id.id in invader_variant_ids
             )
 
 

--- a/shopinvader_wishlist/services/wishlist.py
+++ b/shopinvader_wishlist/services/wishlist.py
@@ -312,7 +312,7 @@ class WishlistService(Component):
 
     def _get_existing_line(self, record, params, raise_if_not_found=False):
         product_id = params["product_id"]
-        line = record.get_line_by_product(product_id=product_id)
+        line = record.get_lines_by_products(product_ids=[product_id])
         if not line and raise_if_not_found:
             raise NotFound(
                 "No product found with id %s" % params["product_id"]

--- a/shopinvader_wishlist/services/wishlist.py
+++ b/shopinvader_wishlist/services/wishlist.py
@@ -61,6 +61,16 @@ class WishlistService(Component):
         # return new cart
         return cart_service._to_json(cart)
 
+    def add_items_to_cart(self, _id, **params):
+        record = self._get(_id)
+        cart_service = self.component(usage="cart")
+        cart = cart_service._get()
+        prod_ids = [x["product_id"] for x in params["lines"]]
+        lines = record.get_lines_by_products(product_ids=prod_ids)
+        self._add_items_to_cart(record, cart, lines)
+        # return new cart
+        return cart_service._to_json(cart)
+
     def add_items(self, _id, **params):
         record = self._get(_id)
         self._add_items(record, params)
@@ -165,6 +175,28 @@ class WishlistService(Component):
             }
         }
 
+    def _validator_add_items_to_cart(self):
+        schema = self._validator_add_to_cart()
+        schema.update(
+            {
+                "lines": {
+                    "type": "list",
+                    "required": True,
+                    "schema": {
+                        "type": "dict",
+                        "schema": {
+                            "product_id": {
+                                "coerce": to_int,
+                                "required": True,
+                                "type": "integer",
+                            },
+                        },
+                    },
+                },
+            }
+        )
+        return schema
+
     def _validator_add_item(self):
         return self._validator_line_schema()
 
@@ -262,6 +294,11 @@ class WishlistService(Component):
 
     def _add_to_cart(self, record, cart):
         wizard = self._get_add_to_cart_wizard(record, cart)
+        return wizard.add_set()
+
+    def _add_items_to_cart(self, record, cart, lines):
+        wizard = self._get_add_to_cart_wizard(record, cart)
+        wizard.product_set_line_ids = lines
         return wizard.add_set()
 
     def _prepare_params(self, params, mode="create"):

--- a/shopinvader_wishlist/tests/test_product_set.py
+++ b/shopinvader_wishlist/tests/test_product_set.py
@@ -57,8 +57,31 @@ class ProductSet(CommonCase):
     #     )
     #     self.assertEqual(line.shopinvader_variant_id, variant_en)
 
-    def test_get_line_by_product(self):
+    def test_get_lines_by_products(self):
         # ensure we can create a line from the product and we get the variant
+        prod = self.env.ref("product.product_product_4d")
+        line = self.prod_set.set_line_ids.create(
+            {
+                "product_set_id": self.prod_set.id,
+                "product_id": prod.id,
+                "quantity": 1,
+            }
+        )
+        variant = prod.shopinvader_bind_ids[0]
+        self.assertEqual(
+            self.prod_set.get_lines_by_products(
+                invader_variant_ids=variant.ids
+            ),
+            line,
+        )
+        self.assertEqual(
+            self.prod_set.get_lines_by_products(product_ids=prod.ids), line
+        )
+        with self.assertRaises(exceptions.ValidationError):
+            self.prod_set.get_lines_by_products()
+
+    def test_get_line_by_product_backward_compat(self):
+        # ensure old method `get_line_by_product` works
         prod = self.env.ref("product.product_product_4d")
         line = self.prod_set.set_line_ids.create(
             {

--- a/shopinvader_wishlist/tests/test_wishlist.py
+++ b/shopinvader_wishlist/tests/test_wishlist.py
@@ -212,8 +212,8 @@ class WishlistCase(CommonWishlistCase):
             "update_items", self.prod_set.id, params=params
         )
         for line in lines_data:
-            line = self.prod_set.get_line_by_product(
-                product_id=line["product_id"]
+            line = self.prod_set.get_lines_by_products(
+                product_ids=[line["product_id"]]
             )
             self.assertEqual(line.quantity, line["quantity"])
 
@@ -243,7 +243,7 @@ class WishlistCase(CommonWishlistCase):
         self._test_update_items(
             prod1, [{"product_id": prod1.id, "quantity": 1}]
         )
-        line1 = self.prod_set.get_line_by_product(product_id=prod1.id)
+        line1 = self.prod_set.get_lines_by_products(product_ids=prod1.ids)
         line1.sequence = 10
         # Add another line and change order
         prod2 = self.env.ref("product.product_product_4d")
@@ -255,7 +255,7 @@ class WishlistCase(CommonWishlistCase):
         before = self.wishlist_service.dispatch(
             "add_items", self.prod_set.id, params=params
         )
-        line2 = self.prod_set.get_line_by_product(product_id=prod2.id)
+        line2 = self.prod_set.get_lines_by_products(product_ids=prod2.ids)
         self.assertEqual(line1.sequence, 10)
         self.assertEqual(line2.sequence, 0)
         self.assertEqual(
@@ -276,7 +276,7 @@ class WishlistCase(CommonWishlistCase):
         prod = self.env.ref("product.product_product_4b")
         self._bind_products(prod)
         self.assertIn(prod, self.prod_set.mapped("set_line_ids.product_id"))
-        line = self.prod_set.get_line_by_product(product_id=prod.id)
+        line = self.prod_set.get_lines_by_products(product_ids=prod.ids)
         self.assertEqual(line.quantity, 1)
         params = {"lines": [{"product_id": prod.id}]}
         self.wishlist_service.dispatch(

--- a/shopinvader_wishlist/tests/test_wishlist.py
+++ b/shopinvader_wishlist/tests/test_wishlist.py
@@ -186,6 +186,26 @@ class WishlistCase(CommonWishlistCase):
             self.wishlist_service.add_to_cart(self.prod_set.id)
             self.assertEqual(cart.order_line[0].product_id, prod)
 
+    def test_add_items_to_cart(self):
+        for line in self.wl_params["lines"]:
+            self.prod_set.set_line_ids.create(
+                dict(line, product_set_id=self.prod_set.id)
+            )
+        self.assertEqual(len(self.prod_set.set_line_ids), 3)
+        with self.work_on_services(partner=self.partner) as work:
+            cart_service = work.component(usage="cart")
+        cart = cart_service._get()
+        # no line yet
+        self.assertFalse(cart.order_line)
+
+        # add only to products to cart
+        prods = self.prod_set.set_line_ids[:2].mapped("product_id")
+        params = {"lines": [{"product_id": x.id} for x in prods]}
+        with mock.patch.object(type(cart_service), "_get") as mocked:
+            mocked.return_value = cart
+            self.wishlist_service.add_items_to_cart(self.prod_set.id, **params)
+            self.assertEqual(cart.mapped("order_line.product_id"), prods)
+
     def test_add_items(self):
         prod1 = self.env.ref("product.product_product_4d")
         prod2 = self.env.ref("product.product_product_11")


### PR DESCRIPTION
New endpoint to allow adding selected products to cart
instead of the whole set of products in the wishlist.

Depends on https://github.com/OCA/sale-workflow/pull/1471 (merged)