### PR TITLE
s_wishlist: fix variant lookup by lang

### DIFF
--- a/shopinvader_wishlist/models/product_set.py
+++ b/shopinvader_wishlist/models/product_set.py
@@ -17,13 +17,6 @@ class ProductSet(models.Model):
         help="If you are using this set for shopinvader customer "
         "you must select a backend.",
     )
-    lang_id = fields.Many2one(
-        "res.lang",
-        string="Lang",
-        default=lambda self: self.env["res.lang"]._lang_get(
-            self.env.context.get("lang")
-        ),
-    )
 
     def get_line_by_product(self, product_id=None, invader_variant_id=None):
         # Backward compat
@@ -70,24 +63,18 @@ class ProductSetLine(models.Model):
             if record.shopinvader_variant_id and not record.product_id:
                 record.product_id = record.shopinvader_variant_id.record_id
 
-    @api.depends("product_id", "product_set_id.lang_id")
+    @api.depends("product_id")
+    @api.depends_context("lang")
     def _compute_shopinvader_variant(self):
         for record in self:
             if record.product_id and not record.shopinvader_variant_id:
                 backend = record.product_set_id.shopinvader_backend_id
-                # lang = record.product_set_id.lang_id.code
-                # TMP FIX: apparently the lang is not propagate to the context
-                # from the locomotive request
-                # and we cannot make sure which lang
-                # is going to be used.
-                # Let's rely only on the partner until we solve it.
-                lang = record.product_set_id.partner_id.lang
-                # / FIX
+                lang = self.env.context.get("lang")
                 variant = record.product_id._get_invader_variant(backend, lang)
-                # if not variant:
-                #     lang = record.product_set_id.partner_id.lang
-                #     # try w/ partner lang
-                #     variant = record.product_id._get_invader_variant(
-                #         backend, lang
-                #     )
+                if not variant:
+                    lang = record.product_set_id.partner_id.lang
+                    # try w/ partner lang
+                    variant = record.product_id._get_invader_variant(
+                        backend, lang
+                    )
                 record.shopinvader_variant_id = variant

--- a/shopinvader_wishlist/tests/test_product_set.py
+++ b/shopinvader_wishlist/tests/test_product_set.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import exceptions
+from odoo.tools import mute_logger
 
 from odoo.addons.shopinvader.tests.common import CommonCase
 
@@ -28,35 +29,35 @@ class ProductSet(CommonCase):
         self.assertEqual(line.shopinvader_variant_id, variant)
         self.assertEqual(variant.lang_id.code, "en_US")
 
-    # TODO: disabled for temporary fix to rely only on partner lang.
-    # See ../models/product_set.py
-    # def test_create_no_variant_switch_lang(self):
-    #     lang_fr = self._install_lang("base.lang_fr")
-    #     self.backend.lang_ids |= lang_fr
-    #     self.prod_set.lang_id = lang_fr
-    #     # ensure we can create a line from the product and we get the variant
-    #     prod = self.env.ref("product.product_product_4b")
-    #     self._bind_products(prod)
-    #     line = self.prod_set.set_line_ids.create(
-    #         {
-    #             "product_set_id": self.prod_set.id,
-    #             "product_id": prod.id,
-    #             "quantity": 1,
-    #         }
-    #     )
-    #     # test it w/ multi lang
-    #     variant_en = prod._get_invader_variant(self.backend, "en_US")
-    #     variant_fr = prod._get_invader_variant(self.backend, "fr_FR")
-    #     self.assertEqual(line.shopinvader_variant_id, variant_fr)
-    #     self.prod_set.lang_id = False
-    #     line = self.prod_set.set_line_ids.create(
-    #         {
-    #             "product_set_id": self.prod_set.id,
-    #             "product_id": prod.id,
-    #             "quantity": 1,
-    #         }
-    #     )
-    #     self.assertEqual(line.shopinvader_variant_id, variant_en)
+    @mute_logger("odoo.models.unlink")
+    def test_create_no_variant_switch_lang(self):
+        lang_fr = self._install_lang("base.lang_fr")
+        self.backend.lang_ids |= lang_fr
+        self.prod_set.partner_id.lang = lang_fr.code
+        # ensure we can create a line from the product and we get the variant
+        prod = self.env.ref("product.product_product_4b")
+        self._bind_products(prod)
+        line = self.prod_set.set_line_ids.create(
+            {
+                "product_set_id": self.prod_set.id,
+                "product_id": prod.id,
+                "quantity": 1,
+            }
+        )
+        # test it w/ multi lang
+        variant_en = prod._get_invader_variant(self.backend, "en_US")
+        variant_fr = prod._get_invader_variant(self.backend, "fr_FR")
+        self.assertEqual(
+            line.with_context(lang="en_US").shopinvader_variant_id, variant_en
+        )
+        self.assertEqual(
+            line.with_context(lang="fr_FR").shopinvader_variant_id, variant_fr
+        )
+        # delete variant, fallback to the one matching partner lang
+        variant_en.unlink()
+        self.assertEqual(
+            line.with_context(lang="en_US").shopinvader_variant_id, variant_fr
+        )
 
     def test_get_lines_by_products(self):
         # ensure we can create a line from the product and we get the variant

--- a/shopinvader_wishlist/views/product_set.xml
+++ b/shopinvader_wishlist/views/product_set.xml
@@ -9,9 +9,6 @@
       <field name="name" position="before">
         <field name="shopinvader_backend_id"/>
       </field>
-      <field name="partner_id" position="after">
-        <field name="lang_id"/>
-      </field>
     </field>
   </record>
 


### PR DESCRIPTION
The lang used to load the variant must be the one of the current request.
This change removes and hack from a long time ago where the lang was not respected.