### PR TITLE
[10.0][FIX] shopinvader_membership: missing ID in search

### DIFF
--- a/shopinvader_membership/services/membership_product.py
+++ b/shopinvader_membership/services/membership_product.py
@@ -54,6 +54,7 @@ class MembershipService(Component):
         :return: dict
         """
         membership_product_schema = {
+            "id": {"type": "integer"},
             "name": {"type": "string", "nullable": True},
             "default_code": {"type": "string", "nullable": True},
             "description_sale": {"type": "string", "nullable": True},
@@ -76,7 +77,13 @@ class MembershipService(Component):
         Get the parser of membership products
         :return: list
         """
-        to_parse = ["name", "default_code", "description_sale", "list_price"]
+        to_parse = [
+            "id",
+            "name",
+            "default_code",
+            "description_sale",
+            "list_price",
+        ]
         return to_parse
 
     def _to_json_membership_product(self, membership_product):

--- a/shopinvader_membership/tests/test_membership_product_service.py
+++ b/shopinvader_membership/tests/test_membership_product_service.py
@@ -30,6 +30,7 @@ class TestMembershipProductService(CommonCase):
         )
         self.assertEquals(len(data), len(membership_products))
         for current_data, membership_product in zip(data, membership_products):
+            self.assertEquals(current_data.get("id"), membership_product.id)
             self.assertEquals(
                 current_data.get("name"), membership_product.name
             )


### PR DESCRIPTION
Missing `id` in `shopinvader_membership/search` so it's not possible then to browse or work with it.