### PR TITLE
[10.0][FIX] shopinvader_sale_profile: takes default profile if partner pricelist not listed

### DIFF
--- a/shopinvader_sale_profile/services/__init__.py
+++ b/shopinvader_sale_profile/services/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
+from . import cart
 from . import shopinvader_customer_service

--- a/shopinvader_sale_profile/services/cart.py
+++ b/shopinvader_sale_profile/services/cart.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo.addons.component.core import Component
+
+
+class CartService(Component):
+    _inherit = "shopinvader.cart.service"
+
+    def _prepare_cart(self):
+        vals = super(CartService, self)._prepare_cart()
+        backend = self.shopinvader_backend
+        partner = self.partner or self.shopinvader_backend.anonymous_partner_id
+        if backend.use_sale_profile:
+            partner_pricelist = partner.property_product_pricelist
+            if partner_pricelist not in backend.sale_profile_ids.mapped(
+                "pricelist_id"
+            ):
+                vals.update(
+                    {
+                        "pricelist_id": backend.sale_profile_ids.filtered(
+                            "default"
+                        ).pricelist_id.id
+                    }
+                )
+        return vals

--- a/shopinvader_sale_profile/tests/__init__.py
+++ b/shopinvader_sale_profile/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from . import test_cart
 from . import test_shopinvader_sale_profile
 from . import test_customer_service
 from . import test_shopinvader_partner

--- a/shopinvader_sale_profile/tests/test_cart.py
+++ b/shopinvader_sale_profile/tests/test_cart.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.addons.shopinvader.tests.test_cart import CartCase
+
+
+class TestCartPricelist(CartCase):
+    def setUp(self, *args, **kwargs):
+        super(TestCartPricelist, self).setUp(*args, **kwargs)
+        self.partner = self.backend.anonymous_partner_id
+        self.product_1 = self.env.ref("product.product_product_4b")
+        self.sale_obj = self.env["sale.order"]
+
+        self.pricelist_no_profile = self.env["product.pricelist"].create(
+            {"name": "TEST no profile"}
+        )
+        self.backend.pricelist_id = False
+        self.backend.use_sale_profile = True
+        with self.work_on_services(
+            partner=None, shopinvader_session=self.shopinvader_session
+        ) as work:
+            self.service = work.component(usage="cart")
+
+    def test_cart_pricelist_profile(self):
+        """
+        If the partner pricelist is listed on sale profiles
+        it should keep this one
+        """
+        self.assertEqual(
+            self.partner.property_product_pricelist,
+            self.env.ref("product.list0"),
+        )
+        cart = self.service._get()
+        self.assertEqual(cart.pricelist_id, self.env.ref("product.list0"))
+
+    def test_cart_pricelist_no_profile(self):
+        """
+        If the partner pricelist is not listed on sale profiles it should
+        take the default one
+        """
+        self.partner.write(
+            {"property_product_pricelist": self.pricelist_no_profile.id}
+        )
+        self.assertEqual(
+            self.partner.property_product_pricelist.id,
+            self.pricelist_no_profile.id,
+        )
+        cart = self.service._get()
+        self.assertEqual(cart.pricelist_id, self.env.ref("product.list0"))


### PR DESCRIPTION
When using shopinvader sale_profile, you define which pricelists are exposed on frontend.
Than depending on the pricelist set on the partner, the right role is assigned on frontend. If the pricelist set on the partner is not listed on configured profiles, the default one is set.
Thansks to that, the customer always see the good prices on frontend.

The problem is when he creates a cart, by default, the one set on the partner is used. So if its not listed, you can have inconsistencies between prices on product page and price on the cart.

This PR aims to solve this point. If the partner pricelist is not listed on the backend profiles, the default one is used to ensure consistency.