### PR TITLE
shopinvader: product filter custom path for fields

### DIFF
--- a/shopinvader/models/product_filter.py
+++ b/shopinvader/models/product_filter.py
@@ -43,11 +43,22 @@ class ProductFilter(models.Model):
     # TODO: rename to not clash w/ built-in
     help = fields.Html(translate=True)
     name = fields.Char(translate=True, required=True)
+    # TODO: rename this to `code`, "display_name" makes no sense.
+    # Also, in shopinvader_locomotive it is exported as `code`.
     display_name = fields.Char(compute="_compute_display_name")
+    # TODO: replace completely `display_name`
+    # NOTE: this allows to unify filter/index keys across languages.
+    # For prod attributes we'd neeed a unique language agnostic key
+    # on product.attribute.
+    path = fields.Char(
+        help="Enforce external filter key used for indexing and search."
+        "Being a path, you can specify a dotted path to an inner value. "
+        "Eg: supplier = {id: 1, name: 'Foo'} -> `supplier.name`",
+    )
 
     def _build_display_name(self):
         if self.based_on == "field":
-            return self.field_id.name
+            return self.path or self.field_id.name
         elif self.based_on == "variant_attribute":
             return "variant_attributes.%s" % sanitize_attr_name(
                 self.variant_attribute_id

--- a/shopinvader/tests/test_product_filter.py
+++ b/shopinvader/tests/test_product_filter.py
@@ -54,6 +54,16 @@ class TestProductFilter(CommonCase):
             "x_custom_field",
         )
 
+    def test_product_filter_field_name_with_path(self):
+        self.filter_on_field.path = "x_custom_field.inner_value"
+        self.assertEqual(
+            self.filter_on_field.display_name, "x_custom_field.inner_value"
+        )
+        self.assertEqual(
+            self.filter_on_field.with_context(lang="fr_FR").display_name,
+            "x_custom_field.inner_value",
+        )
+
     def test_product_filter_attribute_name(self):
         self.assertEqual(
             self.filter_on_attr.display_name,

--- a/shopinvader/views/product_filter_view.xml
+++ b/shopinvader/views/product_filter_view.xml
@@ -9,10 +9,10 @@
                     <field name="name"/>
                     <field name="based_on"/>
                     <field name="field_id" attrs="{'invisible': [('based_on', '!=', 'field')],
-
-                                               'required': [('based_on', '=', 'field')]}"/>
+                                                   'required': [('based_on', '=', 'field')]}"/>
                     <field name="variant_attribute_id" attrs="{'invisible': [('based_on', '!=', 'variant_attribute')],
                                                    'required': [('based_on', '=', 'variant_attribute')]}"/>
+                    <field name="path"  attrs="{'invisible': [('based_on', '!=', 'field')]}" />
                     <separator string="Help"/>
                     <field name="help" colspan="4" nolabel="1"/>
                 </group>


### PR DESCRIPTION
It's quite common to define product data for index using serialized fields.
Often you need to take control of the resulting value for the filter
(eg: search on inner value) and now you can do it by setting `path`.