### PR TITLE
s_sale_packaging: make packaging info consistent

### DIFF
--- a/shopinvader_sale_packaging/services/abstract_sale.py
+++ b/shopinvader_sale_packaging/services/abstract_sale.py
@@ -19,16 +19,22 @@ class AbstractSaleService(AbstractComponent):
             "packaging_by_qty": [],
         }
         if line.product_packaging:
-            pkg_vals.update(
-                {
-                    "packaging": line.product_packaging.jsonify(
-                        ["id", "name"]
-                    )[0],
-                    "packaging_qty": line.product_packaging_qty,
-                    "packaging_by_qty": self._packaging_info_by_qty(
-                        line.product_id, line.product_uom_qty
-                    ),
-                }
-            )
+            pkg_vals = line.jsonify(self._parser_line_packaging(), one=True)
         res.update(pkg_vals)
         return res
+
+    def _parser_line_packaging(self):
+        return [
+            (
+                "product_packaging:packaging",
+                lambda rec, fname: self._packaging_to_json(rec[fname]),
+            ),
+            ("product_packaging_qty:packaging_qty"),
+            (
+                "product_packaging_qty:packaging_by_qty",
+                self._parser_packaging_by_qty,
+            ),
+        ]
+
+    def _parser_packaging_by_qty(self, rec, fname):
+        return self._packaging_info_by_qty(rec.product_id, rec.product_uom_qty)

--- a/shopinvader_sale_packaging/services/packaging_mixin.py
+++ b/shopinvader_sale_packaging/services/packaging_mixin.py
@@ -45,3 +45,13 @@ class PackagingServiceMixin(AbstractComponent):
                 "product_packaging_qty": params.pop("packaging_qty"),
             }
         return {}
+
+    def _packaging_to_json(self, packaging):
+        if not packaging:
+            return None
+        return {
+            "id": packaging.id,
+            # Use packaging type name because it's translated
+            "name": packaging.packaging_type_id.name,
+            "code": packaging.packaging_type_id.code,
+        }

--- a/shopinvader_sale_packaging/tests/test_cart.py
+++ b/shopinvader_sale_packaging/tests/test_cart.py
@@ -61,7 +61,11 @@ class ConnectedItemCase(ItemCaseMixin, CommonCase):
         self.check_product_and_qty(cart_line, self.product_1.id, 4000)
         self.assertEqual(
             cart_line["packaging"],
-            {"id": self.pkg_pallet.id, "name": self.pkg_pallet.name},
+            {
+                "id": self.pkg_pallet.id,
+                "name": self.pkg_pallet.packaging_type_id.name,
+                "code": self.pkg_pallet.packaging_type_id.code,
+            },
         )
         self.assertEqual(cart_line["packaging_qty"], 2)
         self.assertIn("sell_only_by_packaging", cart_line["product"])
@@ -83,7 +87,11 @@ class ConnectedItemCase(ItemCaseMixin, CommonCase):
         self.check_product_and_qty(cart_line, product.id, 6000)
         self.assertEqual(
             cart_line["packaging"],
-            {"id": self.pkg_pallet.id, "name": self.pkg_pallet.name},
+            {
+                "id": self.pkg_pallet.id,
+                "name": self.pkg_pallet.packaging_type_id.name,
+                "code": self.pkg_pallet.packaging_type_id.code,
+            },
         )
         self.assertEqual(cart_line["packaging_qty"], 3.0)
         self.assertIn("sell_only_by_packaging", cart_line["product"])
@@ -111,7 +119,11 @@ class ConnectedItemCase(ItemCaseMixin, CommonCase):
         # Check cart line values
         self.assertEqual(
             cart_line["packaging"],
-            {"id": self.pkg_pallet.id, "name": self.pkg_pallet.name},
+            {
+                "id": self.pkg_pallet.id,
+                "name": self.pkg_pallet.packaging_type_id.name,
+                "code": self.pkg_pallet.packaging_type_id.code,
+            },
         )
         self.assertEqual(cart_line["packaging_qty"], 4.0)
         # check SO line values

--- a/shopinvader_sale_packaging/tests/test_sale.py
+++ b/shopinvader_sale_packaging/tests/test_sale.py
@@ -41,7 +41,11 @@ class TestSaleOrderPackaging(CommonCase):
             if line["id"] == self.sale_line1.id:
                 self.assertEqual(
                     line["packaging"],
-                    {"id": self.pkg_box.id, "name": self.pkg_box.name},
+                    {
+                        "id": self.pkg_box.id,
+                        "name": self.pkg_box.packaging_type_id.name,
+                        "code": self.pkg_box.packaging_type_id.code,
+                    },
                 )
                 self.assertEqual(line["packaging_qty"], 5)
                 self.assertEqual(line["qty"], 500)

--- a/shopinvader_sale_packaging_wishlist/services/wishlist.py
+++ b/shopinvader_sale_packaging_wishlist/services/wishlist.py
@@ -26,7 +26,10 @@ class WishlistService(Component):
                 "product_id:packaging_by_qty",
                 self._json_parser_product_packaging,
             ),
-            ("product_packaging_id:packaging", ("id", "name")),
+            (
+                "product_packaging_id:packaging",
+                lambda rec, fname: self._packaging_to_json(rec[fname]),
+            ),
             "product_packaging_qty:packaging_qty",
         ]
 

--- a/shopinvader_sale_packaging_wishlist/tests/test_wishlist_packaging.py
+++ b/shopinvader_sale_packaging_wishlist/tests/test_wishlist_packaging.py
@@ -13,8 +13,18 @@ class WishlistCase(CommonWishlistCase):
         super().setUpClass()
         cls.prod_set = cls.env.ref("shopinvader_wishlist.wishlist_1")
         cls.prod_set.shopinvader_backend_id = cls.backend
+        cls.packaging_type = (
+            cls.env["product.packaging.type"]
+            .sudo()
+            .create({"name": "TYPE 1", "code": "P", "sequence": 3})
+        )
         cls.product_packaging = cls.env["product.packaging"].create(
-            {"name": "PKG TEST", "product_id": cls.prod1.id, "qty": 4}
+            {
+                "name": "PKG TEST",
+                "product_id": cls.prod1.id,
+                "qty": 4,
+                "packaging_type_id": cls.packaging_type.id,
+            }
         )
         # Make sure our products' data is up to date
         cls._refresh_json_data(
@@ -86,6 +96,7 @@ class WishlistCase(CommonWishlistCase):
                 "product_id": prod.id,
                 "qty": 100,
                 "can_be_sold": False,
+                "packaging_type_id": self.packaging_type.id,
             }
         )
         self.assertEqual(res_line["quantity"], 1)
@@ -115,7 +126,12 @@ class WishlistCase(CommonWishlistCase):
         self.assertEqual(res_line["quantity"], 300)
         self.assertEqual(res_line["packaging_qty"], 3.0)
         self.assertEqual(
-            res_line["packaging"], {"id": packaging.id, "name": packaging.name}
+            res_line["packaging"],
+            {
+                "id": packaging.id,
+                "name": self.packaging_type.name,
+                "code": self.packaging_type.code,
+            },
         )
         self.assertEqual(
             res_line["packaging_by_qty"],


### PR DESCRIPTION
Select packaging info should always be consistent
and come from packaging type which is translatable.