### PR TITLE
s_wishlist: product.set.ref not required

### DIFF
--- a/shopinvader_wishlist/services/wishlist.py
+++ b/shopinvader_wishlist/services/wishlist.py
@@ -122,7 +122,7 @@ class WishlistService(Component):
     def _validator_create(self):
         return {
             "name": {"type": "string", "required": True},
-            "ref": {"type": "string", "required": True, "empty": False},
+            "ref": {"type": "string", "required": False, "nullable": True},
             "partner_id": {
                 "type": "integer",
                 "coerce": to_int,


### PR DESCRIPTION
The 'ref' field is not required on product.set.
No reason to make it required on the endpoints.