### PR TITLE
[14.0] shopinvader: forward port all recent goodies from v13

### DIFF
--- a/shopinvader/__manifest__.py
+++ b/shopinvader/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Shopinvader",
     "summary": "Shopinvader",
-    "version": "14.0.1.2.3",
+    "version": "14.0.2.0.0",
     "category": "e-commerce",
     "website": "https://github.com/shopinvader/odoo-shopinvader",
     "author": "Akretion",
@@ -40,6 +40,8 @@
         "wizards/shopinvader_category_binding_wizard.xml",
         "wizards/shopinvader_category_unbinding_wizard.xml",
         "wizards/shopinvader_partner_binding.xml",
+        "wizards/shopinvader_address_validate.xml",
+        "wizards/shopinvader_partner_validate.xml",
         "views/shopinvader_menu.xml",
         "views/shopinvader_product_view.xml",
         "views/shopinvader_variant_view.xml",

--- a/shopinvader/components/__init__.py
+++ b/shopinvader/components/__init__.py
@@ -6,3 +6,5 @@ from . import core
 from . import access_info
 from . import partner_validator
 from . import product_product_event_listener
+from . import shopinvader_partner_event_listener
+from . import res_partner_event_listener

--- a/shopinvader/components/access_info.py
+++ b/shopinvader/components/access_info.py
@@ -22,8 +22,16 @@ class PartnerAccess(Component):
         return getattr(self.work, "partner", None)
 
     @property
+    def invader_partner(self):
+        return getattr(self.work, "invader_partner", None)
+
+    @property
     def partner_user(self):
         return getattr(self.work, "partner_user", self.partner)
+
+    @property
+    def invader_partner_user(self):
+        return getattr(self.work, "invader_partner_user", self.partner)
 
     def is_main_partner(self):
         return self.partner == self.partner_user

--- a/shopinvader/components/access_info.py
+++ b/shopinvader/components/access_info.py
@@ -69,12 +69,12 @@ class PartnerAccess(Component):
             # scope: permissions
             "addresses": {
                 # can create addresses only if profile partner is enabled
-                "create": self.partner.shopinvader_enabled
+                "create": self.invader_partner.is_shopinvader_active,
             },
             "cart": {
                 # can hit the button to add to cart
-                "add_item": self.partner.shopinvader_enabled,
+                "add_item": self.invader_partner.is_shopinvader_active,
                 # can go on w/ checkout steps
-                "update_item": self.partner.shopinvader_enabled,
+                "update_item": self.invader_partner.is_shopinvader_active,
             },
         }

--- a/shopinvader/components/partner_validator.py
+++ b/shopinvader/components/partner_validator.py
@@ -115,9 +115,6 @@ class PartnerValidator(Component):
 
     def is_partner_validated(self, partner):
         """Check if given partner is enabled for current backend."""
-        if (
-            self.backend.validate_customers
-            and not partner.is_shopinvader_active
-        ):
+        if self.backend.validate_customers and not partner.is_shopinvader_active:
             return False
         return True

--- a/shopinvader/components/partner_validator.py
+++ b/shopinvader/components/partner_validator.py
@@ -24,10 +24,14 @@ class PartnerValidator(Component):
                 "_validate_partner_{}".format(self.backend.validate_customers_type),
                 lambda partner: True,
             )
+            # TODO: this should raise an exception if not satisfied
+            # but the validation is done in the controller
+            # and the frontend is not able to handle it properly yet.
+            # See `InvaderController._get_partner_from_headers`
             validator(partner)
 
     def _validate_partner_all(self, partner):
-        if not partner.shopinvader_enabled:
+        if not partner.is_shopinvader_active:
             # raise PartnerNotValidatedError(
             #     "Customer found but not validated yet."
             # )
@@ -42,7 +46,7 @@ class PartnerValidator(Component):
 
     def _validate_partner_company(self, partner):
         if (
-            not partner.shopinvader_enabled
+            not partner.is_shopinvader_active
             and partner.is_company
             and partner.address_type == "profile"
         ):
@@ -53,7 +57,7 @@ class PartnerValidator(Component):
 
     def _validate_partner_user(self, partner):
         if (
-            not partner.shopinvader_enabled
+            not partner.is_shopinvader_active
             and not partner.is_company
             and partner.address_type == "profile"
         ):
@@ -111,6 +115,9 @@ class PartnerValidator(Component):
 
     def is_partner_validated(self, partner):
         """Check if given partner is enabled for current backend."""
-        if self.backend.validate_customers and not partner.shopinvader_enabled:
+        if (
+            self.backend.validate_customers
+            and not partner.is_shopinvader_active
+        ):
             return False
         return True

--- a/shopinvader/components/res_partner_event_listener.py
+++ b/shopinvader/components/res_partner_event_listener.py
@@ -1,0 +1,32 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import _
+from odoo.addons.component.core import Component
+from odoo.addons.component_event import skip_if
+
+
+class ResPartnerEventListener(Component):
+    _name = "res.partner.event.listener"
+    _inherit = "base.event.listener"
+    _apply_on = ["res.partner"]
+
+    @skip_if(lambda self, record, backends: self._skip_it(record, backends))
+    def on_shopinvader_validate(self, record, backends):
+        self._notify_address_validate(record, backends)
+
+    def _skip_it(self, record, backends):
+        return not backends or record.address_type != "address"
+
+    def _notify_address_validate(self, partner, backends):
+        """Notify address' owner."""
+        notif_type = "address_validated"
+        recipient = partner.parent_id
+        for backend in backends:
+            # Send shopinvader notification
+            backend._send_notification(notif_type, recipient)
+        name = partner.name or partner.contact_address.replace("\n", " | ")
+        msg_body = _("Shop {addr_type} '{name}' validated").format(
+            addr_type=partner.addr_type_display().lower(), name=name
+        )
+        recipient.message_post(body=msg_body)

--- a/shopinvader/components/res_partner_event_listener.py
+++ b/shopinvader/components/res_partner_event_listener.py
@@ -2,6 +2,7 @@
 # @author Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import _
+
 from odoo.addons.component.core import Component
 from odoo.addons.component_event import skip_if
 

--- a/shopinvader/components/shopinvader_partner_event_listener.py
+++ b/shopinvader/components/shopinvader_partner_event_listener.py
@@ -2,6 +2,7 @@
 # @author Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import _
+
 from odoo.addons.component.core import Component
 from odoo.addons.component_event import skip_if
 

--- a/shopinvader/components/shopinvader_partner_event_listener.py
+++ b/shopinvader/components/shopinvader_partner_event_listener.py
@@ -1,0 +1,34 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import _
+from odoo.addons.component.core import Component
+from odoo.addons.component_event import skip_if
+
+
+class ShopinvaderPartnerEventListener(Component):
+    _name = "shopinvader.partner.event.listener"
+    _inherit = "base.event.listener"
+
+    _apply_on = ["shopinvader.partner"]
+
+    @skip_if(lambda self, record: self._skip_it(record))
+    def on_shopinvader_validate(self, record):
+        self._notify_customer_validate(record)
+
+    def _skip_it(self, record):
+        return self.env.context.get("_bypass_validate_notification")
+
+    def _notify_customer_validate(self, invader_partner):
+        """Notify real res.partner based on its type."""
+        partner = invader_partner.record_id
+        # TODO: handle other states?
+        if invader_partner.state == "active":
+            notif_type = "customer_validated"
+            # Send shopinvader notification
+            invader_partner.backend_id._send_notification(notif_type, partner)
+            name = partner.name or partner.contact_address.replace("\n", " | ")
+            msg_body = _("Shop {addr_type} '{name}' validated").format(
+                addr_type=partner.addr_type_display().lower(), name=name
+            )
+            partner.message_post(body=msg_body)

--- a/shopinvader/controllers/main.py
+++ b/shopinvader/controllers/main.py
@@ -97,9 +97,22 @@ class InvaderController(main.RestController):
         # rather than the real partner
         shopinvader_partner = self._get_partner_from_headers(headers)
         res["invader_partner"] = shopinvader_partner
-        partner = shopinvader_partner.record_id
-        res["partner_user"] = partner
+        res["invader_partner_user"] = shopinvader_partner
+        partner_user = shopinvader_partner.record_id
+        res["partner_user"] = partner_user
         # The partner user for the main account or for sale order may differ.
-        res["partner"] = partner.get_shop_partner(res["shopinvader_backend"])
-        res["shopinvader_session"] = self._get_shopinvader_session_from_headers(headers)
+        partner_shop = partner_user.get_shop_partner(
+            res["shopinvader_backend"]
+        )
+        res["partner"] = partner_shop
+        if partner_shop != partner_user:
+            # Invader partner must rappresent the same partner as the shop
+            invader_partner_shop = partner_shop._get_invader_partner(
+                res["shopinvader_backend"]
+            )
+            if invader_partner_shop:
+                res["invader_partner"] = invader_partner_shop
+        res[
+            "shopinvader_session"
+        ] = self._get_shopinvader_session_from_headers(headers)
         return res

--- a/shopinvader/controllers/main.py
+++ b/shopinvader/controllers/main.py
@@ -99,7 +99,5 @@ class InvaderController(main.RestController):
         # rather than the real partner
         shopinvader_partner = self._get_partner_from_headers(headers)
         res.update(get_partner_work_context(shopinvader_partner))
-        res[
-            "shopinvader_session"
-        ] = self._get_shopinvader_session_from_headers(headers)
+        res["shopinvader_session"] = self._get_shopinvader_session_from_headers(headers)
         return res

--- a/shopinvader/controllers/main.py
+++ b/shopinvader/controllers/main.py
@@ -21,10 +21,14 @@ class InvaderController(main.RestController):
     _collection_name = "shopinvader.backend"
     _default_auth = "api_key"
 
-    @route(["/shopinvader/<service>/<int:_id>/download"], methods=["GET"])
+    @route(
+        ["/shopinvader/<service>/<int:_id>/download"],
+        methods=["GET"],
+        auth=_default_auth,
+    )
     def service_download(self, service, _id=None, **params):
         params["id"] = _id
-        return self._process_method(service, "download", _id, params)
+        return self._process_method(service, "download", _id, params=params)
 
     @classmethod
     def _get_partner_from_headers(cls, headers):

--- a/shopinvader/controllers/main.py
+++ b/shopinvader/controllers/main.py
@@ -12,6 +12,8 @@ from odoo.http import request, route
 
 from odoo.addons.base_rest.controllers import main
 
+from ..utils import get_partner_work_context
+
 _logger = logging.getLogger(__name__)
 
 
@@ -96,22 +98,7 @@ class InvaderController(main.RestController):
         # TODO: all services should rely on shopinvader partner
         # rather than the real partner
         shopinvader_partner = self._get_partner_from_headers(headers)
-        res["invader_partner"] = shopinvader_partner
-        res["invader_partner_user"] = shopinvader_partner
-        partner_user = shopinvader_partner.record_id
-        res["partner_user"] = partner_user
-        # The partner user for the main account or for sale order may differ.
-        partner_shop = partner_user.get_shop_partner(
-            res["shopinvader_backend"]
-        )
-        res["partner"] = partner_shop
-        if partner_shop != partner_user:
-            # Invader partner must rappresent the same partner as the shop
-            invader_partner_shop = partner_shop._get_invader_partner(
-                res["shopinvader_backend"]
-            )
-            if invader_partner_shop:
-                res["invader_partner"] = invader_partner_shop
+        res.update(get_partner_work_context(shopinvader_partner))
         res[
             "shopinvader_session"
         ] = self._get_shopinvader_session_from_headers(headers)

--- a/shopinvader/data/queue_job_channel_data.xml
+++ b/shopinvader/data/queue_job_channel_data.xml
@@ -7,4 +7,8 @@
         <field name="name">notification</field>
         <field name="parent_id" ref="channel_shopinvader" />
     </record>
+    <record model="queue.job.channel" id="channel_shopinvader_bind_products">
+        <field name="name">bind_products</field>
+        <field name="parent_id" ref="channel_shopinvader" />
+    </record>
 </odoo>

--- a/shopinvader/data/queue_job_function_data.xml
+++ b/shopinvader/data/queue_job_function_data.xml
@@ -4,4 +4,14 @@
         <field name="method">send</field>
         <field name="channel_id" ref="channel_shopinvader_notification" />
     </record>
+    <record id="job_function_shopinvader_bind_selected_products" model="queue.job.function">
+        <field name="model_id" ref="model_shopinvader_backend" />
+        <field name="method">bind_selected_products</field>
+        <field name="channel_id" ref="channel_shopinvader_bind_products" />
+    </record>
+    <record id="job_function_shopinvader_bind_single_product" model="queue.job.function">
+        <field name="model_id" ref="model_shopinvader_backend" />
+        <field name="method">bind_single_product</field>
+        <field name="channel_id" ref="channel_shopinvader_bind_products" />
+    </record>
 </odoo>

--- a/shopinvader/data/queue_job_function_data.xml
+++ b/shopinvader/data/queue_job_function_data.xml
@@ -4,12 +4,18 @@
         <field name="method">send</field>
         <field name="channel_id" ref="channel_shopinvader_notification" />
     </record>
-    <record id="job_function_shopinvader_bind_selected_products" model="queue.job.function">
+    <record
+        id="job_function_shopinvader_bind_selected_products"
+        model="queue.job.function"
+    >
         <field name="model_id" ref="model_shopinvader_backend" />
         <field name="method">bind_selected_products</field>
         <field name="channel_id" ref="channel_shopinvader_bind_products" />
     </record>
-    <record id="job_function_shopinvader_bind_single_product" model="queue.job.function">
+    <record
+        id="job_function_shopinvader_bind_single_product"
+        model="queue.job.function"
+    >
         <field name="model_id" ref="model_shopinvader_backend" />
         <field name="method">bind_single_product</field>
         <field name="channel_id" ref="channel_shopinvader_bind_products" />

--- a/shopinvader/migrations/14.0.2.0.0/pre-migration.py
+++ b/shopinvader/migrations/14.0.2.0.0/pre-migration.py
@@ -1,0 +1,10 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+from odoo.tools.sql import column_exists, rename_column
+
+
+def migrate(cr, version):
+    if column_exists(cr, "res_partner", "shopinvader_enabled"):
+        rename_column(
+            cr, "res_partner", "shopinvader_enabled", "is_shopinvader_active"
+        )

--- a/shopinvader/migrations/14.0.2.0.0/pre-migration.py
+++ b/shopinvader/migrations/14.0.2.0.0/pre-migration.py
@@ -5,6 +5,4 @@ from odoo.tools.sql import column_exists, rename_column
 
 def migrate(cr, version):
     if column_exists(cr, "res_partner", "shopinvader_enabled"):
-        rename_column(
-            cr, "res_partner", "shopinvader_enabled", "is_shopinvader_active"
-        )
+        rename_column(cr, "res_partner", "shopinvader_enabled", "is_shopinvader_active")

--- a/shopinvader/models/product_filter.py
+++ b/shopinvader/models/product_filter.py
@@ -43,11 +43,22 @@ class ProductFilter(models.Model):
     # TODO: rename to not clash w/ built-in
     help = fields.Html(translate=True)
     name = fields.Char(translate=True, required=True)
+    # TODO: rename this to `code`, "display_name" makes no sense.
+    # Also, in shopinvader_locomotive it is exported as `code`.
     display_name = fields.Char(compute="_compute_display_name")
+    # TODO: replace completely `display_name`
+    # NOTE: this allows to unify filter/index keys across languages.
+    # For prod attributes we'd neeed a unique language agnostic key
+    # on product.attribute.
+    path = fields.Char(
+        help="Enforce external filter key used for indexing and search."
+        "Being a path, you can specify a dotted path to an inner value. "
+        "Eg: supplier = {id: 1, name: 'Foo'} -> `supplier.name`",
+    )
 
     def _build_display_name(self):
         if self.based_on == "field":
-            return self.field_id.name
+            return self.path or self.field_id.name
         elif self.based_on == "variant_attribute":
             return "variant_attributes.%s" % sanitize_attr_name(
                 self.variant_attribute_id

--- a/shopinvader/models/res_partner.py
+++ b/shopinvader/models/res_partner.py
@@ -96,14 +96,10 @@ class ResPartner(models.Model):
         for record in self:
             record.has_shopinvader_user = bool(record.shopinvader_bind_ids)
             record.has_shopinvader_user_active = any(
-                record.shopinvader_bind_ids.filtered(
-                    lambda x: x.state == STATE_ACTIVE
-                )
+                record.shopinvader_bind_ids.filtered(lambda x: x.state == STATE_ACTIVE)
             )
             record.has_shopinvader_user_to_validate = any(
-                record.shopinvader_bind_ids.filtered(
-                    lambda x: x.state == STATE_PENDING
-                )
+                record.shopinvader_bind_ids.filtered(lambda x: x.state == STATE_PENDING)
             )
 
     @api.depends(
@@ -129,15 +125,11 @@ class ResPartner(models.Model):
             if x["parent_id"]
         }
         for record in self:
-            record.has_shopinvader_address_to_validate = bool(
-                by_parent.get(record.id)
-            )
+            record.has_shopinvader_address_to_validate = bool(by_parent.get(record.id))
 
     def _compute_display_flags(self):
         for record in self:
-            record.display_validate_address = (
-                record._display_validate_address()
-            )
+            record.display_validate_address = record._display_validate_address()
 
     def _display_validate_address(self):
         if self.has_shopinvader_user:
@@ -222,9 +214,7 @@ class ResPartner(models.Model):
 
     def action_shopinvader_validate_address(self):
         wiz = self._get_shopinvader_validate_address_wizard()
-        action = self.env.ref(
-            "shopinvader.shopinvader_address_validate_act_window"
-        )
+        action = self.env.ref("shopinvader.shopinvader_address_validate_act_window")
         action_data = action.read()[0]
         action_data["res_id"] = wiz.id
         return action_data

--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -409,9 +409,7 @@ class ShopinvaderBackend(models.Model):
         # TODO: we should exclude levels from `category_binding_level` as well
         self._bind_all_content("product.category", "shopinvader.category", domain)
 
-    def bind_selected_products(
-        self, products, langs=None, run_immediately=False
-    ):
+    def bind_selected_products(self, products, langs=None, run_immediately=False):
         """Bind given product variants.
 
         :param products: product.product recordset
@@ -420,9 +418,7 @@ class ShopinvaderBackend(models.Model):
         """
         for backend in self:
             langs = langs or backend.lang_ids
-            grouped_by_template = defaultdict(
-                self.env["product.product"].browse
-            )
+            grouped_by_template = defaultdict(self.env["product.product"].browse)
             for rec in products:
                 grouped_by_template[rec.product_tmpl_id] |= rec
             method = backend.with_delay().bind_single_product
@@ -444,9 +440,7 @@ class ShopinvaderBackend(models.Model):
             langs, product_tmpl
         )
         for shopinvader_product in shopinvader_products:
-            self._get_or_create_shopinvader_variants(
-                shopinvader_product, variants
-            )
+            self._get_or_create_shopinvader_variants(shopinvader_product, variants)
         self.auto_bind_categories()
 
     def _get_or_create_shopinvader_products(self, langs, product_tmpl):
@@ -455,9 +449,7 @@ class ShopinvaderBackend(models.Model):
         :param langs: res.lang recordset
         :param product_tmpl: product.template browse record
         """
-        binding_model = self.env["shopinvader.product"].with_context(
-            active_test=False
-        )
+        binding_model = self.env["shopinvader.product"].with_context(active_test=False)
         bound_templates = binding_model.search(
             [
                 ("record_id", "=", product_tmpl.id),
@@ -466,9 +458,7 @@ class ShopinvaderBackend(models.Model):
             ]
         )
         for lang in langs:
-            shopinvader_product = bound_templates.filtered(
-                lambda x: x.lang_id == lang
-            )
+            shopinvader_product = bound_templates.filtered(lambda x: x.lang_id == lang)
             if not shopinvader_product:
                 # fmt: off
                 data = {
@@ -482,9 +472,7 @@ class ShopinvaderBackend(models.Model):
                 shopinvader_product.write({"active": True})
         return bound_templates
 
-    def _get_or_create_shopinvader_variants(
-        self, shopinvader_product, variants
-    ):
+    def _get_or_create_shopinvader_variants(self, shopinvader_product, variants):
         """Get variant bindings, create if missing.
 
         :param langs: res.lang recordset

--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -4,6 +4,7 @@
 # @author Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from collections import defaultdict
 from contextlib import contextmanager
 
 from odoo import _, api, fields, models, tools
@@ -407,6 +408,107 @@ class ShopinvaderBackend(models.Model):
                 domain = [("id", "not in", to_exclude.ids)]
         # TODO: we should exclude levels from `category_binding_level` as well
         self._bind_all_content("product.category", "shopinvader.category", domain)
+
+    def bind_selected_products(
+        self, products, langs=None, run_immediately=False
+    ):
+        """Bind given product variants.
+
+        :param products: product.product recordset
+        :param langs: res.lang recordset. If none, all langs from backend
+        :param run_immediately: do not use jobs
+        """
+        for backend in self:
+            langs = langs or backend.lang_ids
+            grouped_by_template = defaultdict(
+                self.env["product.product"].browse
+            )
+            for rec in products:
+                grouped_by_template[rec.product_tmpl_id] |= rec
+            method = backend.with_delay().bind_single_product
+            if run_immediately:
+                method = backend.bind_single_product
+            for tmpl, variants in grouped_by_template.items():
+                method(langs, tmpl, variants)
+
+    def bind_single_product(self, langs, product_tmpl, variants):
+        """Bind given product variants for given template and languages.
+
+        :param langs: res.lang recordset
+        :param product_tmpl: product.template browse record
+        :param variants: product.product recordset
+        :param run_immediately: do not use jobs
+        """
+        self.ensure_one()
+        shopinvader_products = self._get_or_create_shopinvader_products(
+            langs, product_tmpl
+        )
+        for shopinvader_product in shopinvader_products:
+            self._get_or_create_shopinvader_variants(
+                shopinvader_product, variants
+            )
+        self.auto_bind_categories()
+
+    def _get_or_create_shopinvader_products(self, langs, product_tmpl):
+        """Get template bindings for given languages or create if missing.
+
+        :param langs: res.lang recordset
+        :param product_tmpl: product.template browse record
+        """
+        binding_model = self.env["shopinvader.product"].with_context(
+            active_test=False
+        )
+        bound_templates = binding_model.search(
+            [
+                ("record_id", "=", product_tmpl.id),
+                ("backend_id", "=", self.id),
+                ("lang_id", "in", langs.ids),
+            ]
+        )
+        for lang in langs:
+            shopinvader_product = bound_templates.filtered(
+                lambda x: x.lang_id == lang
+            )
+            if not shopinvader_product:
+                # fmt: off
+                data = {
+                    "record_id": product_tmpl.id,
+                    "backend_id": self.id,
+                    "lang_id": lang.id,
+                }
+                # fmt: on
+                bound_templates |= binding_model.create(data)
+            elif not shopinvader_product.active:
+                shopinvader_product.write({"active": True})
+        return bound_templates
+
+    def _get_or_create_shopinvader_variants(
+        self, shopinvader_product, variants
+    ):
+        """Get variant bindings, create if missing.
+
+        :param langs: res.lang recordset
+        :param product_tmpl: product.template browse record
+        """
+        binding_model = self.env["shopinvader.variant"]
+        bound_variants = shopinvader_product.shopinvader_variant_ids
+        for variant in variants:
+            shopinvader_variant = bound_variants.filtered(
+                lambda p: p.record_id == variant
+            )
+            if not shopinvader_variant:
+                # fmt: off
+                data = {
+                    "record_id": variant.id,
+                    "backend_id": self.id,
+                    "shopinvader_product_id":
+                        shopinvader_product.id,
+                }
+                # fmt: on
+                bound_variants |= binding_model.create(data)
+            elif not shopinvader_variant.active:
+                shopinvader_variant.write({"active": True})
+        return bound_variants
 
     def _send_notification(self, notification, record):
         self.ensure_one()

--- a/shopinvader/models/shopinvader_partner.py
+++ b/shopinvader/models/shopinvader_partner.py
@@ -29,15 +29,16 @@ class ShopinvaderPartner(models.Model):
         string="Partner Email",
     )
     role = fields.Char(compute="_compute_role")
-    state = fields.Selection(selection="_select_state", default=STATE_ACTIVE,)
+    state = fields.Selection(
+        selection="_select_state",
+        default=STATE_ACTIVE,
+    )
     # Common interface to mimic the same behavior as res.partner.
     # On the binding we have a selection for the state
     # and we can set the value for each backend.
     # On addresses is relevant only if the record is enabled or not for the shop.
     # Having the same field on both models allows to use simple conditions to check.
-    is_shopinvader_active = fields.Boolean(
-        compute="_compute_is_shopinvader_active"
-    )
+    is_shopinvader_active = fields.Boolean(compute="_compute_is_shopinvader_active")
 
     def _select_state(self):
         return [
@@ -173,9 +174,7 @@ class ShopinvaderPartner(models.Model):
 
     def action_shopinvader_validate(self):
         wiz = self._get_shopinvader_validate_wizard()
-        action = self.env.ref(
-            "shopinvader.shopinvader_partner_validate_act_window"
-        )
+        action = self.env.ref("shopinvader.shopinvader_partner_validate_act_window")
         action_data = action.read()[0]
         action_data["res_id"] = wiz.id
         return action_data

--- a/shopinvader/models/shopinvader_partner.py
+++ b/shopinvader/models/shopinvader_partner.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 STATE_ACTIVE = "active"
 STATE_INACTIVE = "inactive"
@@ -183,3 +183,21 @@ class ShopinvaderPartner(models.Model):
     def _get_shopinvader_validate_wizard(self, **kw):
         vals = dict(shopinvader_partner_ids=self.ids, **kw)
         return self.env["shopinvader.partner.validate"].create(vals)
+
+    def action_edit_in_form(self):
+        self.ensure_one()
+        form_xid = self.env.context.get(
+            "form_view_ref", "shopinvader.shopinvader_partner_view_form"
+        )
+        view = self.env.ref(form_xid)
+        return {
+            "name": _("Edit %s") % self.name,
+            "type": "ir.actions.act_window",
+            "view_type": "form",
+            "res_model": self._name,
+            "views": [(view.id, "form")],
+            "view_id": view.id,
+            "target": "new",
+            "res_id": self.id,
+            "context": dict(self.env.context),
+        }

--- a/shopinvader/models/shopinvader_partner.py
+++ b/shopinvader/models/shopinvader_partner.py
@@ -7,6 +7,11 @@
 
 from odoo import api, fields, models
 
+STATE_ACTIVE = "active"
+STATE_INACTIVE = "inactive"
+STATE_PENDING = "pending"
+ALL_STATES = (STATE_ACTIVE, STATE_INACTIVE, STATE_PENDING)
+
 
 class ShopinvaderPartner(models.Model):
     _name = "shopinvader.partner"
@@ -24,6 +29,27 @@ class ShopinvaderPartner(models.Model):
         string="Partner Email",
     )
     role = fields.Char(compute="_compute_role")
+    state = fields.Selection(selection="_select_state", default=STATE_ACTIVE,)
+    # Common interface to mimic the same behavior as res.partner.
+    # On the binding we have a selection for the state
+    # and we can set the value for each backend.
+    # On addresses is relevant only if the record is enabled or not for the shop.
+    # Having the same field on both models allows to use simple conditions to check.
+    is_shopinvader_active = fields.Boolean(
+        compute="_compute_is_shopinvader_active"
+    )
+
+    def _select_state(self):
+        return [
+            (STATE_ACTIVE, "Active"),
+            (STATE_INACTIVE, "Inactive"),
+            (STATE_PENDING, "Pending"),
+        ]
+
+    @api.depends("state")
+    def _compute_is_shopinvader_active(self):
+        for rec in self:
+            rec.is_shopinvader_active = rec.state == STATE_ACTIVE
 
     _sql_constraints = [
         (
@@ -144,3 +170,16 @@ class ShopinvaderPartner(models.Model):
             if f not in partner_fields:
                 v.pop(f)
         return v
+
+    def action_shopinvader_validate(self):
+        wiz = self._get_shopinvader_validate_wizard()
+        action = self.env.ref(
+            "shopinvader.shopinvader_partner_validate_act_window"
+        )
+        action_data = action.read()[0]
+        action_data["res_id"] = wiz.id
+        return action_data
+
+    def _get_shopinvader_validate_wizard(self, **kw):
+        vals = dict(shopinvader_partner_ids=self.ids, **kw)
+        return self.env["shopinvader.partner.validate"].create(vals)

--- a/shopinvader/models/shopinvader_variant.py
+++ b/shopinvader/models/shopinvader_variant.py
@@ -250,9 +250,7 @@ class ShopinvaderVariant(models.Model):
             # but it's very unlikely that the default order for product.product
             # will be changed.
             try:
-                ordered = sorted(
-                    prods, key=lambda var: [var[x] for x in order_by]
-                )
+                ordered = sorted(prods, key=lambda var: [var[x] for x in order_by])
             except TypeError as orig_exception:
                 # TypeError: '<' not supported between instances of 'bool' and 'str'
                 # It means we don't have all values to determine this value.

--- a/shopinvader/models/shopinvader_variant.py
+++ b/shopinvader/models/shopinvader_variant.py
@@ -6,8 +6,10 @@
 from contextlib import contextmanager
 from itertools import groupby
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.tools import float_compare, float_round
+
+from odoo.addons.queue_job.exception import RetryableJobError
 
 from .tools import sanitize_attr_name
 
@@ -249,10 +251,27 @@ class ShopinvaderVariant(models.Model):
             # NOTE: if the order is changed by adding `asc/desc` this can be broken
             # but it's very unlikely that the default order for product.product
             # will be changed.
-            ordered = sorted(prods, key=lambda var: [var[x] for x in order_by])
+            try:
+                ordered = sorted(
+                    prods, key=lambda var: [var[x] for x in order_by]
+                )
+            except TypeError as orig_exception:
+                # TypeError: '<' not supported between instances of 'bool' and 'str'
+                # It means we don't have all values to determine this value.
+                msg = _(
+                    "Cannot determine main variant for template ID: %s."
+                    "\nAt least one variant misses one of these values: %s."
+                    "\nWill try again later till 'max retries' count is reached."
+                ) % (prods[0]["tmpl_record_id"], ", ".join(order_by))
+                # This issue might depend on incomplete state of product info.
+                # Eg: missing translation for variant matching current lang.
+                # Let's retry later a bunch of times (5 by default).
+                raise RetryableJobError(msg) from orig_exception
             return ordered[0].get("id") if ordered else None
 
-        main_by_tmpl = {tmpl: pick_1st_variant(prods) for tmpl, prods in var_by_tmpl}
+        main_by_tmpl = {
+            tmpl: pick_1st_variant(tuple(prods)) for tmpl, prods in var_by_tmpl
+        }
         for record in self:
             record.main = main_by_tmpl.get(record.tmpl_record_id.id) == record.id
 

--- a/shopinvader/models/shopinvader_variant.py
+++ b/shopinvader/models/shopinvader_variant.py
@@ -132,9 +132,7 @@ class ShopinvaderVariant(models.Model):
 
     def _prepare_variant_name_and_short_name(self):
         self.ensure_one()
-        attributes = self.mapped(
-            "product_template_attribute_value_ids." "product_attribute_value_id"
-        )
+        attributes = self.attribute_value_ids
         short_name = ", ".join(attributes.mapped("name"))
         full_name = self.shopinvader_display_name
         if short_name:

--- a/shopinvader/services/abstract_sale.py
+++ b/shopinvader/services/abstract_sale.py
@@ -114,7 +114,7 @@ class AbstractSaleService(AbstractComponent):
             "total_without_discount": sale.price_total_no_discount,
         }
 
-    def _to_json(self, sales):
+    def _to_json(self, sales, **kw):
         res = []
         for sale in sales:
             res.append(self._convert_one_sale(sale))

--- a/shopinvader/services/address.py
+++ b/shopinvader/services/address.py
@@ -197,7 +197,7 @@ class AddressService(Component):
         ]
         return res
 
-    def _to_json(self, address):
+    def _to_json(self, address, **kw):
         data = address.jsonify(self._json_parser())
         for item in data:
             # access info on the current record partner record

--- a/shopinvader/services/address.py
+++ b/shopinvader/services/address.py
@@ -192,7 +192,7 @@ class AddressService(Component):
             "is_company",
             "lang",
             ("title", ["id", "name"]),
-            "shopinvader_enabled:enabled",
+            "is_shopinvader_active:enabled",
             ("industry_id", ["id", "name"]),
         ]
         return res
@@ -221,7 +221,7 @@ class AddressService(Component):
             params["title"] = params.get("title")["id"]
 
         if mode == "create":
-            params["shopinvader_enabled"] = self.partner_validator.enabled_by_params(
-                params, "address"
-            )
+            params[
+                "is_shopinvader_active"
+            ] = self.partner_validator.enabled_by_params(params, "address")
         return params

--- a/shopinvader/services/address.py
+++ b/shopinvader/services/address.py
@@ -221,7 +221,7 @@ class AddressService(Component):
             params["title"] = params.get("title")["id"]
 
         if mode == "create":
-            params[
-                "is_shopinvader_active"
-            ] = self.partner_validator.enabled_by_params(params, "address")
+            params["is_shopinvader_active"] = self.partner_validator.enabled_by_params(
+                params, "address"
+            )
         return params

--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -402,7 +402,7 @@ class CartService(Component):
         else:
             return step
 
-    def _to_json(self, cart):
+    def _to_json(self, cart, **kw):
         if not cart:
             return {
                 "data": {},

--- a/shopinvader/services/customer.py
+++ b/shopinvader/services/customer.py
@@ -7,6 +7,8 @@
 
 from odoo.addons.component.core import Component
 
+from ..models.shopinvader_partner import STATE_ACTIVE, STATE_PENDING
+
 
 class CustomerService(Component):
     """Shopinvader service to create and edit customers."""
@@ -79,9 +81,10 @@ class CustomerService(Component):
         if mode == "create":
             if params.get("is_company"):
                 params["is_company"] = True
-            params["shopinvader_enabled"] = self.partner_validator.enabled_by_params(
+            enabled = self.partner_validator.enabled_by_params(
                 params, "profile"
             )
+            params["state"] = STATE_ACTIVE if enabled else STATE_PENDING
         return params
 
     def _get_and_assign_cart(self):

--- a/shopinvader/services/customer.py
+++ b/shopinvader/services/customer.py
@@ -79,9 +79,7 @@ class CustomerService(Component):
         if mode == "create":
             if params.get("is_company"):
                 params["is_company"] = True
-            enabled = self.partner_validator.enabled_by_params(
-                params, "profile"
-            )
+            enabled = self.partner_validator.enabled_by_params(params, "profile")
             params["state"] = STATE_ACTIVE if enabled else STATE_PENDING
         return params
 

--- a/shopinvader/services/customer.py
+++ b/shopinvader/services/customer.py
@@ -33,9 +33,7 @@ class CustomerService(Component):
     def create(self, **params):
         vals = self._prepare_params(params)
         binding = self.env["shopinvader.partner"].create(vals)
-        # TODO: move to `service._[init|update]_context` to centralize it
-        self.work.invader_partner = binding
-        self.work.partner = binding.record_id
+        self._load_partner_work_context(binding)
         self._post_create(self.work.partner)
         return self._prepare_create_response(binding)
 
@@ -124,8 +122,8 @@ class CustomerService(Component):
     def _prepare_create_response(self, binding):
         response = self._assign_cart_and_get_store_cache()
         response["data"] = {
-            "id": self.partner.id,
-            "name": self.partner.name,
+            "id": binding.record_id.id,
+            "name": binding.name,
             "role": binding.role,
         }
         return response

--- a/shopinvader/services/partner_mixin.py
+++ b/shopinvader/services/partner_mixin.py
@@ -26,6 +26,8 @@ class PartnerServiceMixin(AbstractComponent):
             "res.partner",
             partner=self.partner,
             partner_user=self.partner_user,
+            invader_partner=self.invader_partner,
+            invader_partner_user=self.invader_partner_user,
             service_work=self.work,
         ) as work:
             return work.component(usage="access.info")

--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -45,6 +45,10 @@ class BaseShopinvaderService(AbstractComponent):
         return getattr(self.work, "partner_user", self.partner)
 
     @property
+    def invader_partner_user(self):
+        return self.work.invader_partner_user
+
+    @property
     def shopinvader_session(self):
         return self.work.shopinvader_session
 

--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -79,7 +79,9 @@ class BaseShopinvaderService(AbstractComponent):
                 domain.append((key, op, value))
             return domain
         except Exception as e:
-            raise UserError(_("Invalid scope %s, error : %s"), scope, e)
+            raise UserError(
+                _("Invalid scope %s, error: %s") % (str(scope), str(e))
+            )
 
     # Validator
     def _default_validator_search(self):

--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -77,7 +77,7 @@ class BaseShopinvaderService(AbstractComponent):
                 else:
                     op = "="
                 domain.append((key, op, value))
-            return expression.normalize_domain(domain)
+            return domain
         except Exception as e:
             raise UserError(_("Invalid scope %s, error : %s"), scope, e)
 

--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -129,7 +129,7 @@ class BaseShopinvaderService(AbstractComponent):
             offset=per_page * (page - 1),
             order=self._get_search_order(order, **params),
         )
-        return {"size": total_count, "data": self._to_json(records)}
+        return {"size": total_count, "data": self._to_json(records, **params)}
 
     def _get_search_order(self, order, **params):
         """Customize search results order.

--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -56,21 +56,24 @@ class BaseShopinvaderService(AbstractComponent):
     def client_header(self):
         return self.work.client_header
 
+    _scope_to_domain_operators = {
+        "gt": ">",
+        "gte": ">=",
+        "lt": "<",
+        "lte": "<=",
+        "ne": "!=",
+        "like": "like",
+        "ilike": "ilike",
+    }
+
     def _scope_to_domain(self, scope):
-        # Convert the liquid scope syntax to the odoo domain
+        # Convert the frontend scope syntax to the odoo domain
         try:
-            OPERATORS = {
-                "gt": ">",
-                "gte": ">=",
-                "lt": "<",
-                "lte": "<=",
-                "ne": "!=",
-            }
             domain = []
             for key, value in scope.items():
                 if "." in key:
                     key, op = key.split(".")
-                    op = OPERATORS[op]
+                    op = self._scope_to_domain_operators[op]
                 else:
                     op = "="
                 domain.append((key, op, value))

--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -12,7 +12,7 @@ from odoo.osv import expression
 from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import AbstractComponent
 
-from .. import shopinvader_response
+from .. import shopinvader_response, utils
 
 _logger = logging.getLogger(__name__)
 
@@ -22,6 +22,13 @@ class BaseShopinvaderService(AbstractComponent):
     _name = "base.shopinvader.service"
     _collection = "shopinvader.backend"
     _expose_model = None
+
+    def _load_partner_work_context(self, invader_partner, force=False):
+        utils.load_partner_work_ctx(self, invader_partner, force=force)
+
+    def _reset_partner_work_context(self):
+        # Basically like logging out a user
+        utils.reset_partner_work_ctx(self)
 
     @property
     def partner(self):

--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -90,9 +90,7 @@ class BaseShopinvaderService(AbstractComponent):
                 domain.append((key, op, value))
             return domain
         except Exception as e:
-            raise UserError(
-                _("Invalid scope %s, error: %s") % (str(scope), str(e))
-            )
+            raise UserError(_("Invalid scope %s, error: %s") % (str(scope), str(e)))
 
     # Validator
     def _default_validator_search(self):

--- a/shopinvader/tests/__init__.py
+++ b/shopinvader/tests/__init__.py
@@ -22,3 +22,4 @@ from . import test_shopinvader_partner_binding
 from . import test_notification
 from . import test_salesman_notification
 from . import test_search
+from . import test_utils

--- a/shopinvader/tests/__init__.py
+++ b/shopinvader/tests/__init__.py
@@ -21,3 +21,4 @@ from . import test_invoice
 from . import test_shopinvader_partner_binding
 from . import test_notification
 from . import test_salesman_notification
+from . import test_search

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -99,30 +99,36 @@ class CommonMixin(RegistryMixin, ComponentMixin, UtilsMixin):
 
     @contextmanager
     def work_on_services(self, **params):
-        params = params or {}
-        if params.get("partner") and not params.get("partner_user"):
-            params["partner_user"] = params["partner"]
-        if "shopinvader_backend" not in params:
-            params["shopinvader_backend"] = self.backend
-        if "shopinvader_session" not in params:
-            params["shopinvader_session"] = {}
-        if not params.get("partner_user") and params.get("partner"):
-            params["partner_user"] = params["partner"]
-        if params.get("partner_user"):
-            params["invader_partner"] = params["partner_user"]._get_invader_partner(
-                self.backend
-            )
-        # Safe defaults as these keys are mandatory for work ctx
-        if "partner" not in params:
-            params["partner"] = self.env["res.partner"].browse()
-        if "partner_user" not in params:
-            params["partner_user"] = self.env["res.partner"].browse()
-        if "invader_partner" not in params:
-            params["invader_partner"] = self.env["shopinvader.partner"].browse()
+        params = self._work_on_services_default_params(self, **params)
         collection = _PseudoCollection("shopinvader.backend", self.env)
         yield WorkContext(
             model_name="rest.service.registration", collection=collection, **params
         )
+
+    @staticmethod
+    def _work_on_services_default_params(class_or_instance, **params):
+        if "shopinvader_backend" not in params:
+            params["shopinvader_backend"] = class_or_instance.backend
+        if "shopinvader_session" not in params:
+            params["shopinvader_session"] = {}
+        if params.get("partner") and not params.get("partner_user"):
+            params["partner_user"] = params["partner"]
+
+        # Safe defaults as these keys are mandatory for work ctx
+        for k in ("partner", "partner_user"):
+            if not params.get(k):
+                params[k] = class_or_instance.env["res.partner"].browse()
+            if not params.get("invader_" + k):
+                params["invader_" + k] = params[k]._get_invader_partner(
+                    class_or_instance.backend
+                )
+        return params
+
+    def _update_work_ctx(self, service, **params):
+        params = self._work_on_services_default_params(self, **params)
+        for k, v in params.items():
+            if not getattr(service.work, k, None) and v:
+                setattr(service.work, k, v)
 
     def _init_job_counter(self):
         self.existing_jobs = self.env["queue.job"].search([])

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -39,7 +39,11 @@ class UtilsMixin(object):
         backend = backend or self.backend
         bind_wizard_model = self.env["shopinvader.variant.binding.wizard"]
         bind_wizard = bind_wizard_model.create(
-            {"backend_id": backend.id, "product_ids": [(6, 0, products.ids)]}
+            {
+                "backend_id": backend.id,
+                "product_ids": [(6, 0, products.ids)],
+                "run_immediately": True,
+            }
         )
         bind_wizard.bind_products()
 

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -11,13 +11,11 @@ from odoo import fields
 from odoo.exceptions import MissingError
 from odoo.tests import SavepointCase
 
-from odoo.addons.base_rest.controllers.main import _PseudoCollection
 from odoo.addons.base_rest.tests.common import BaseRestCase, RegistryMixin
-from odoo.addons.component.core import WorkContext
 from odoo.addons.component.tests.common import ComponentMixin
 from odoo.addons.queue_job.job import Job
 
-from .. import shopinvader_response
+from .. import shopinvader_response, utils
 from ..services import abstract_download
 
 
@@ -100,10 +98,8 @@ class CommonMixin(RegistryMixin, ComponentMixin, UtilsMixin):
     @contextmanager
     def work_on_services(self, **params):
         params = self._work_on_services_default_params(self, **params)
-        collection = _PseudoCollection("shopinvader.backend", self.env)
-        yield WorkContext(
-            model_name="rest.service.registration", collection=collection, **params
-        )
+        with utils.work_on_service(self.env, **params) as work:
+            yield work
 
     @staticmethod
     def _work_on_services_default_params(class_or_instance, **params):
@@ -111,24 +107,14 @@ class CommonMixin(RegistryMixin, ComponentMixin, UtilsMixin):
             params["shopinvader_backend"] = class_or_instance.backend
         if "shopinvader_session" not in params:
             params["shopinvader_session"] = {}
-        if params.get("partner") and not params.get("partner_user"):
-            params["partner_user"] = params["partner"]
-
-        # Safe defaults as these keys are mandatory for work ctx
-        for k in ("partner", "partner_user"):
-            if not params.get(k):
-                params[k] = class_or_instance.env["res.partner"].browse()
-            if not params.get("invader_" + k):
-                params["invader_" + k] = params[k]._get_invader_partner(
-                    class_or_instance.backend
-                )
+        utils.partner_work_context_defaults(
+            class_or_instance.env, class_or_instance.backend, params
+        )
         return params
 
     def _update_work_ctx(self, service, **params):
         params = self._work_on_services_default_params(self, **params)
-        for k, v in params.items():
-            if not getattr(service.work, k, None) and v:
-                setattr(service.work, k, v)
+        utils.update_work_ctx(service, params)
 
     def _init_job_counter(self):
         self.existing_jobs = self.env["queue.job"].search([])

--- a/shopinvader/tests/test_backend.py
+++ b/shopinvader/tests/test_backend.py
@@ -12,6 +12,10 @@ class BackendCase(CommonCase):
     def setUpClass(cls):
         super(BackendCase, cls).setUpClass()
         cls.lang_fr = cls._install_lang(cls, "base.lang_fr")
+        cls.env = cls.env(
+            context=dict(cls.env.context, test_queue_job_no_delay=True)
+        )
+        cls.backend = cls.backend.with_context(test_queue_job_no_delay=True)
 
     def _all_products_count(self):
         return self.env["product.template"].search_count([("sale_ok", "=", True)])

--- a/shopinvader/tests/test_backend.py
+++ b/shopinvader/tests/test_backend.py
@@ -12,9 +12,7 @@ class BackendCase(CommonCase):
     def setUpClass(cls):
         super(BackendCase, cls).setUpClass()
         cls.lang_fr = cls._install_lang(cls, "base.lang_fr")
-        cls.env = cls.env(
-            context=dict(cls.env.context, test_queue_job_no_delay=True)
-        )
+        cls.env = cls.env(context=dict(cls.env.context, test_queue_job_no_delay=True))
         cls.backend = cls.backend.with_context(test_queue_job_no_delay=True)
 
     def _all_products_count(self):

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -107,15 +107,16 @@ class AnonymousCartCase(CartCase, CartClearTest):
         ) as work:
             self.service = work.component(usage="cart")
 
-    def _sign_with(self, partner):
-        self.service.work.partner = partner
+    def _sign_with(self, invader_partner):
+        self.service._load_partner_work_context(invader_partner, force=True)
         service_sign = self.service.component("customer")
         service_sign.sign_in()
 
     def test_anonymous_cart_then_sign(self):
         cart = self.cart
-        partner = self.env.ref("shopinvader.partner_1")
-        self._sign_with(partner)
+        invader_partner = self.env.ref("shopinvader.shopinvader_partner_1")
+        partner = invader_partner.record_id
+        self._sign_with(invader_partner)
         self.assertEqual(cart.partner_id, partner)
         self.assertEqual(cart.partner_shipping_id, partner)
         self.assertEqual(cart.partner_invoice_id, partner)

--- a/shopinvader/tests/test_customer.py
+++ b/shopinvader/tests/test_customer.py
@@ -171,7 +171,9 @@ class TestCustomer(TestCustomerCommon):
 
     def test_has_address_to_validate(self):
         invader_partner = self._create_invader_partner(
-            self.env, name="Just A User", email="just@auser.com",
+            self.env,
+            name="Just A User",
+            email="just@auser.com",
         )
         self.assertTrue(invader_partner.is_shopinvader_active)
         partner = invader_partner.record_id

--- a/shopinvader/tests/test_customer.py
+++ b/shopinvader/tests/test_customer.py
@@ -106,7 +106,7 @@ class TestCustomer(TestCustomerCommon):
         res = self.service.dispatch("create", params=data)["data"]
         partner = self.env["res.partner"].browse(res["id"])
         # hence is enabled by default
-        self.assertTrue(partner.shopinvader_enabled)
+        self.assertTrue(partner.is_shopinvader_active)
         # enable validation for all
         self.backend.update(
             dict(validate_customers=True, validate_customers_type="all")
@@ -114,15 +114,18 @@ class TestCustomer(TestCustomerCommon):
         data = dict(self.data, external_id="D5CdkqOEL", email="funny@foo.com")
         res = self.service.dispatch("create", params=data)["data"]
         partner = self.env["res.partner"].browse(res["id"])
+        invader_partner = partner._get_invader_partner(self.backend)
         # must not be validated
-        self.assertFalse(partner.shopinvader_enabled)
+        self.assertFalse(invader_partner.is_shopinvader_active)
+        self.assertTrue(partner.has_shopinvader_user_to_validate)
         # now let's enable it w/ specific action
-        partner.action_enable_for_shop()
-        self.assertTrue(partner.shopinvader_enabled)
+        invader_partner._get_shopinvader_validate_wizard().action_apply()
+        self.assertTrue(invader_partner.is_shopinvader_active)
+        self.assertFalse(partner.has_shopinvader_user_to_validate)
         # no let's call an update -> validation state won't change
         data = dict(data, email="funny@boo.com")
         self.address_service.dispatch("update", partner.id, params=data)
-        self.assertTrue(partner.shopinvader_enabled)
+        self.assertFalse(partner.has_shopinvader_user_to_validate)
 
     def test_create_customer_validation_company(self):
         data = dict(
@@ -139,7 +142,7 @@ class TestCustomer(TestCustomerCommon):
         res = self.service.dispatch("create", params=data)["data"]
         partner = self.env["res.partner"].browse(res["id"])
         # hence the company is enabled
-        self.assertTrue(partner.shopinvader_enabled)
+        self.assertTrue(partner.is_shopinvader_active)
         # now enable it for company only
         self.backend.validate_customers_type = "company"
         data = dict(
@@ -151,7 +154,29 @@ class TestCustomer(TestCustomerCommon):
         )
         res = self.service.dispatch("create", params=data)["data"]
         partner = self.env["res.partner"].browse(res["id"])
-        self.assertFalse(partner.shopinvader_enabled)
+        invader_partner = partner._get_invader_partner(self.backend)
+        self.assertFalse(invader_partner.is_shopinvader_active)
+        self.assertTrue(partner.has_shopinvader_user_to_validate)
         # now let's enable it w/ specific action
-        partner.action_enable_for_shop()
-        self.assertTrue(partner.shopinvader_enabled)
+        invader_partner._get_shopinvader_validate_wizard().action_apply()
+        self.assertTrue(invader_partner.is_shopinvader_active)
+        self.assertFalse(partner.has_shopinvader_user_to_validate)
+
+    def test_has_address_to_validate(self):
+        invader_partner = self._create_invader_partner(
+            self.env, name="Just A User", email="just@auser.com",
+        )
+        self.assertTrue(invader_partner.is_shopinvader_active)
+        partner = invader_partner.record_id
+        self.assertTrue(partner.has_shopinvader_user)
+        self.assertFalse(partner.has_shopinvader_user_to_validate)
+        self.assertFalse(partner.has_shopinvader_address_to_validate)
+        addr1 = partner.create(
+            {
+                "address_type": "address",
+                "parent_id": partner.id,
+                "name": "Just a contact",
+            }
+        )
+        self.assertFalse(addr1.is_shopinvader_active)
+        self.assertTrue(partner.has_shopinvader_address_to_validate)

--- a/shopinvader/tests/test_notification.py
+++ b/shopinvader/tests/test_notification.py
@@ -134,7 +134,8 @@ class NotificationCustomerCase(CommonAddressCase, NotificationCaseMixin):
         self._check_notification("new_customer_welcome_not_validated", partner)
 
         # now enable it
-        partner.action_enable_for_shop()
+        invader_partner = partner._get_invader_partner(self.backend)
+        invader_partner._get_shopinvader_validate_wizard().action_apply()
         job = self._find_job(
             name="Notify customer_validated for res.partner,%d" % partner.id
         )
@@ -174,7 +175,7 @@ class NotificationCustomerCase(CommonAddressCase, NotificationCaseMixin):
         self._check_notification("address_created_not_validated", partner)
 
         # now enable it
-        address.action_enable_for_shop()
+        address._get_shopinvader_validate_address_wizard().action_apply()
         job = self._find_job(
             name="Notify address_validated for res.partner,%d" % partner.id
         )

--- a/shopinvader/tests/test_partner_access_info.py
+++ b/shopinvader/tests/test_partner_access_info.py
@@ -54,7 +54,7 @@ class TestPartnerAccessInfo(CommonCase):
         self.assertTrue(info.is_owner(self.partner.id))
 
         # partner is enabled, can do everything
-        self.partner.shopinvader_enabled = True
+        self.invader_partner.state = "active"
         expected = {
             "addresses": {"create": True},
             "cart": {"add_item": True, "update_item": True},
@@ -62,7 +62,7 @@ class TestPartnerAccessInfo(CommonCase):
         self.assertEqual(info.permissions(), expected)
 
         # partner is disabled, can do nothing
-        self.partner.shopinvader_enabled = False
+        self.invader_partner.state = "inactive"
         expected = {
             "addresses": {"create": False},
             "cart": {"add_item": False, "update_item": False},
@@ -107,10 +107,10 @@ class TestPartnerAccessInfo(CommonCase):
         self.assertTrue(info.is_owner(self.contact.id))
 
         # no matter if the partner user is enabled
-        self.contact.shopinvader_enabled = True
+        self.invader_contact.state = "active"
 
         # partner is enabled, can do everything
-        self.partner.shopinvader_enabled = True
+        self.invader_partner.state = "active"
         expected = {
             "addresses": {"create": True},
             "cart": {"add_item": True, "update_item": True},
@@ -118,7 +118,7 @@ class TestPartnerAccessInfo(CommonCase):
         self.assertEqual(info.permissions(), expected)
 
         # partner is disabled, can do nothing
-        self.partner.shopinvader_enabled = False
+        self.invader_partner.state = "inactive"
         expected = {
             "addresses": {"create": False},
             "cart": {"add_item": False, "update_item": False},

--- a/shopinvader/tests/test_partner_access_info.py
+++ b/shopinvader/tests/test_partner_access_info.py
@@ -9,17 +9,22 @@ class TestPartnerAccessInfo(CommonCase):
     def setUpClass(cls):
         super(TestPartnerAccessInfo, cls).setUpClass()
         cls.partner = cls.env.ref("shopinvader.partner_1")
-        cls.contact = cls.partner.create(
-            {
-                "name": "Just an address",
-                "type": "contact",
-                "parent_id": cls.partner.id,
-            }
+        cls.invader_partner = cls.partner._get_invader_partner(cls.backend)
+        cls.invader_contact = cls._create_invader_partner(
+            cls.env,
+            name="Just A User",
+            parent_id=cls.partner.id,
+            email="just@auser.com",
         )
+        cls.contact = cls.invader_contact.record_id
 
     def test_access_info_owner1(self):
         with self.backend.work_on(
-            "res.partner", partner=self.partner, partner_user=self.partner
+            "res.partner",
+            partner=self.partner,
+            partner_user=self.partner,
+            invader_partner=self.invader_partner,
+            invader_partner_user=self.invader_partner,
         ) as work:
             info = work.component(usage="access.info")
 
@@ -38,7 +43,11 @@ class TestPartnerAccessInfo(CommonCase):
 
     def test_access_info_owner2(self):
         with self.backend.work_on(
-            "res.partner", partner=self.partner, partner_user=self.partner
+            "res.partner",
+            partner=self.partner,
+            partner_user=self.partner,
+            invader_partner=self.invader_partner,
+            invader_partner_user=self.invader_partner,
         ) as work:
             info = work.component(usage="access.info")
 
@@ -62,7 +71,11 @@ class TestPartnerAccessInfo(CommonCase):
 
     def test_access_info_non_owner1(self):
         with self.backend.work_on(
-            "res.partner", partner=self.partner, partner_user=self.contact
+            "res.partner",
+            partner=self.partner,
+            invader_partner=self.invader_partner,
+            partner_user=self.contact,
+            invader_partner_user=self.invader_contact,
         ) as work:
             info = work.component(usage="access.info")
 
@@ -82,7 +95,11 @@ class TestPartnerAccessInfo(CommonCase):
 
     def test_access_info_non_owner2(self):
         with self.backend.work_on(
-            "res.partner", partner=self.partner, partner_user=self.contact
+            "res.partner",
+            partner=self.partner,
+            invader_partner=self.invader_partner,
+            partner_user=self.contact,
+            invader_partner_user=self.invader_contact,
         ) as work:
             info = work.component(usage="access.info")
 

--- a/shopinvader/tests/test_product.py
+++ b/shopinvader/tests/test_product.py
@@ -12,6 +12,14 @@ from .common import ProductCommonCase
 
 
 class ProductCase(ProductCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(
+            context=dict(cls.env.context, test_queue_job_no_delay=True)
+        )
+        cls.backend = cls.backend.with_context(test_queue_job_no_delay=True)
+
     def test_create_shopinvader_variant(self):
         self.assertEqual(
             len(self.template.product_variant_ids),

--- a/shopinvader/tests/test_product.py
+++ b/shopinvader/tests/test_product.py
@@ -904,3 +904,23 @@ class ProductCase(ProductCommonCase):
                 lambda x: x.record_id != main_variant1
             ).mapped("main"),
         )
+
+    def test_create_shopinvader_category_from_product_category(self):
+        categ = self.env["product.category"].search([])[0]
+        lang = self.env["res.lang"]._lang_get(self.env.user.lang)
+        categ.write(
+            {
+                "shopinvader_bind_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "backend_id": self.backend.id,
+                            "lang_id": lang.id,
+                            "seo_title": False,
+                            "active": True,
+                        },
+                    )
+                ]
+            }
+        )

--- a/shopinvader/tests/test_product.py
+++ b/shopinvader/tests/test_product.py
@@ -15,9 +15,7 @@ class ProductCase(ProductCommonCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env = cls.env(
-            context=dict(cls.env.context, test_queue_job_no_delay=True)
-        )
+        cls.env = cls.env(context=dict(cls.env.context, test_queue_job_no_delay=True))
         cls.backend = cls.backend.with_context(test_queue_job_no_delay=True)
 
     def test_create_shopinvader_variant(self):
@@ -857,60 +855,6 @@ class ProductCase(ProductCommonCase):
             invader_variants.filtered(lambda x: x.record_id != main_variant1).mapped(
                 "main"
             ),
-        )
-
-    def test_create_shopinvader_category_from_product_category(self):
-        categ = self.env["product.category"].search([])[0]
-        lang = self.env["res.lang"]._lang_get(self.env.user.lang)
-        categ.write(
-            {
-                "shopinvader_bind_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "backend_id": self.backend.id,
-                            "lang_id": lang.id,
-                            "seo_title": False,
-                            "active": True,
-                        },
-                    )
-                ]
-            }
-        )
-
-    # TODO: split this and other computed field tests to its own class
-    def test_main_product(self):
-        invader_variants = self.shopinvader_variants
-        tmpl = invader_variants[0].product_tmpl_id
-        main_variant = tmpl.product_variant_ids[0]
-        self.assertTrue(
-            invader_variants.filtered(
-                lambda x: x.record_id == main_variant
-            ).main
-        )
-        self.assertNotIn(
-            True,
-            invader_variants.filtered(
-                lambda x: x.record_id != main_variant
-            ).mapped("main"),
-        )
-        # change order
-        tmpl.product_variant_ids[0].default_code = "ZZZZZZZ"
-        tmpl.product_variant_ids[0].name = "ZZZZZZ"
-        tmpl.product_variant_ids.invalidate_cache()
-        main_variant1 = tmpl.product_variant_ids[0]
-        self.assertNotEqual(main_variant, main_variant1)
-        self.assertTrue(
-            invader_variants.filtered(
-                lambda x: x.record_id == main_variant1
-            ).main
-        )
-        self.assertNotIn(
-            True,
-            invader_variants.filtered(
-                lambda x: x.record_id != main_variant1
-            ).mapped("main"),
         )
 
     def test_create_shopinvader_category_from_product_category(self):

--- a/shopinvader/tests/test_product.py
+++ b/shopinvader/tests/test_product.py
@@ -870,3 +870,37 @@ class ProductCase(ProductCommonCase):
                 ]
             }
         )
+
+    # TODO: split this and other computed field tests to its own class
+    def test_main_product(self):
+        invader_variants = self.shopinvader_variants
+        tmpl = invader_variants[0].product_tmpl_id
+        main_variant = tmpl.product_variant_ids[0]
+        self.assertTrue(
+            invader_variants.filtered(
+                lambda x: x.record_id == main_variant
+            ).main
+        )
+        self.assertNotIn(
+            True,
+            invader_variants.filtered(
+                lambda x: x.record_id != main_variant
+            ).mapped("main"),
+        )
+        # change order
+        tmpl.product_variant_ids[0].default_code = "ZZZZZZZ"
+        tmpl.product_variant_ids[0].name = "ZZZZZZ"
+        tmpl.product_variant_ids.invalidate_cache()
+        main_variant1 = tmpl.product_variant_ids[0]
+        self.assertNotEqual(main_variant, main_variant1)
+        self.assertTrue(
+            invader_variants.filtered(
+                lambda x: x.record_id == main_variant1
+            ).main
+        )
+        self.assertNotIn(
+            True,
+            invader_variants.filtered(
+                lambda x: x.record_id != main_variant1
+            ).mapped("main"),
+        )

--- a/shopinvader/tests/test_product_filter.py
+++ b/shopinvader/tests/test_product_filter.py
@@ -52,6 +52,16 @@ class TestProductFilter(CommonCase):
             "x_custom_field",
         )
 
+    def test_product_filter_field_name_with_path(self):
+        self.filter_on_field.path = "x_custom_field.inner_value"
+        self.assertEqual(
+            self.filter_on_field.display_name, "x_custom_field.inner_value"
+        )
+        self.assertEqual(
+            self.filter_on_field.with_context(lang="fr_FR").display_name,
+            "x_custom_field.inner_value",
+        )
+
     def test_product_filter_attribute_name(self):
         self.assertEqual(
             self.filter_on_attr.display_name,

--- a/shopinvader/tests/test_salesman_notification.py
+++ b/shopinvader/tests/test_salesman_notification.py
@@ -48,8 +48,9 @@ class TestCustomer(CommonCase):
     def _create_customer(self, **kw):
         data = dict(self.base_data)
         data.update(kw)
-        res = self.customer_service.dispatch("create", params=data)["data"]
-        return self.env["res.partner"].browse(res["id"])
+        self.customer_service._reset_partner_work_context()
+        self.customer_service.dispatch("create", params=data)["data"]
+        return self.customer_service.partner
 
     def _create_address(self, partner=None, **kw):
         data = dict(self.base_data)

--- a/shopinvader/tests/test_search.py
+++ b/shopinvader/tests/test_search.py
@@ -1,0 +1,81 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import UserError
+
+from .common import CommonCase
+
+
+class CommonSearchCase(CommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env.ref("shopinvader.partner_1")
+        cls.address = cls.env.ref("shopinvader.partner_1_address_1")
+        cls.address_2 = cls.env.ref("shopinvader.partner_1_address_2")
+
+    def setUp(self):
+        super().setUp()
+        with self.work_on_services(partner=self.partner) as work:
+            self.address_service = work.component(usage="addresses")
+
+
+class SearchCase(CommonSearchCase):
+    def test_domain_conversion(self):
+        service = self.address_service
+        scope = {
+            "foo.gt": 1,
+            "bar.gte": 2,
+            "baz.lt": 3,
+            "boo.lte": 4,
+            "yoo.like": "Me%",
+            "woo.ilike": "%you%",
+        }
+        expected = [
+            ("foo", ">", 1),
+            ("bar", ">=", 2),
+            ("baz", "<", 3),
+            ("boo", "<=", 4),
+            ("yoo", "like", "Me%"),
+            ("woo", "ilike", "%you%"),
+        ]
+        domain = service._scope_to_domain(scope)
+        self.assertEqual(sorted(domain), sorted(expected))
+
+    def test_search_by_text(self):
+        self.address.name = "TEST ADDR 1"
+        self.address_2.name = "TEST ADDR 2 WHATEVER"
+        scope = {"name.like": "TEST%"}
+        res = self.address_service.dispatch("search", params={"scope": scope})[
+            "data"
+        ]
+        found = [(x["id"], x["name"]) for x in res]
+        expected = [
+            (x["id"], x["name"]) for x in self.address + self.address_2
+        ]
+        self.assertEqual(found, expected)
+
+        scope = {"name.ilike": "test%"}
+        res = self.address_service.dispatch("search", params={"scope": scope})[
+            "data"
+        ]
+        found = [(x["id"], x["name"]) for x in res]
+        expected = [
+            (x["id"], x["name"]) for x in self.address + self.address_2
+        ]
+        self.assertEqual(found, expected)
+
+        scope = {"name.ilike": "%whatever"}
+        res = self.address_service.dispatch("search", params={"scope": scope})[
+            "data"
+        ]
+        found = [(x["id"], x["name"]) for x in res]
+        expected = [(x["id"], x["name"]) for x in self.address_2]
+        self.assertEqual(found, expected)
+
+    def test_search_bad_scope(self):
+        scope = {"name.noway": "TEST%"}
+        msg = "Invalid scope"
+        with self.assertRaisesRegex(UserError, msg):
+            self.address_service.dispatch("search", params={"scope": scope})

--- a/shopinvader/tests/test_search.py
+++ b/shopinvader/tests/test_search.py
@@ -47,29 +47,19 @@ class SearchCase(CommonSearchCase):
         self.address.name = "TEST ADDR 1"
         self.address_2.name = "TEST ADDR 2 WHATEVER"
         scope = {"name.like": "TEST%"}
-        res = self.address_service.dispatch("search", params={"scope": scope})[
-            "data"
-        ]
+        res = self.address_service.dispatch("search", params={"scope": scope})["data"]
         found = [(x["id"], x["name"]) for x in res]
-        expected = [
-            (x["id"], x["name"]) for x in self.address + self.address_2
-        ]
+        expected = [(x["id"], x["name"]) for x in self.address + self.address_2]
         self.assertEqual(found, expected)
 
         scope = {"name.ilike": "test%"}
-        res = self.address_service.dispatch("search", params={"scope": scope})[
-            "data"
-        ]
+        res = self.address_service.dispatch("search", params={"scope": scope})["data"]
         found = [(x["id"], x["name"]) for x in res]
-        expected = [
-            (x["id"], x["name"]) for x in self.address + self.address_2
-        ]
+        expected = [(x["id"], x["name"]) for x in self.address + self.address_2]
         self.assertEqual(found, expected)
 
         scope = {"name.ilike": "%whatever"}
-        res = self.address_service.dispatch("search", params={"scope": scope})[
-            "data"
-        ]
+        res = self.address_service.dispatch("search", params={"scope": scope})["data"]
         found = [(x["id"], x["name"]) for x in res]
         expected = [(x["id"], x["name"]) for x in self.address_2]
         self.assertEqual(found, expected)

--- a/shopinvader/tests/test_shopinvader_variant_binding_wizard.py
+++ b/shopinvader/tests/test_shopinvader_variant_binding_wizard.py
@@ -11,7 +11,13 @@ class TestShopinvaderVariantBindingWizard(SavepointComponentCase):
     @classmethod
     def setUpClass(cls):
         super(TestShopinvaderVariantBindingWizard, cls).setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+                test_queue_job_no_delay=True,
+            )
+        )
         cls.backend = cls.env.ref("shopinvader.backend_1")
         cls.template = cls.env.ref("product.product_product_4_product_template")
         cls.variant = cls.env.ref("product.product_product_4b")

--- a/shopinvader/tests/test_utils.py
+++ b/shopinvader/tests/test_utils.py
@@ -1,0 +1,94 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import mock
+
+from odoo.addons.shopinvader import utils  # pylint: disable=W7950
+
+from .common import CommonCase
+
+
+class TestUtils(CommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.invader_partner = cls.env.ref("shopinvader.shopinvader_partner_1")
+
+    def test_partner_work_ctx(self):
+        ctx = utils.get_partner_work_context(self.invader_partner)
+        expected = {
+            "partner": self.invader_partner.record_id,
+            "partner_user": self.invader_partner.record_id,
+            "invader_partner": self.invader_partner,
+            "invader_partner_user": self.invader_partner,
+        }
+        self.assertEqual(ctx, expected)
+
+    def test_partner_work_ctx_custom(self):
+        new_invader_partner = self._create_invader_partner(
+            self.env,
+            name="Just A User",
+            email="just@auser.com",
+            parent_id=self.invader_partner.record_id.id,
+        )
+        # Simulate `get_shop_partner` give us another partner eg: the parent
+        with mock.patch.object(
+            type(new_invader_partner.record_id), "get_shop_partner"
+        ) as mocked:
+            mocked.return_value = new_invader_partner.record_id.parent_id
+            ctx = utils.get_partner_work_context(new_invader_partner)
+        expected = {
+            "partner": self.invader_partner.record_id,
+            "partner_user": new_invader_partner.record_id,
+            "invader_partner": self.invader_partner,
+            "invader_partner_user": new_invader_partner,
+        }
+        self.assertEqual(ctx, expected)
+
+    def test_load_partner_work_ctx(self):
+        with utils.work_on_service(
+            self.env, shopinvader_backend=self.backend
+        ) as work:
+            service = work.component(usage="customer")
+            service._load_partner_work_context(self.invader_partner)
+        expected = {
+            "partner": self.invader_partner.record_id,
+            "partner_user": self.invader_partner.record_id,
+            "invader_partner": self.invader_partner,
+            "invader_partner_user": self.invader_partner,
+        }
+        for k, v in expected.items():
+            self.assertEqual(getattr(service, k), v)
+
+    def test_reset_partner_work_ctx(self):
+        with utils.work_on_service(
+            self.env, shopinvader_backend=self.backend
+        ) as work:
+            service = work.component(usage="customer")
+            service._load_partner_work_context(self.invader_partner)
+        service.work.whatever_shall_be_kept = "something"
+        service._reset_partner_work_context()
+        expected = {
+            "partner": self.env["res.partner"].browse(),
+            "partner_user": self.env["res.partner"].browse(),
+            "invader_partner": self.env["shopinvader.partner"].browse(),
+            "invader_partner_user": self.env["shopinvader.partner"].browse(),
+        }
+        for k, v in expected.items():
+            self.assertEqual(getattr(service, k), v)
+
+    def test_work_on_service_with_partner(self):
+        with utils.work_on_service_with_partner(
+            self.env, self.invader_partner
+        ) as work:
+            service = work.component(usage="customer")
+            service._load_partner_work_context(self.invader_partner)
+        expected = {
+            "partner": self.invader_partner.record_id,
+            "partner_user": self.invader_partner.record_id,
+            "invader_partner": self.invader_partner,
+            "invader_partner_user": self.invader_partner,
+        }
+        for k, v in expected.items():
+            self.assertEqual(getattr(service, k), v)

--- a/shopinvader/tests/test_utils.py
+++ b/shopinvader/tests/test_utils.py
@@ -47,9 +47,7 @@ class TestUtils(CommonCase):
         self.assertEqual(ctx, expected)
 
     def test_load_partner_work_ctx(self):
-        with utils.work_on_service(
-            self.env, shopinvader_backend=self.backend
-        ) as work:
+        with utils.work_on_service(self.env, shopinvader_backend=self.backend) as work:
             service = work.component(usage="customer")
             service._load_partner_work_context(self.invader_partner)
         expected = {
@@ -62,9 +60,7 @@ class TestUtils(CommonCase):
             self.assertEqual(getattr(service, k), v)
 
     def test_reset_partner_work_ctx(self):
-        with utils.work_on_service(
-            self.env, shopinvader_backend=self.backend
-        ) as work:
+        with utils.work_on_service(self.env, shopinvader_backend=self.backend) as work:
             service = work.component(usage="customer")
             service._load_partner_work_context(self.invader_partner)
         service.work.whatever_shall_be_kept = "something"
@@ -79,9 +75,7 @@ class TestUtils(CommonCase):
             self.assertEqual(getattr(service, k), v)
 
     def test_work_on_service_with_partner(self):
-        with utils.work_on_service_with_partner(
-            self.env, self.invader_partner
-        ) as work:
+        with utils.work_on_service_with_partner(self.env, self.invader_partner) as work:
             service = work.component(usage="customer")
             service._load_partner_work_context(self.invader_partner)
         expected = {

--- a/shopinvader/utils.py
+++ b/shopinvader/utils.py
@@ -1,0 +1,85 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from contextlib import contextmanager
+
+from odoo.addons.base_rest.controllers.main import _PseudoCollection
+from odoo.addons.component.core import WorkContext
+
+
+def get_partner_work_context(shopinvader_partner):
+    """Retrieve service work context for given shopinvader.partner
+    """
+    ctx = {}
+    ctx["invader_partner"] = shopinvader_partner
+    ctx["invader_partner_user"] = shopinvader_partner
+    # TODO: `partner` and `partner_user` could be abandoned as soon as
+    # all `shopinvader` modules stop relying on `self.partner`.
+    partner_user = shopinvader_partner.record_id
+    ctx["partner_user"] = partner_user
+    # The partner user for the main account or for sale order may differ.
+    partner_shop = partner_user.get_shop_partner(
+        shopinvader_partner.backend_id
+    )
+    ctx["partner"] = partner_shop
+    if partner_shop != partner_user:
+        # Invader partner must represent the same partner as the shop
+        invader_partner_shop = partner_shop._get_invader_partner(
+            shopinvader_partner.backend_id
+        )
+        if invader_partner_shop:
+            ctx["invader_partner"] = invader_partner_shop
+    return ctx
+
+
+def load_partner_work_ctx(service, invader_partner, force=False):
+    """Update work context for given service loading given invader partner ctx."""
+    params = get_partner_work_context(invader_partner)
+    update_work_ctx(service, params, force=force)
+
+
+def reset_partner_work_ctx(service):
+    """Update work context flushing all partner keys."""
+    defaults = {}
+    partner_work_context_defaults(
+        service.env, service.shopinvader_backend, defaults
+    )
+    update_work_ctx(service, defaults, force=True)
+
+
+def update_work_ctx(service, params, force=False):
+    """Update work context for given service."""
+    for k, v in params.items():
+        # The attribute on the service could be None or empty recordset.
+        if force or not getattr(service.work, k, None):
+            setattr(service.work, k, v)
+
+
+def partner_work_context_defaults(env, backend, params):
+    """Inject defaults as these keys are mandatory for work ctx."""
+    if params.get("partner") and not params.get("partner_user"):
+        params["partner_user"] = params["partner"]
+    for k in ("partner", "partner_user"):
+        if not params.get(k):
+            params[k] = env["res.partner"].browse()
+        if not params.get("invader_" + k):
+            params["invader_" + k] = params[k]._get_invader_partner(backend)
+
+
+@contextmanager
+def work_on_service(env, **params):
+    """Work on a shopinvader service."""
+    collection = _PseudoCollection("shopinvader.backend", env)
+    yield WorkContext(
+        model_name="rest.service.registration", collection=collection, **params
+    )
+
+
+@contextmanager
+def work_on_service_with_partner(env, invader_partner, **kw):
+    """Work on a shopinvader service using given shopinvader.partner."""
+    params = get_partner_work_context(invader_partner)
+    params["shopinvader_backend"] = invader_partner.backend_id
+    params.update(kw)
+    with work_on_service(env, **params) as work:
+        yield work

--- a/shopinvader/utils.py
+++ b/shopinvader/utils.py
@@ -8,8 +8,7 @@ from odoo.addons.component.core import WorkContext
 
 
 def get_partner_work_context(shopinvader_partner):
-    """Retrieve service work context for given shopinvader.partner
-    """
+    """Retrieve service work context for given shopinvader.partner"""
     ctx = {}
     ctx["invader_partner"] = shopinvader_partner
     ctx["invader_partner_user"] = shopinvader_partner
@@ -18,9 +17,7 @@ def get_partner_work_context(shopinvader_partner):
     partner_user = shopinvader_partner.record_id
     ctx["partner_user"] = partner_user
     # The partner user for the main account or for sale order may differ.
-    partner_shop = partner_user.get_shop_partner(
-        shopinvader_partner.backend_id
-    )
+    partner_shop = partner_user.get_shop_partner(shopinvader_partner.backend_id)
     ctx["partner"] = partner_shop
     if partner_shop != partner_user:
         # Invader partner must represent the same partner as the shop
@@ -41,9 +38,7 @@ def load_partner_work_ctx(service, invader_partner, force=False):
 def reset_partner_work_ctx(service):
     """Update work context flushing all partner keys."""
     defaults = {}
-    partner_work_context_defaults(
-        service.env, service.shopinvader_backend, defaults
-    )
+    partner_work_context_defaults(service.env, service.shopinvader_backend, defaults)
     update_work_ctx(service, defaults, force=True)
 
 

--- a/shopinvader/views/partner_view.xml
+++ b/shopinvader/views/partner_view.xml
@@ -15,6 +15,12 @@
                             <field name="create_date" readonly="True"/>
                             <field name="sync_date" readonly="True"/>
                             <field name="state" />
+                            <button
+                                name="action_edit_in_form"
+                                type="object"
+                                title="Edit in form"
+                                icon="fa-pencil"
+                            />
                         </tree>
                     </field>
                     <group name="extras">

--- a/shopinvader/views/partner_view.xml
+++ b/shopinvader/views/partner_view.xml
@@ -7,13 +7,13 @@
         <field name="arch" type="xml">
             <notebook position="inside">
                 <page name="shopinvader" string="Shopinvader">
-                    <separator string="Shopinvader users"/>
+                    <separator string="Shopinvader users" />
                     <field name="shopinvader_bind_ids" nolabel="1">
                         <tree editable="bottom">
-                            <field name="backend_id"/>
-                            <field name="external_id" readonly="True"/>
-                            <field name="create_date" readonly="True"/>
-                            <field name="sync_date" readonly="True"/>
+                            <field name="backend_id" />
+                            <field name="external_id" readonly="True" />
+                            <field name="create_date" readonly="True" />
+                            <field name="sync_date" readonly="True" />
                             <field name="state" />
                             <button
                                 name="action_edit_in_form"
@@ -25,36 +25,51 @@
                     </field>
                     <group name="extras">
                       <group>
-                        <field name="address_type" readonly="1"/>
+                        <field name="address_type" readonly="1" />
                         <field name="has_shopinvader_user" invisible="1" />
                         <field name="has_shopinvader_user_active" invisible="1" />
-                        <field name="has_shopinvader_user_to_validate" attrs="{'invisible':[('has_shopinvader_user_to_validate','=',False)]}" />
-                        <field name="is_shopinvader_active" readonly="1" attrs="{'invisible':[('has_shopinvader_user','=',True)]}"/>
-                        <field name="display_validate_address" invisible="1"/>
-                        <button class="btn btn-sm btn-warning"
-                            name="action_shopinvader_validate_customer"
-                            type="object"
-                            title="Validate user for Shopinvader"
-                            attrs="{'invisible':['|', ('has_shopinvader_user_active', '=', True), ('has_shopinvader_user', '=', False) ]}"
-                            icon="fa-user-o">
+                        <field
+                                name="has_shopinvader_user_to_validate"
+                                attrs="{'invisible':[('has_shopinvader_user_to_validate','=',False)]}"
+                            />
+                        <field
+                                name="is_shopinvader_active"
+                                readonly="1"
+                                attrs="{'invisible':[('has_shopinvader_user','=',True)]}"
+                            />
+                        <field name="display_validate_address" invisible="1" />
+                        <button
+                                class="btn btn-sm btn-warning"
+                                name="action_shopinvader_validate_customer"
+                                type="object"
+                                title="Validate user for Shopinvader"
+                                attrs="{'invisible':['|', ('has_shopinvader_user_active', '=', True), ('has_shopinvader_user', '=', False) ]}"
+                                icon="fa-user-o"
+                            >
                           Shop: validate user
                         </button>
-                        <div attrs="{'invisible':[('display_validate_address', '=', False)]}">
-                          <button class="btn btn-sm btn-success"
-                              name="action_shopinvader_validate_address"
-                              type="object"
-                              title="Validate address for Shopinvader"
-                              attrs="{'invisible':[('is_shopinvader_active', '=', True)]}"
-                              icon="fa-address-card-o">
+                        <div
+                                attrs="{'invisible':[('display_validate_address', '=', False)]}"
+                            >
+                          <button
+                                    class="btn btn-sm btn-success"
+                                    name="action_shopinvader_validate_address"
+                                    type="object"
+                                    title="Validate address for Shopinvader"
+                                    attrs="{'invisible':[('is_shopinvader_active', '=', True)]}"
+                                    icon="fa-address-card-o"
+                                >
                             Shop: validate address
                           </button>
-                          <button class="btn btn-sm btn-warning"
-                              name="action_shopinvader_validate_address"
-                              type="object"
-                              context="{'default_next_state': 'inactive'}"
-                              title="Deactivate address for Shopinvader"
-                              attrs="{'invisible':[('is_shopinvader_active', '=', False)]}"
-                              icon="fa-address-card-o">
+                          <button
+                                    class="btn btn-sm btn-warning"
+                                    name="action_shopinvader_validate_address"
+                                    type="object"
+                                    context="{'default_next_state': 'inactive'}"
+                                    title="Deactivate address for Shopinvader"
+                                    attrs="{'invisible':[('is_shopinvader_active', '=', False)]}"
+                                    icon="fa-address-card-o"
+                                >
                             Shop: deactivate address
                           </button>
                         </div>
@@ -65,32 +80,47 @@
             <xpath expr="//field[@name='child_ids']" position="before">
                 <field name="has_shopinvader_user_to_validate" invisible="1" />
                 <field name="has_shopinvader_address_to_validate" invisible="1" />
-                <button class="btn btn-sm btn-success"
+                <button
+                    class="btn btn-sm btn-success"
                     name="action_shopinvader_validate_customer"
                     context="{'validate_all': True}"
                     type="object"
                     title="There's at least one Shopinvader user to validate"
                     attrs="{'invisible':[('has_shopinvader_user_to_validate','=',False)]}"
-                    icon="fa-user-o">
+                    icon="fa-user-o"
+                >
                   Shop: validate users
                 </button>
-                <button class="btn btn-sm btn-success"
+                <button
+                    class="btn btn-sm btn-success"
                     name="action_shopinvader_validate_address"
                     context="{'validate_all': True}"
                     type="object"
                     title="There's at least one address to validate for Shopinvader"
                     attrs="{'invisible':[('has_shopinvader_address_to_validate','=',False)]}"
-                    icon="fa-address-card-o">
+                    icon="fa-address-card-o"
+                >
                   Shop: validate addresses
                 </button>
             </xpath>
-            <xpath expr="//field[@name='child_ids']/kanban//div[hasclass('o_kanban_image')]" position="before">
+            <xpath
+                expr="//field[@name='child_ids']/kanban//div[hasclass('o_kanban_image')]"
+                position="before"
+            >
                 <field name="address_type" invisible="1" />
-                <field name="has_shopinvader_user"  invisible="1" />
-                <field name="parent_has_shopinvader_user"  invisible="1" />
-                <field name="is_shopinvader_active"  invisible="1" />
-                <div t-if="record.parent_has_shopinvader_user.raw_value and record.address_type.raw_value=='address' and !record.has_shopinvader_user.raw_value and !record.is_shopinvader_active.raw_value" class="float-right">
-                    <a class="btn btn-sm btn-success"  name="action_shopinvader_validate_address" type="object" title="There's at least one address to validate">
+                <field name="has_shopinvader_user" invisible="1" />
+                <field name="parent_has_shopinvader_user" invisible="1" />
+                <field name="is_shopinvader_active" invisible="1" />
+                <div
+                    t-if="record.parent_has_shopinvader_user.raw_value and record.address_type.raw_value=='address' and !record.has_shopinvader_user.raw_value and !record.is_shopinvader_active.raw_value"
+                    class="float-right"
+                >
+                    <a
+                        class="btn btn-sm btn-success"
+                        name="action_shopinvader_validate_address"
+                        type="object"
+                        title="There's at least one address to validate"
+                    >
                         Shop: validate address
                     </a>
                 </div>
@@ -100,27 +130,33 @@
 
     <record id="view_res_partner_filter" model="ir.ui.view">
         <field name="model">res.partner</field>
-        <field name="inherit_id" ref="base.view_res_partner_filter"/>
+        <field name="inherit_id" ref="base.view_res_partner_filter" />
         <field name="arch" type="xml">
             <filter name="inactive" position="after">
-                <separator/>
+                <separator />
                 <filter
                     string="Shopinvader: address to validate"
                     name="shopinvader_address_to_validate"
-                    domain="[('parent_has_shopinvader_user','=', True), ('has_shopinvader_user_active','=', False),('is_shopinvader_active','=',False),('address_type','=','address')]"/>
+                    domain="[('parent_has_shopinvader_user','=', True), ('has_shopinvader_user_active','=', False),('is_shopinvader_active','=',False),('address_type','=','address')]"
+                />
                 <filter
                     string="Shopinvader: active user"
                     name="shopinvader_active_user"
-                    domain="[('has_shopinvader_user_active', '=', True)]"/>
+                    domain="[('has_shopinvader_user_active', '=', True)]"
+                />
                 <filter
                     string="Shopinvader: user to validate"
                     name="shopinvader_user_to_validate"
-                    domain="[('has_shopinvader_user_to_validate', '=', True)]"/>
+                    domain="[('has_shopinvader_user_to_validate', '=', True)]"
+                />
             </filter>
         </field>
     </record>
 
-    <record id="action_sale_shopinvader_customer_to_validate" model="ir.actions.act_window">
+    <record
+        id="action_sale_shopinvader_customer_to_validate"
+        model="ir.actions.act_window"
+    >
         <field name="name">Shopinvader customers to validate</field>
         <field name="res_model">res.partner</field>
         <field name="view_mode">tree,form</field>
@@ -135,11 +171,16 @@
         </field>
     </record>
 
-    <record id="action_sale_shopinvader_addresses_to_validate" model="ir.actions.act_window">
+    <record
+        id="action_sale_shopinvader_addresses_to_validate"
+        model="ir.actions.act_window"
+    >
         <field name="name">Shopinvader addresses to validate</field>
         <field name="res_model">res.partner</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">[('has_shopinvader_address_to_validate', '=', True)]</field>
+        <field
+            name="domain"
+        >[('has_shopinvader_address_to_validate', '=', True)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No address to validate for Shopinvader.

--- a/shopinvader/views/partner_view.xml
+++ b/shopinvader/views/partner_view.xml
@@ -7,52 +7,154 @@
         <field name="arch" type="xml">
             <notebook position="inside">
                 <page name="shopinvader" string="Shopinvader">
-                    <group name="extras">
-                        <div name="shopinvader_enabled">
-                            <label for="shopinvader_enabled" />
-                            <field
-                                name="shopinvader_enabled"
-                                nolabel="1"
-                                readonly="1"
-                            />
-                            <button
-                                name="action_enable_for_shop"
-                                type="object"
-                                string="Enable customer"
-                                attrs="{'invisible': [('shopinvader_enabled','=',True)]}"
-                            />
-                        </div>
-                    </group>
-                    <field name="shopinvader_bind_ids">
+                    <separator string="Shopinvader users"/>
+                    <field name="shopinvader_bind_ids" nolabel="1">
                         <tree editable="bottom">
-                            <field name="backend_id" />
-                            <field name="external_id" readonly="True" />
-                            <field name="create_date" readonly="True" />
-                            <field name="sync_date" readonly="True" />
+                            <field name="backend_id"/>
+                            <field name="external_id" readonly="True"/>
+                            <field name="create_date" readonly="True"/>
+                            <field name="sync_date" readonly="True"/>
+                            <field name="state" />
                         </tree>
                     </field>
+                    <group name="extras">
+                      <group>
+                        <field name="address_type" readonly="1"/>
+                        <field name="has_shopinvader_user" invisible="1" />
+                        <field name="has_shopinvader_user_active" invisible="1" />
+                        <field name="has_shopinvader_user_to_validate" attrs="{'invisible':[('has_shopinvader_user_to_validate','=',False)]}" />
+                        <field name="is_shopinvader_active" readonly="1" attrs="{'invisible':[('has_shopinvader_user','=',True)]}"/>
+                        <field name="display_validate_address" invisible="1"/>
+                        <button class="btn btn-sm btn-warning"
+                            name="action_shopinvader_validate_customer"
+                            type="object"
+                            title="Validate user for Shopinvader"
+                            attrs="{'invisible':['|', ('has_shopinvader_user_active', '=', True), ('has_shopinvader_user', '=', False) ]}"
+                            icon="fa-user-o">
+                          Shop: validate user
+                        </button>
+                        <div attrs="{'invisible':[('display_validate_address', '=', False)]}">
+                          <button class="btn btn-sm btn-success"
+                              name="action_shopinvader_validate_address"
+                              type="object"
+                              title="Validate address for Shopinvader"
+                              attrs="{'invisible':[('is_shopinvader_active', '=', True)]}"
+                              icon="fa-address-card-o">
+                            Shop: validate address
+                          </button>
+                          <button class="btn btn-sm btn-warning"
+                              name="action_shopinvader_validate_address"
+                              type="object"
+                              context="{'default_next_state': 'inactive'}"
+                              title="Deactivate address for Shopinvader"
+                              attrs="{'invisible':[('is_shopinvader_active', '=', False)]}"
+                              icon="fa-address-card-o">
+                            Shop: deactivate address
+                          </button>
+                        </div>
+                      </group>
+                    </group>
                 </page>
             </notebook>
-            <!-- add validation button to address kanban -->
-            <xpath
-                expr="//field[@name='child_ids']/kanban/field[@name='display_name']"
-                position="after"
-            >
-                <field name="shopinvader_enabled" />
+            <xpath expr="//field[@name='child_ids']" position="before">
+                <field name="has_shopinvader_user_to_validate" invisible="1" />
+                <field name="has_shopinvader_address_to_validate" invisible="1" />
+                <button class="btn btn-sm btn-success"
+                    name="action_shopinvader_validate_customer"
+                    context="{'validate_all': True}"
+                    type="object"
+                    title="There's at least one Shopinvader user to validate"
+                    attrs="{'invisible':[('has_shopinvader_user_to_validate','=',False)]}"
+                    icon="fa-user-o">
+                  Shop: validate users
+                </button>
+                <button class="btn btn-sm btn-success"
+                    name="action_shopinvader_validate_address"
+                    context="{'validate_all': True}"
+                    type="object"
+                    title="There's at least one address to validate for Shopinvader"
+                    attrs="{'invisible':[('has_shopinvader_address_to_validate','=',False)]}"
+                    icon="fa-address-card-o">
+                  Shop: validate addresses
+                </button>
             </xpath>
-            <xpath
-                expr="//field[@name='child_ids']/kanban//div[hasclass('o_kanban_image')]"
-                position="before"
-            >
-                <div t-if="!record.shopinvader_enabled.raw_value" class="float-right">
-                    <button
-                        name="action_enable_for_shop"
-                        type="object"
-                        class="btn btn-warning btn-sm"
-                    >Shop: enable address</button>
+            <xpath expr="//field[@name='child_ids']/kanban//div[hasclass('o_kanban_image')]" position="before">
+                <field name="address_type" invisible="1" />
+                <field name="has_shopinvader_user"  invisible="1" />
+                <field name="parent_has_shopinvader_user"  invisible="1" />
+                <field name="is_shopinvader_active"  invisible="1" />
+                <div t-if="record.parent_has_shopinvader_user.raw_value and record.address_type.raw_value=='address' and !record.has_shopinvader_user.raw_value and !record.is_shopinvader_active.raw_value" class="float-right">
+                    <a class="btn btn-sm btn-success"  name="action_shopinvader_validate_address" type="object" title="There's at least one address to validate">
+                        Shop: validate address
+                    </a>
                 </div>
             </xpath>
         </field>
     </record>
+
+    <record id="view_res_partner_filter" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_res_partner_filter"/>
+        <field name="arch" type="xml">
+            <filter name="inactive" position="after">
+                <separator/>
+                <filter
+                    string="Shopinvader: address to validate"
+                    name="shopinvader_address_to_validate"
+                    domain="[('parent_has_shopinvader_user','=', True), ('has_shopinvader_user_active','=', False),('is_shopinvader_active','=',False),('address_type','=','address')]"/>
+                <filter
+                    string="Shopinvader: active user"
+                    name="shopinvader_active_user"
+                    domain="[('has_shopinvader_user_active', '=', True)]"/>
+                <filter
+                    string="Shopinvader: user to validate"
+                    name="shopinvader_user_to_validate"
+                    domain="[('has_shopinvader_user_to_validate', '=', True)]"/>
+            </filter>
+        </field>
+    </record>
+
+    <record id="action_sale_shopinvader_customer_to_validate" model="ir.actions.act_window">
+        <field name="name">Shopinvader customers to validate</field>
+        <field name="res_model">res.partner</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[('has_shopinvader_user_to_validate', '=', True)]</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No Shopinvader customer to be validated.
+            </p>
+            <p>
+                View all partners that have a Shopinvader user to be validated.
+            </p>
+        </field>
+    </record>
+
+    <record id="action_sale_shopinvader_addresses_to_validate" model="ir.actions.act_window">
+        <field name="name">Shopinvader addresses to validate</field>
+        <field name="res_model">res.partner</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[('has_shopinvader_address_to_validate', '=', True)]</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No address to validate for Shopinvader.
+            </p>
+            <p>
+                View all partners that have an address to be validated.
+            </p>
+        </field>
+    </record>
+
+    <menuitem
+        id="menu_sale_shopinvader_customer_to_validate"
+        parent="sale.sale_order_menu"
+        action="action_sale_shopinvader_customer_to_validate"
+        sequence="80"
+    />
+    <menuitem
+        id="menu_sale_shopinvader_addresses_to_validate"
+        parent="sale.sale_order_menu"
+        action="action_sale_shopinvader_addresses_to_validate"
+        sequence="90"
+    />
 
 </odoo>

--- a/shopinvader/views/product_filter_view.xml
+++ b/shopinvader/views/product_filter_view.xml
@@ -6,21 +6,15 @@
         <field name="arch" type="xml">
             <form string="Filter">
                 <group>
-                    <field name="name" />
-                    <field name="based_on" />
-                    <field
-                        name="field_id"
-                        attrs="{'invisible': [('based_on', '!=', 'field')],
-
-                                               'required': [('based_on', '=', 'field')]}"
-                    />
-                    <field
-                        name="variant_attribute_id"
-                        attrs="{'invisible': [('based_on', '!=', 'variant_attribute')],
-                                                   'required': [('based_on', '=', 'variant_attribute')]}"
-                    />
-                    <separator string="Help" />
-                    <field name="help" colspan="4" nolabel="1" />
+                    <field name="name"/>
+                    <field name="based_on"/>
+                    <field name="field_id" attrs="{'invisible': [('based_on', '!=', 'field')],
+                                                   'required': [('based_on', '=', 'field')]}"/>
+                    <field name="variant_attribute_id" attrs="{'invisible': [('based_on', '!=', 'variant_attribute')],
+                                                   'required': [('based_on', '=', 'variant_attribute')]}"/>
+                    <field name="path"  attrs="{'invisible': [('based_on', '!=', 'field')]}" />
+                    <separator string="Help"/>
+                    <field name="help" colspan="4" nolabel="1"/>
                 </group>
             </form>
         </field>

--- a/shopinvader/views/product_filter_view.xml
+++ b/shopinvader/views/product_filter_view.xml
@@ -6,15 +6,24 @@
         <field name="arch" type="xml">
             <form string="Filter">
                 <group>
-                    <field name="name"/>
-                    <field name="based_on"/>
-                    <field name="field_id" attrs="{'invisible': [('based_on', '!=', 'field')],
-                                                   'required': [('based_on', '=', 'field')]}"/>
-                    <field name="variant_attribute_id" attrs="{'invisible': [('based_on', '!=', 'variant_attribute')],
-                                                   'required': [('based_on', '=', 'variant_attribute')]}"/>
-                    <field name="path"  attrs="{'invisible': [('based_on', '!=', 'field')]}" />
-                    <separator string="Help"/>
-                    <field name="help" colspan="4" nolabel="1"/>
+                    <field name="name" />
+                    <field name="based_on" />
+                    <field
+                        name="field_id"
+                        attrs="{'invisible': [('based_on', '!=', 'field')],
+                                                   'required': [('based_on', '=', 'field')]}"
+                    />
+                    <field
+                        name="variant_attribute_id"
+                        attrs="{'invisible': [('based_on', '!=', 'variant_attribute')],
+                                                   'required': [('based_on', '=', 'variant_attribute')]}"
+                    />
+                    <field
+                        name="path"
+                        attrs="{'invisible': [('based_on', '!=', 'field')]}"
+                    />
+                    <separator string="Help" />
+                    <field name="help" colspan="4" nolabel="1" />
                 </group>
             </form>
         </field>

--- a/shopinvader/views/shopinvader_partner_view.xml
+++ b/shopinvader/views/shopinvader_partner_view.xml
@@ -6,15 +6,13 @@
         <field name="arch" type="xml">
             <form string="Shopinvader Partner">
                 <group name="main">
-                    <field
-                        name="record_id"
-                        invisible="not context.get('shopinvader_partner_main_view')"
-                    />
-                    <field name="partner_email" />
-                    <field name="backend_id" />
-                    <field name="external_id" />
-                    <field name="create_date" readonly="1" />
-                    <field name="sync_date" />
+                    <field name="record_id" invisible="not context.get('shopinvader_partner_main_view')"/>
+                    <field name="partner_email"/>
+                    <field name="backend_id"/>
+                    <field name="external_id"/>
+                    <field name="create_date" readonly="1"/>
+                    <field name="sync_date"/>
+                    <field name="state"/>
                 </group>
             </form>
         </field>
@@ -25,16 +23,13 @@
         <field name="model">shopinvader.partner</field>
         <field name="arch" type="xml">
             <tree string="Shopinvader Partner">
-                <field
-                    name="record_id"
-                    invisible="not context.get('shopinvader_partner_main_view')"
-                />
-                <field name="partner_email" />
-                <field name="backend_id" />
-                <field name="external_id" />
-                <field name="create_date" readonly="1" />
-                <field name="sync_date" />
-                <field name="shopinvader_enabled" />
+                <field name="record_id" invisible="not context.get('shopinvader_partner_main_view')"/>
+                <field name="partner_email"/>
+                <field name="backend_id"/>
+                <field name="external_id"/>
+                <field name="create_date" readonly="1"/>
+                <field name="sync_date"/>
+                <field name="state"/>
             </tree>
         </field>
     </record>
@@ -43,23 +38,18 @@
         <field name="model">shopinvader.partner</field>
         <field name="arch" type="xml">
             <search string="Shopinvader Partner">
-                <field name="name" />
-                <field name="email" />
-                <field name="external_id" />
-                <field name="shopinvader_enabled" />
+                <field name="name"/>
+                <field name="email"/>
+                <field name="external_id"/>
+                <field name="parent_id"/>
+                <field name="state"/>
+                <filter name="active" string="State: Active" domain="[('state','=','active')]" />
+                <filter name="inactive" string="State: Inactive" domain="[('state','=','inactive')]" />
+                <filter name="pending" string="State: Pending" domain="[('state','=','pending')]" />
                 <group string="Group By">
-                    <filter
-                        name="group_by_backend_id"
-                        string="Backend"
-                        domain="[]"
-                        context="{'group_by':'backend_id'}"
-                    />
-                    <filter
-                        name="group_by_shopinvader_enabled"
-                        string="Enabled"
-                        domain="[]"
-                        context="{'group_by':'shopinvader_enabled'}"
-                    />
+                    <filter name="group_by_backend_id" string="Backend" domain="[]" context="{'group_by':'backend_id'}"/>
+                    <filter name="group_by_state" string="State" domain="[]" context="{'group_by':'state'}"/>
+                    <filter name="group_by_parent" string="Parent" domain="[]" context="{'group_by':'parent_id'}"/>
                 </group>
             </search>
         </field>

--- a/shopinvader/views/shopinvader_partner_view.xml
+++ b/shopinvader/views/shopinvader_partner_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
 
-        <record id="shopinvader_partner_view_form" model="ir.ui.view">
+    <record id="shopinvader_partner_view_form" model="ir.ui.view">
         <field name="model">shopinvader.partner</field>
         <field name="arch" type="xml">
             <form string="Shopinvader Partner">

--- a/shopinvader/views/shopinvader_partner_view.xml
+++ b/shopinvader/views/shopinvader_partner_view.xml
@@ -6,13 +6,16 @@
         <field name="arch" type="xml">
             <form string="Shopinvader Partner">
                 <group name="main">
-                    <field name="record_id" invisible="not context.get('shopinvader_partner_main_view')"/>
-                    <field name="partner_email"/>
-                    <field name="backend_id"/>
-                    <field name="external_id"/>
-                    <field name="create_date" readonly="1"/>
-                    <field name="sync_date"/>
-                    <field name="state"/>
+                    <field
+                        name="record_id"
+                        invisible="not context.get('shopinvader_partner_main_view')"
+                    />
+                    <field name="partner_email" />
+                    <field name="backend_id" />
+                    <field name="external_id" />
+                    <field name="create_date" readonly="1" />
+                    <field name="sync_date" />
+                    <field name="state" />
                 </group>
             </form>
         </field>
@@ -23,13 +26,16 @@
         <field name="model">shopinvader.partner</field>
         <field name="arch" type="xml">
             <tree string="Shopinvader Partner">
-                <field name="record_id" invisible="not context.get('shopinvader_partner_main_view')"/>
-                <field name="partner_email"/>
-                <field name="backend_id"/>
-                <field name="external_id"/>
-                <field name="create_date" readonly="1"/>
-                <field name="sync_date"/>
-                <field name="state"/>
+                <field
+                    name="record_id"
+                    invisible="not context.get('shopinvader_partner_main_view')"
+                />
+                <field name="partner_email" />
+                <field name="backend_id" />
+                <field name="external_id" />
+                <field name="create_date" readonly="1" />
+                <field name="sync_date" />
+                <field name="state" />
             </tree>
         </field>
     </record>
@@ -38,18 +44,45 @@
         <field name="model">shopinvader.partner</field>
         <field name="arch" type="xml">
             <search string="Shopinvader Partner">
-                <field name="name"/>
-                <field name="email"/>
-                <field name="external_id"/>
-                <field name="parent_id"/>
-                <field name="state"/>
-                <filter name="active" string="State: Active" domain="[('state','=','active')]" />
-                <filter name="inactive" string="State: Inactive" domain="[('state','=','inactive')]" />
-                <filter name="pending" string="State: Pending" domain="[('state','=','pending')]" />
+                <field name="name" />
+                <field name="email" />
+                <field name="external_id" />
+                <field name="parent_id" />
+                <field name="state" />
+                <filter
+                    name="active"
+                    string="State: Active"
+                    domain="[('state','=','active')]"
+                />
+                <filter
+                    name="inactive"
+                    string="State: Inactive"
+                    domain="[('state','=','inactive')]"
+                />
+                <filter
+                    name="pending"
+                    string="State: Pending"
+                    domain="[('state','=','pending')]"
+                />
                 <group string="Group By">
-                    <filter name="group_by_backend_id" string="Backend" domain="[]" context="{'group_by':'backend_id'}"/>
-                    <filter name="group_by_state" string="State" domain="[]" context="{'group_by':'state'}"/>
-                    <filter name="group_by_parent" string="Parent" domain="[]" context="{'group_by':'parent_id'}"/>
+                    <filter
+                        name="group_by_backend_id"
+                        string="Backend"
+                        domain="[]"
+                        context="{'group_by':'backend_id'}"
+                    />
+                    <filter
+                        name="group_by_state"
+                        string="State"
+                        domain="[]"
+                        context="{'group_by':'state'}"
+                    />
+                    <filter
+                        name="group_by_parent"
+                        string="Parent"
+                        domain="[]"
+                        context="{'group_by':'parent_id'}"
+                    />
                 </group>
             </search>
         </field>

--- a/shopinvader/views/shopinvader_variant_view.xml
+++ b/shopinvader/views/shopinvader_variant_view.xml
@@ -66,13 +66,13 @@
             <form>
                 <sheet>
                     <group name="variant">
-                            <field name="name" />
-                            <field name="shopinvader_product_id" />
-                            <field name="lang_id" />
-                            <field name="default_code" />
-                            <field name="backend_id" />
-                            <field name="tmpl_record_id" />
-                            <field name="record_id" />
+                        <field name="name" />
+                        <field name="shopinvader_product_id" />
+                        <field name="lang_id" />
+                        <field name="default_code" />
+                        <field name="backend_id" />
+                        <field name="tmpl_record_id" />
+                        <field name="record_id" />
                     </group>
                 </sheet>
             </form>

--- a/shopinvader/wizards/__init__.py
+++ b/shopinvader/wizards/__init__.py
@@ -4,3 +4,5 @@ from . import shopinvader_variant_binding_wizard
 from . import shopinvader_variant_unbinding_wizard
 from . import shopinvader_partner_binding
 from . import shopinvader_partner_binding_line
+from . import shopinvader_partner_validate
+from . import shopinvader_address_validate

--- a/shopinvader/wizards/shopinvader_address_validate.py
+++ b/shopinvader/wizards/shopinvader_address_validate.py
@@ -1,0 +1,54 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import fields, models
+
+
+class ShopinvaderAddressValidate(models.TransientModel):
+    """
+    Wizard used to validate customers' addresses for a given backend.
+    """
+
+    _name = "shopinvader.address.validate"
+    _description = "Shopinvader address validate"
+
+    backend_ids = fields.Many2many(
+        comodel_name="shopinvader.backend",
+        string="ShopInvader Backends",
+        required=True,
+        readonly=False,
+        default=lambda self: self._default_backend_ids(),
+    )
+    partner_ids = fields.Many2many(
+        string="Addresses",
+        comodel_name="res.partner",
+        default=lambda self: self._default_partner_ids(),
+        required=True,
+    )
+    next_state = fields.Selection(
+        string="Action",
+        selection=[("active", "Activate"), ("inactive", "Inactivate")],
+        default="active",
+    )
+
+    def _default_backend_ids(self):
+        return self.env.context.get("backend_ids") or self.env[
+            "shopinvader.backend"
+        ].search([])
+
+    def _default_partner_ids(self):
+        return self.env.context.get("active_ids")
+
+    def action_apply(self):
+        self.ensure_one()
+        active = self.next_state == "active"
+        records = self.partner_ids.filtered_domain(
+            [("is_shopinvader_active", "!=", active)]
+        )
+        records.write({"is_shopinvader_active": active})
+        if active:
+            for record in records:
+                record._event("on_shopinvader_validate").notify(
+                    record, self.backend_ids
+                )
+        return {"type": "ir.actions.act_window_close"}

--- a/shopinvader/wizards/shopinvader_address_validate.xml
+++ b/shopinvader/wizards/shopinvader_address_validate.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record model="ir.ui.view" id="shopinvader_address_validate_form_view">
+        <field name="name">shopinvader.address.validate.form (in shopinvader)</field>
+        <field name="model">shopinvader.address.validate</field>
+        <field name="arch" type="xml">
+            <form>
+                <div class="alert alert-info" role="alert">
+                  Validate Shopinvader addresses.
+                  Selected addresses not matching this status will be updated.
+                </div>
+                <group name="actions">
+                    <separator string="Shopinvader backends not notify" />
+                    <field name="backend_ids" nolabel="1" colspan="4" />
+                    <field name="next_state" colspan="4"/>
+                </group>
+                <group name="selected">
+                    <field name="partner_ids" colspan="4" nolabel="1">
+                        <tree create="false" delete="false">
+                            <field name="parent_id"/>
+                            <field name="name"/>
+                            <field name="email"/>
+                            <field name="type"/>
+                            <field name="is_shopinvader_active"/>
+                        </tree>
+                    </field>
+                </group>
+                <footer>
+                    <button string="Apply" name="action_apply" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="shopinvader_address_validate_act_window">
+        <field name="name">Shopinvader Address validate Wizard</field>
+        <field name="res_model">shopinvader.address.validate</field>
+        <field name="view_mode">form</field>
+        <field name="context">{}</field>
+        <field name="target">new</field>
+        <field name="view_id" ref="shopinvader_address_validate_form_view"/>
+        <field name="groups_id" eval="[(4, ref('shopinvader.group_shopinvader_manager'))]"/>
+        <field name="binding_model_id" ref="base.model_res_partner"/>
+    </record>
+
+</odoo>

--- a/shopinvader/wizards/shopinvader_address_validate.xml
+++ b/shopinvader/wizards/shopinvader_address_validate.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2021 Camptocamp SA
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
@@ -14,21 +14,26 @@
                 <group name="actions">
                     <separator string="Shopinvader backends not notify" />
                     <field name="backend_ids" nolabel="1" colspan="4" />
-                    <field name="next_state" colspan="4"/>
+                    <field name="next_state" colspan="4" />
                 </group>
                 <group name="selected">
                     <field name="partner_ids" colspan="4" nolabel="1">
                         <tree create="false" delete="false">
-                            <field name="parent_id"/>
-                            <field name="name"/>
-                            <field name="email"/>
-                            <field name="type"/>
-                            <field name="is_shopinvader_active"/>
+                            <field name="parent_id" />
+                            <field name="name" />
+                            <field name="email" />
+                            <field name="type" />
+                            <field name="is_shopinvader_active" />
                         </tree>
                     </field>
                 </group>
                 <footer>
-                    <button string="Apply" name="action_apply" type="object" class="btn-primary"/>
+                    <button
+                        string="Apply"
+                        name="action_apply"
+                        type="object"
+                        class="btn-primary"
+                    />
                     <button string="Cancel" class="btn-default" special="cancel" />
                 </footer>
             </form>
@@ -41,9 +46,12 @@
         <field name="view_mode">form</field>
         <field name="context">{}</field>
         <field name="target">new</field>
-        <field name="view_id" ref="shopinvader_address_validate_form_view"/>
-        <field name="groups_id" eval="[(4, ref('shopinvader.group_shopinvader_manager'))]"/>
-        <field name="binding_model_id" ref="base.model_res_partner"/>
+        <field name="view_id" ref="shopinvader_address_validate_form_view" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('shopinvader.group_shopinvader_manager'))]"
+        />
+        <field name="binding_model_id" ref="base.model_res_partner" />
     </record>
 
 </odoo>

--- a/shopinvader/wizards/shopinvader_partner_validate.py
+++ b/shopinvader/wizards/shopinvader_partner_validate.py
@@ -1,0 +1,40 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import fields, models
+
+
+class ShopinvaderPartnerValidate(models.TransientModel):
+    """Wizard used to validate customers.
+    """
+
+    _name = "shopinvader.partner.validate"
+    _description = "Shopinvader partner validate"
+
+    shopinvader_partner_ids = fields.Many2many(
+        string="Invader Partners",
+        comodel_name="shopinvader.partner",
+        default=lambda self: self._default_shopinvader_partner_ids(),
+    )
+    next_state = fields.Selection(
+        string="Action",
+        selection=[
+            ("active", "Activate"),
+            ("inactive", "Inactivate"),
+            ("pending", "Make pending"),
+        ],
+        default="active",
+    )
+
+    def _default_shopinvader_partner_ids(self):
+        return self.env.context.get("active_ids")
+
+    def action_apply(self):
+        self.ensure_one()
+        records = self.shopinvader_partner_ids.filtered_domain(
+            [("state", "!=", self.next_state)]
+        )
+        records.write({"state": self.next_state})
+        for record in records:
+            record._event("on_shopinvader_validate").notify(record)
+        return {"type": "ir.actions.act_window_close"}

--- a/shopinvader/wizards/shopinvader_partner_validate.py
+++ b/shopinvader/wizards/shopinvader_partner_validate.py
@@ -5,8 +5,7 @@ from odoo import fields, models
 
 
 class ShopinvaderPartnerValidate(models.TransientModel):
-    """Wizard used to validate customers.
-    """
+    """Wizard used to validate customers."""
 
     _name = "shopinvader.partner.validate"
     _description = "Shopinvader partner validate"

--- a/shopinvader/wizards/shopinvader_partner_validate.xml
+++ b/shopinvader/wizards/shopinvader_partner_validate.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record model="ir.ui.view" id="shopinvader_partner_validate_form_view">
+        <field name="name">shopinvader.partner.validate.form (in shopinvader)</field>
+        <field name="model">shopinvader.partner.validate</field>
+        <field name="arch" type="xml">
+            <form>
+                <div class="alert alert-info" role="alert">
+                  Validate Shopinvader customers.
+                  Selected customers not matching this state will be updated.
+                </div>
+                <group>
+                  <field name="next_state" />
+                </group>
+                <group>
+                    <field name="shopinvader_partner_ids" colspan="4" nolabel="1">
+                        <tree create="false" delete="false">
+                            <field name="record_id"/>
+                            <field name="email"/>
+                            <field name="state"/>
+                        </tree>
+                    </field>
+                </group>
+                <footer>
+                    <button string="Apply" name="action_apply" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="shopinvader_partner_validate_act_window">
+        <field name="name">Shopinvader Partner validate Wizard</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">shopinvader.partner.validate</field>
+        <field name="view_mode">form</field>
+        <field name="context">{}</field>
+        <field name="target">new</field>
+        <field name="view_id" ref="shopinvader_partner_validate_form_view"/>
+        <field name="groups_id" eval="[(4, ref('shopinvader.group_shopinvader_manager'))]"/>
+        <field name="binding_model_id" ref="shopinvader.model_shopinvader_partner"/>
+    </record>
+
+</odoo>

--- a/shopinvader/wizards/shopinvader_partner_validate.xml
+++ b/shopinvader/wizards/shopinvader_partner_validate.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2021 Camptocamp SA
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
@@ -17,14 +17,19 @@
                 <group>
                     <field name="shopinvader_partner_ids" colspan="4" nolabel="1">
                         <tree create="false" delete="false">
-                            <field name="record_id"/>
-                            <field name="email"/>
-                            <field name="state"/>
+                            <field name="record_id" />
+                            <field name="email" />
+                            <field name="state" />
                         </tree>
                     </field>
                 </group>
                 <footer>
-                    <button string="Apply" name="action_apply" type="object" class="btn-primary"/>
+                    <button
+                        string="Apply"
+                        name="action_apply"
+                        type="object"
+                        class="btn-primary"
+                    />
                     <button string="Cancel" class="btn-default" special="cancel" />
                 </footer>
             </form>
@@ -38,9 +43,12 @@
         <field name="view_mode">form</field>
         <field name="context">{}</field>
         <field name="target">new</field>
-        <field name="view_id" ref="shopinvader_partner_validate_form_view"/>
-        <field name="groups_id" eval="[(4, ref('shopinvader.group_shopinvader_manager'))]"/>
-        <field name="binding_model_id" ref="shopinvader.model_shopinvader_partner"/>
+        <field name="view_id" ref="shopinvader_partner_validate_form_view" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('shopinvader.group_shopinvader_manager'))]"
+        />
+        <field name="binding_model_id" ref="shopinvader.model_shopinvader_partner" />
     </record>
 
 </odoo>

--- a/shopinvader/wizards/shopinvader_variant_binding_wizard.py
+++ b/shopinvader/wizards/shopinvader_variant_binding_wizard.py
@@ -43,12 +43,15 @@ class ShopinvaderVariantBindingWizard(models.TransientModel):
         for wizard in self:
             backend = wizard.backend_id
             method = backend.with_delay().bind_selected_products
-            if wizard.run_immediately:
+            run_immediately = wizard.run_immediately or self.env.context.get(
+                "bind_products_immediately"
+            )
+            if run_immediately:
                 method = backend.bind_selected_products
             method(
                 wizard.product_ids,
                 langs=wizard.lang_ids,
-                run_immediately=wizard.run_immediately,
+                run_immediately=run_immediately,
             )
 
     @api.model

--- a/shopinvader/wizards/shopinvader_variant_binding_wizard.py
+++ b/shopinvader/wizards/shopinvader_variant_binding_wizard.py
@@ -1,7 +1,7 @@
 # Copyright 2017 ACSONE SA/NV
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
-from collections import defaultdict
 
 from odoo import api, fields, models
 
@@ -27,6 +27,7 @@ class ShopinvaderVariantBindingWizard(models.TransientModel):
         help="List of langs for which a binding must exists. If not "
         "specified, the list of langs defined on the backend is used.",
     )
+    run_immediately = fields.Boolean(help="Do not schedule jobs.")
 
     @api.model
     def default_get(self, fields_list):
@@ -38,79 +39,27 @@ class ShopinvaderVariantBindingWizard(models.TransientModel):
             res["lang_ids"] = [(6, None, backend.lang_ids.ids)]
         return res
 
-    def _get_langs_to_bind(self):
-        self.ensure_one()
-        return self.lang_ids or self.backend_id.lang_ids
-
-    def _get_bound_templates(self):
-        """
-        return a dict of bound shopinvader.product by product template id
-        :return:
-        """
-        self.ensure_one()
-        binding = self.env["shopinvader.product"]
-        product_template_ids = self.mapped("product_ids.product_tmpl_id")
-        bound_templates = binding.with_context(active_test=False).search(
-            [
-                ("record_id", "in", product_template_ids.ids),
-                ("backend_id", "=", self.backend_id.id),
-                ("lang_id", "in", self._get_langs_to_bind().ids),
-            ]
-        )
-        ret = defaultdict(dict)
-        for bt in bound_templates:
-            ret[bt.record_id][bt.lang_id] = bt
-        for product in self.mapped("product_ids.product_tmpl_id"):
-            product_tmpl_id = product
-            bind_records = ret.get(product_tmpl_id)
-            for lang_id in self._get_langs_to_bind():
-                bind_record = bind_records and bind_records.get(lang_id)
-                if not bind_record:
-                    data = {
-                        "record_id": product.id,
-                        "backend_id": self.backend_id.id,
-                        "lang_id": lang_id.id,
-                    }
-                    ret[product_tmpl_id][lang_id] = binding.create(data)
-                elif not bind_record.active:
-                    bind_record.write({"active": True})
-        return ret
-
     def bind_products(self):
         for wizard in self:
-            bound_templates = wizard._get_bound_templates()
-            binding = self.env["shopinvader.variant"]
-            for product in wizard.product_ids:
-                bound_products = bound_templates[product.product_tmpl_id]
-                for lang_id in wizard._get_langs_to_bind():
-                    for shopinvader_product in bound_products[lang_id]:
-                        bound_variants = (
-                            shopinvader_product.shopinvader_variant_ids
-                        )
-                        bind_record = bound_variants.filtered(
-                            lambda p: p.record_id == product
-                        )
-                        if not bind_record:
-                            # fmt: off
-                            data = {
-                                "record_id": product.id,
-                                "backend_id": wizard.backend_id.id,
-                                "shopinvader_product_id":
-                                    shopinvader_product.id,
-                            }
-                            # fmt: on
-                            binding.create(data)
-                        elif not bind_record.active:
-                            bind_record.write({"active": True})
-            wizard.backend_id.auto_bind_categories()
+            backend = wizard.backend_id
+            method = backend.with_delay().bind_selected_products
+            if wizard.run_immediately:
+                method = backend.bind_selected_products
+            method(
+                wizard.product_ids,
+                langs=wizard.lang_ids,
+                run_immediately=wizard.run_immediately,
+            )
 
     @api.model
     def bind_langs(self, backend, lang_ids):
-        """
-        Ensure that a shopinvader.variant exists for each lang_id. If not,
-        create a new binding for the missing lang. This method is usefull
+        """Ensure that a shopinvader.variant exists for each lang_id.
+
+        If not, create a new binding for the missing lang. This method is useful
         to ensure that when a lang is added to a backend, all the binding
         for this lang are created for the existing bound products
+        for this lang are created for the existing bound products.
+
         :param backend: backend record
         :param lang_ids: list of lang ids we must ensure that a binding exists
         :return:

--- a/shopinvader/wizards/shopinvader_variant_binding_wizard.py
+++ b/shopinvader/wizards/shopinvader_variant_binding_wizard.py
@@ -42,15 +42,15 @@ class ShopinvaderVariantBindingWizard(models.TransientModel):
         self.ensure_one()
         return self.lang_ids or self.backend_id.lang_ids
 
-    def _get_binded_templates(self):
+    def _get_bound_templates(self):
         """
-        return a dict of binded shopinvader.product by product template id
+        return a dict of bound shopinvader.product by product template id
         :return:
         """
         self.ensure_one()
         binding = self.env["shopinvader.product"]
         product_template_ids = self.mapped("product_ids.product_tmpl_id")
-        binded_templates = binding.with_context(active_test=False).search(
+        bound_templates = binding.with_context(active_test=False).search(
             [
                 ("record_id", "in", product_template_ids.ids),
                 ("backend_id", "=", self.backend_id.id),
@@ -58,7 +58,7 @@ class ShopinvaderVariantBindingWizard(models.TransientModel):
             ]
         )
         ret = defaultdict(dict)
-        for bt in binded_templates:
+        for bt in bound_templates:
             ret[bt.record_id][bt.lang_id] = bt
         for product in self.mapped("product_ids.product_tmpl_id"):
             product_tmpl_id = product
@@ -78,14 +78,16 @@ class ShopinvaderVariantBindingWizard(models.TransientModel):
 
     def bind_products(self):
         for wizard in self:
-            binded_templates = wizard._get_binded_templates()
+            bound_templates = wizard._get_bound_templates()
             binding = self.env["shopinvader.variant"]
             for product in wizard.product_ids:
-                binded_products = binded_templates[product.product_tmpl_id]
+                bound_products = bound_templates[product.product_tmpl_id]
                 for lang_id in wizard._get_langs_to_bind():
-                    for shopinvader_product in binded_products[lang_id]:
-                        binded_variants = shopinvader_product.shopinvader_variant_ids
-                        bind_record = binded_variants.filtered(
+                    for shopinvader_product in bound_products[lang_id]:
+                        bound_variants = (
+                            shopinvader_product.shopinvader_variant_ids
+                        )
+                        bind_record = bound_variants.filtered(
                             lambda p: p.record_id == product
                         )
                         if not bind_record:
@@ -108,18 +110,18 @@ class ShopinvaderVariantBindingWizard(models.TransientModel):
         Ensure that a shopinvader.variant exists for each lang_id. If not,
         create a new binding for the missing lang. This method is usefull
         to ensure that when a lang is added to a backend, all the binding
-        for this lang are created for the existing binded products
+        for this lang are created for the existing bound products
         :param backend: backend record
         :param lang_ids: list of lang ids we must ensure that a binding exists
         :return:
         """
-        binded_products = self.env["product.product"].search(
+        bound_products = self.env["product.product"].search(
             [("shopinvader_bind_ids.backend_id", "=", backend.id)]
         )
         # use in memory record to avoid the creation of useless records into
         # the database
-        # by default the wizard check if a product is already binded so we
-        # can use it by giving the list of product already binded in one of
+        # by default the wizard check if a product is already bound so we
+        # can use it by giving the list of product already bound in one of
         # the specified lang and the process will create the missing one.
 
         # TODO 'new({})' doesn't work into V13 -> should use model lassmethod
@@ -127,7 +129,7 @@ class ShopinvaderVariantBindingWizard(models.TransientModel):
             {
                 "lang_ids": self.env["res.lang"].browse(lang_ids),
                 "backend_id": backend.id,
-                "product_ids": binded_products,
+                "product_ids": bound_products,
             }
         )
         wiz.bind_products()

--- a/shopinvader/wizards/shopinvader_variant_binding_wizard.xml
+++ b/shopinvader/wizards/shopinvader_variant_binding_wizard.xml
@@ -10,9 +10,9 @@
         <field name="model">shopinvader.variant.binding.wizard</field>
         <field name="arch" type="xml">
             <form string="Shopinvader Variant Binding Wizard">
-                <field name='backend_id'/>
-                <field name='product_ids'/>
-                <field name='run_immediately'/>
+                <field name='backend_id' />
+                <field name='product_ids' />
+                <field name='run_immediately' />
                 <footer>
                     <button
                         string="Bind Products"

--- a/shopinvader/wizards/shopinvader_variant_binding_wizard.xml
+++ b/shopinvader/wizards/shopinvader_variant_binding_wizard.xml
@@ -10,8 +10,9 @@
         <field name="model">shopinvader.variant.binding.wizard</field>
         <field name="arch" type="xml">
             <form string="Shopinvader Variant Binding Wizard">
-                <field name='backend_id' />
-                <field name='product_ids' />
+                <field name='backend_id'/>
+                <field name='product_ids'/>
+                <field name='run_immediately'/>
                 <footer>
                     <button
                         string="Bind Products"

--- a/shopinvader_assortment/tests/test_product_auto_bind.py
+++ b/shopinvader_assortment/tests/test_product_auto_bind.py
@@ -7,7 +7,9 @@ from odoo.tests.common import TransactionCase
 class TestProductAutoBind(TransactionCase):
     def setUp(self):
         super().setUp()
-        self.backend = self.env.ref("shopinvader.backend_1")
+        self.backend = self.env.ref("shopinvader.backend_1").with_context(
+            bind_products_immediately=True
+        )
         self.variant_obj = self.env["shopinvader.variant"]
         self.product_obj = self.env["product.product"]
         self.backend.product_assortment_id.domain = "[('sale_ok', '=', True)]"
@@ -23,7 +25,9 @@ class TestProductAutoBind(TransactionCase):
 
         variants = self.variant_obj.search([("backend_id", "=", self.backend.id)])
 
-        self.assertEqual(products_to_bind.ids, variants.mapped("record_id").ids)
+        self.assertEqual(
+            sorted(products_to_bind.ids), sorted(variants.mapped("record_id").ids)
+        )
 
         # Exclude one product, related binding should be inactivated
         excluded_product = self.env.ref("product.product_product_7")
@@ -70,7 +74,9 @@ class TestProductAutoBind(TransactionCase):
 
         variants = self.variant_obj.search([("backend_id", "=", self.backend.id)])
 
-        self.assertEqual(products_to_bind.ids, variants.mapped("record_id").ids)
+        self.assertEqual(
+            sorted(products_to_bind.ids), sorted(variants.mapped("record_id").ids)
+        )
 
         # Exclude one product, related binding should be inactivated
         excluded_product = self.env.ref("product.product_product_7")


### PR DESCRIPTION
See atomic commits for details.

Main improvements:

1. shopinvader: centralize partner work ctx setup
2. shopinvader: partner form quick edit form for invader partner
3. shopinvader: refactor partner validation
4. shopinvader: product filter custom path for fields
5. shopinvader: refactor and improve binding wiz
6. shopinvader: support like/ilike for searches
7. shopinvader: propagate params to json rendering


NOTE: PR split in N parts:

- [x] #984 
- [x] #986 
- [ ] #989
- [ ] #991
