### PR TITLE
14.0 [FIX] merge conflicts on test-requirements.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test-requirements.txt merge=ours


### PR DESCRIPTION
When merging several PRs at once, we can run into merge conflicts on `test-requirements.txt` This file being irrelevant if not in CI context, the PR allows to not merge it when there is a conflict.

Also, you will need to run `git config --global merge.ours.driver true` before it works

This is is inspired by this: https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#_merge_strategies 

@sbidoul This may interest you as my use case is git-agregator for this.