### PR TITLE
shopinvader_algolia: preserve settings from index config

### DIFF
--- a/shopinvader_algolia/models/se_index.py
+++ b/shopinvader_algolia/models/se_index.py
@@ -1,15 +1,18 @@
 # Copyright 2019 Akretion (http://www.akretion.com).
 # @author Florian da Costa <florian?dacosta@akretion.com>
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models
+from odoo.addons.connector_algolia.utils import data_merge
 
 
 class SeIndex(models.Model):
     _inherit = "se.index"
 
     def _get_settings(self):
-        data = super(SeIndex, self)._get_settings()
+        settings = super(SeIndex, self)._get_settings()
         model = self.model_id.model
         # TODO check backend se type and call specific algolia method?
         facetting_values = {}
@@ -18,5 +21,5 @@ class SeIndex(models.Model):
                 self.backend_id, self.lang_id
             )
         if facetting_values:
-            data.update({"attributesForFaceting": facetting_values})
-        return data
+            data_merge(settings, {"attributesForFaceting": facetting_values})
+        return settings


### PR DESCRIPTION
Settings can come from models and from index config.
When this happens, make sure they are all preserved and merged.