### PR TITLE
[13.0] shopinvader: refactor and improve binding wiz

### DIFF
--- a/shopinvader/data/queue_job_channel_data.xml
+++ b/shopinvader/data/queue_job_channel_data.xml
@@ -7,4 +7,8 @@
         <field name="name">notification</field>
         <field name="parent_id" ref="channel_shopinvader" />
     </record>
+    <record model="queue.job.channel" id="channel_shopinvader_bind_products">
+        <field name="name">bind_products</field>
+        <field name="parent_id" ref="channel_shopinvader" />
+    </record>
 </odoo>

--- a/shopinvader/data/queue_job_function_data.xml
+++ b/shopinvader/data/queue_job_function_data.xml
@@ -4,4 +4,14 @@
         <field name="method">send</field>
         <field name="channel_id" ref="channel_shopinvader_notification" />
     </record>
+    <record id="job_function_shopinvader_bind_selected_products" model="queue.job.function">
+        <field name="model_id" ref="model_shopinvader_backend" />
+        <field name="method">bind_selected_products</field>
+        <field name="channel_id" ref="channel_shopinvader_bind_products" />
+    </record>
+    <record id="job_function_shopinvader_bind_single_product" model="queue.job.function">
+        <field name="model_id" ref="model_shopinvader_backend" />
+        <field name="method">bind_single_product</field>
+        <field name="channel_id" ref="channel_shopinvader_bind_products" />
+    </record>
 </odoo>

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -37,7 +37,11 @@ class UtilsMixin(object):
         backend = backend or self.backend
         bind_wizard_model = self.env["shopinvader.variant.binding.wizard"]
         bind_wizard = bind_wizard_model.create(
-            {"backend_id": backend.id, "product_ids": [(6, 0, products.ids)]}
+            {
+                "backend_id": backend.id,
+                "product_ids": [(6, 0, products.ids)],
+                "run_immediately": True,
+            }
         )
         bind_wizard.bind_products()
 

--- a/shopinvader/tests/test_backend.py
+++ b/shopinvader/tests/test_backend.py
@@ -12,6 +12,10 @@ class BackendCase(CommonCase):
     def setUpClass(cls):
         super(BackendCase, cls).setUpClass()
         cls.lang_fr = cls._install_lang(cls, "base.lang_fr")
+        cls.env = cls.env(
+            context=dict(cls.env.context, test_queue_job_no_delay=True)
+        )
+        cls.backend = cls.backend.with_context(test_queue_job_no_delay=True)
 
     def _all_products_count(self):
         return self.env["product.template"].search_count(

--- a/shopinvader/tests/test_product.py
+++ b/shopinvader/tests/test_product.py
@@ -12,6 +12,14 @@ from .common import ProductCommonCase
 
 
 class ProductCase(ProductCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(
+            context=dict(cls.env.context, test_queue_job_no_delay=True)
+        )
+        cls.backend = cls.backend.with_context(test_queue_job_no_delay=True)
+
     def test_create_shopinvader_variant(self):
         self.assertEqual(
             len(self.template.product_variant_ids),

--- a/shopinvader/tests/test_shopinvader_variant_binding_wizard.py
+++ b/shopinvader/tests/test_shopinvader_variant_binding_wizard.py
@@ -11,7 +11,13 @@ class TestShopinvaderVariantBindingWizard(SavepointComponentCase):
     @classmethod
     def setUpClass(cls):
         super(TestShopinvaderVariantBindingWizard, cls).setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+                test_queue_job_no_delay=True,
+            )
+        )
         cls.backend = cls.env.ref("shopinvader.backend_1")
         cls.template = cls.env.ref(
             "product.product_product_4_product_template"

--- a/shopinvader/wizards/shopinvader_variant_binding_wizard.py
+++ b/shopinvader/wizards/shopinvader_variant_binding_wizard.py
@@ -1,7 +1,7 @@
 # Copyright 2017 ACSONE SA/NV
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
-from collections import defaultdict
 
 from odoo import api, fields, models
 
@@ -27,6 +27,7 @@ class ShopinvaderVariantBindingWizard(models.TransientModel):
         help="List of langs for which a binding must exists. If not "
         "specified, the list of langs defined on the backend is used.",
     )
+    run_immediately = fields.Boolean(help="Do not schedule jobs.")
 
     @api.model
     def default_get(self, fields_list):
@@ -40,79 +41,27 @@ class ShopinvaderVariantBindingWizard(models.TransientModel):
             res["lang_ids"] = [(6, None, backend.lang_ids.ids)]
         return res
 
-    def _get_langs_to_bind(self):
-        self.ensure_one()
-        return self.lang_ids or self.backend_id.lang_ids
-
-    def _get_bound_templates(self):
-        """
-        return a dict of bound shopinvader.product by product template id
-        :return:
-        """
-        self.ensure_one()
-        binding = self.env["shopinvader.product"]
-        product_template_ids = self.mapped("product_ids.product_tmpl_id")
-        bound_templates = binding.with_context(active_test=False).search(
-            [
-                ("record_id", "in", product_template_ids.ids),
-                ("backend_id", "=", self.backend_id.id),
-                ("lang_id", "in", self._get_langs_to_bind().ids),
-            ]
-        )
-        ret = defaultdict(dict)
-        for bt in bound_templates:
-            ret[bt.record_id][bt.lang_id] = bt
-        for product in self.mapped("product_ids.product_tmpl_id"):
-            product_tmpl_id = product
-            bind_records = ret.get(product_tmpl_id)
-            for lang_id in self._get_langs_to_bind():
-                bind_record = bind_records and bind_records.get(lang_id)
-                if not bind_record:
-                    data = {
-                        "record_id": product.id,
-                        "backend_id": self.backend_id.id,
-                        "lang_id": lang_id.id,
-                    }
-                    ret[product_tmpl_id][lang_id] = binding.create(data)
-                elif not bind_record.active:
-                    bind_record.write({"active": True})
-        return ret
-
     def bind_products(self):
         for wizard in self:
-            bound_templates = wizard._get_bound_templates()
-            binding = self.env["shopinvader.variant"]
-            for product in wizard.product_ids:
-                bound_products = bound_templates[product.product_tmpl_id]
-                for lang_id in wizard._get_langs_to_bind():
-                    for shopinvader_product in bound_products[lang_id]:
-                        bound_variants = (
-                            shopinvader_product.shopinvader_variant_ids
-                        )
-                        bind_record = bound_variants.filtered(
-                            lambda p: p.record_id == product
-                        )
-                        if not bind_record:
-                            # fmt: off
-                            data = {
-                                "record_id": product.id,
-                                "backend_id": wizard.backend_id.id,
-                                "shopinvader_product_id":
-                                    shopinvader_product.id,
-                            }
-                            # fmt: on
-                            binding.create(data)
-                        elif not bind_record.active:
-                            bind_record.write({"active": True})
-            wizard.backend_id.auto_bind_categories()
+            backend = wizard.backend_id
+            method = backend.with_delay().bind_selected_products
+            if wizard.run_immediately:
+                method = backend.bind_selected_products
+            method(
+                wizard.product_ids,
+                langs=wizard.lang_ids,
+                run_immediately=wizard.run_immediately,
+            )
 
     @api.model
     def bind_langs(self, backend, lang_ids):
-        """
-        Ensure that a shopinvader.variant exists for each lang_id. If not,
-        create a new binding for the missing lang. This method is usefull
+        """Ensure that a shopinvader.variant exists for each lang_id.
+
+        If not, create a new binding for the missing lang. This method is useful
         to ensure that when a lang is added to a backend, all the binding
         for this lang are created for the existing bound products
+        for this lang are created for the existing bound products.
+
         :param backend: backend record
         :param lang_ids: list of lang ids we must ensure that a binding exists
         :return:

--- a/shopinvader/wizards/shopinvader_variant_binding_wizard.xml
+++ b/shopinvader/wizards/shopinvader_variant_binding_wizard.xml
@@ -11,6 +11,7 @@
             <form string="Shopinvader Variant Binding Wizard">
                 <field name='backend_id'/>
                 <field name='product_ids'/>
+                <field name='run_immediately'/>
                 <footer>
                     <button string="Bind Products" name="bind_products"
                             type="object" class="oe_highlight"/>

--- a/shopinvader_assortment/models/shopinvader_backend.py
+++ b/shopinvader_assortment/models/shopinvader_backend.py
@@ -26,13 +26,13 @@ class ShopinvaderBackend(models.Model):
         unbinding_wizard_obj = self.env["shopinvader.variant.unbinding.wizard"]
         assortment_domain = self.product_assortment_id._get_eval_domain()
         assortment_products = product_obj.search(assortment_domain)
-        variants_binded = shopinvader_variant_obj.search(
+        variants_bound = shopinvader_variant_obj.search(
             [("backend_id", "=", self.id)]
         )
-        products_binded = variants_binded.mapped("record_id")
-        products_to_bind = assortment_products - products_binded
-        products_to_unbind = products_binded - assortment_products
-        variants_to_unbind = variants_binded.filtered(
+        products_bound = variants_bound.mapped("record_id")
+        products_to_bind = assortment_products - products_bound
+        products_to_unbind = products_bound - assortment_products
+        variants_to_unbind = variants_bound.filtered(
             lambda x: x.record_id.id in products_to_unbind.ids
         )
 

--- a/shopinvader_assortment/tests/test_product_auto_bind.py
+++ b/shopinvader_assortment/tests/test_product_auto_bind.py
@@ -1,16 +1,24 @@
 # Copyright 2018 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import SavepointCase
 
 
-class TestProductAutoBind(TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.backend = self.env.ref("shopinvader.backend_1")
-        self.variant_obj = self.env["shopinvader.variant"]
-        self.product_obj = self.env["product.product"]
-        self.backend.product_assortment_id.domain = "[('sale_ok', '=', True)]"
+class TestProductAutoBind(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+                test_queue_job_no_delay=True,
+            )
+        )
+        cls.backend = cls.env.ref("shopinvader.backend_1")
+        cls.variant_obj = cls.env["shopinvader.variant"]
+        cls.product_obj = cls.env["product.product"]
+        cls.backend.product_assortment_id.domain = "[('sale_ok', '=', True)]"
 
     def test_shopinvader_auto_product_auto_bind(self):
         # Test bind all products from assortment domain
@@ -28,7 +36,8 @@ class TestProductAutoBind(TransactionCase):
         )
 
         self.assertEqual(
-            products_to_bind.ids, variants.mapped("record_id").ids
+            sorted(products_to_bind.ids),
+            sorted(variants.mapped("record_id").ids),
         )
 
         # Exclude one product, related binding should be inactivated
@@ -85,7 +94,8 @@ class TestProductAutoBind(TransactionCase):
         )
 
         self.assertEqual(
-            products_to_bind.ids, variants.mapped("record_id").ids
+            sorted(products_to_bind.ids),
+            sorted(variants.mapped("record_id").ids),
         )
 
         # Exclude one product, related binding should be inactivated


### PR DESCRIPTION
* delegate to backend
* collect records in a job
* create one job per template

This way, we get:

* no frozen instance if tons of records to be created
* if a product fails it doesn't make other fail
* get a visible traceback for failed records

