### PR TITLE
[14.0] shopinvader: fix test_invoice after core change

### DIFF
--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -269,13 +269,19 @@ class CommonTestDownload(object):
         """
         self._test_download_not_allowed(service, target)
 
+    # FIXME: this seems duplicated in some common test cases
+
+    def _ensure_posted(self, invoice):
+        if invoice.state != "posted":
+            invoice._post()
+
     def _make_payment(self, invoice):
         """
         Make the invoice payment
         :param invoice: account.invoice recordset
         :return: bool
         """
-        invoice._post()
+        self._ensure_posted(invoice)
         ctx = {"active_ids": invoice.ids, "active_model": "account.move"}
         wizard_obj = self.register_payments_obj.with_context(ctx)
         register_payments = wizard_obj.create(

--- a/shopinvader/tests/test_invoice.py
+++ b/shopinvader/tests/test_invoice.py
@@ -117,8 +117,8 @@ class TestInvoice(CommonCase, CommonTestDownload):
         # and only paid invoice are accessible
         self.assertFalse(self.backend.invoice_access_open)
         # Invoices are open, none of them is included
-        self.invoice._post()
-        self.non_sale_invoice._post()
+        self._ensure_posted(self.invoice)
+        self._ensure_posted(self.non_sale_invoice)
         domain = self.invoice_service._get_base_search_domain()
         self.assertNotIn(self.non_sale_invoice, self.invoice_obj.search(domain))
         self.assertNotIn(self.invoice, self.invoice_obj.search(domain))
@@ -136,8 +136,8 @@ class TestInvoice(CommonCase, CommonTestDownload):
         # and only paid invoice are accessible
         self.assertFalse(self.backend.invoice_access_open)
         # Invoices are open, none of them is included
-        self.invoice._post()
-        self.non_sale_invoice._post()
+        self._ensure_posted(self.invoice)
+        self._ensure_posted(self.non_sale_invoice)
         domain = self.invoice_service._get_base_search_domain()
         self.assertNotIn(self.non_sale_invoice, self.invoice_obj.search(domain))
         self.assertNotIn(self.invoice, self.invoice_obj.search(domain))
@@ -154,8 +154,8 @@ class TestInvoice(CommonCase, CommonTestDownload):
         self.backend.invoice_linked_to_sale_only = False
         # and open invoices enabled as well
         self.backend.invoice_access_open = True
-        self.invoice._post()
-        self.non_sale_invoice._post()
+        self._ensure_posted(self.invoice)
+        self._ensure_posted(self.non_sale_invoice)
         domain = self.invoice_service._get_base_search_domain()
         self.assertIn(self.non_sale_invoice, self.invoice_obj.search(domain))
         self.assertIn(self.invoice, self.invoice_obj.search(domain))


### PR DESCRIPTION
This commit https://github.com/odoo/odoo/commit/71b82693bb6d
introduced a check on move state. Make the build happy w/ it.


FWD port of https://github.com/shopinvader/odoo-shopinvader/pull/967