### PR TITLE
[14.0][FIX] unique constraint on external_id

### DIFF
--- a/shopinvader_customer_multi_user/tests/common.py
+++ b/shopinvader_customer_multi_user/tests/common.py
@@ -2,6 +2,8 @@
 # @author Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from os import urandom
+
 from odoo.addons.shopinvader.tests.test_customer import TestCustomerCommon
 
 
@@ -23,6 +25,13 @@ class TestMultiUserCommon(TestCustomerCommon):
         cls.backend.multi_user_records_policy = "record_id"
 
     @staticmethod
+    def _get_random_hash():
+        """
+        returns a positive integer from hashing 4 random bytes
+        """
+        return abs(hash(urandom(4)))
+
+    @staticmethod
     def _create_partner(env, **kw):
         values = {
             "backend_id": env.ref("shopinvader.backend_1").id,
@@ -32,4 +41,7 @@ class TestMultiUserCommon(TestCustomerCommon):
             "ref": "#ACME",
         }
         values.update(kw)
+        values["external_id"] = values["external_id"] + str(
+            TestMultiUserCommon._get_random_hash()
+        )
         return env["shopinvader.partner"].create(values)

--- a/shopinvader_customer_multi_user/tests/test_multi_user_partner.py
+++ b/shopinvader_customer_multi_user/tests/test_multi_user_partner.py
@@ -95,6 +95,7 @@ class TestMultiUserPartner(TestMultiUserCommon):
             {
                 "name": "New Binding",
                 "email": "new@test.com",
+                "external_id": "test1",
                 "main_partner_id": custom_partner.id,
             }
         )
@@ -105,6 +106,7 @@ class TestMultiUserPartner(TestMultiUserCommon):
             self.env,
             parent_id=self.company.id,
             name="New Binding 2",
+            external_id="test2",
             email="new2@test.com",
             main_partner_id=custom_partner.id,
         )


### PR DESCRIPTION
Some of the tests were reusing the same external_id but there is a unique sql constraint in the shopinvader_locomotive module that allows only unique external_ids for a backend: 
https://github.com/shopinvader/odoo-shopinvader/blob/14.0/shopinvader_locomotive/models/locomotive_binding.py#L27

depends on: #859 