### PR TITLE
[13.0] s_wishlist: handle missing bindings gently

### DIFF
--- a/shopinvader_customer_price_wishlist/services/wishlist.py
+++ b/shopinvader_customer_price_wishlist/services/wishlist.py
@@ -24,7 +24,11 @@ class WishlistService(Component):
     # we could avoid this module completely.
     def _json_parser_product_data(self, rec, fname):
         res = super()._json_parser_product_data(rec, fname)
-        res["price"] = self._json_parser_product_price(
-            rec.shopinvader_variant_id, fname
-        )
+        if rec.shopinvader_variant_id:
+            # Wishlist endpoint is fault-tolerant here
+            # and allows to return a minimal set of data for products
+            # even when the variant is not available.
+            res["price"] = self._json_parser_product_price(
+                rec.shopinvader_variant_id, fname
+            )
         return res

--- a/shopinvader_customer_price_wishlist/tests/test_wishlist_price.py
+++ b/shopinvader_customer_price_wishlist/tests/test_wishlist_price.py
@@ -72,3 +72,10 @@ class WishlistCase(CommonWishlistCase):
         self.assertEqual(
             res_line["product"]["price"]["default"], expected_price
         )
+
+    def test_jsonify_missing_binding(self):
+        self.prod_set.set_line_ids.mapped(
+            "product_id.shopinvader_bind_ids"
+        ).unlink()
+        res_line = self._get_line_data()
+        self.assertFalse("price" in res_line["product"])

--- a/shopinvader_wishlist/models/product_set.py
+++ b/shopinvader_wishlist/models/product_set.py
@@ -66,7 +66,7 @@ class ProductSetLine(models.Model):
     @api.depends("product_id")
     @api.depends_context("lang")
     def _compute_shopinvader_variant(self):
-        for record in self:
+        for record in self.with_context(active_test=False):
             if record.product_id and not record.shopinvader_variant_id:
                 backend = record.product_set_id.shopinvader_backend_id
                 lang = self.env.context.get("lang")

--- a/shopinvader_wishlist/services/wishlist.py
+++ b/shopinvader_wishlist/services/wishlist.py
@@ -397,7 +397,30 @@ class WishlistService(Component):
         ]
 
     def _json_parser_product_data(self, rec, fname):
-        return rec.shopinvader_variant_id.get_shop_data()
+        if rec.shopinvader_variant_id:
+            data = rec.shopinvader_variant_id.get_shop_data()
+            data["available"] = True
+            return data
+        return rec.product_id.jsonify(
+            self._json_parser_binding_not_available_data(), one=True
+        )
+
+    def _json_parser_binding_not_available_data(self):
+        """Special parser for when the binding is not available.
+
+        A user might delete bindings for a specific product
+        or add a product w/out bindings to a wishlist
+        and then archive the product which will lead to no binding as well.
+        Or, product and wishlists have been imported from CSVs
+        and the product was archived in the process or right after
+        before creating bindings.
+
+        In all the cases, you end up w/ broken reference.
+
+        When this happens, allow the frontend to show a nice message
+        to ask users to replace the product.
+        """
+        return ["id", "name", ("active:available", lambda rec, fname: False)]
 
     def _json_parser_wishlist_access(self, rec, fname):
         return self.access_info.for_wishlist(rec)

--- a/shopinvader_wishlist/tests/test_product_set.py
+++ b/shopinvader_wishlist/tests/test_product_set.py
@@ -29,6 +29,21 @@ class ProductSet(CommonCase):
         self.assertEqual(line.shopinvader_variant_id, variant)
         self.assertEqual(variant.lang_id.code, "en_US")
 
+    def test_archived_product(self):
+        # ensure product archived is visible
+        prod = self.env.ref("product.product_product_4d")
+        line = self.prod_set.set_line_ids.create(
+            {
+                "product_set_id": self.prod_set.id,
+                "product_id": prod.id,
+                "quantity": 1,
+            }
+        )
+        variant = prod.shopinvader_bind_ids[0]
+        variant.active = False
+        line.invalidate_cache(["shopinvader_variant_id"])
+        self.assertEqual(line.shopinvader_variant_id, variant)
+
     @mute_logger("odoo.models.unlink")
     def test_create_no_variant_switch_lang(self):
         lang_fr = self._install_lang("base.lang_fr")

--- a/shopinvader_wishlist/tests/test_wishlist.py
+++ b/shopinvader_wishlist/tests/test_wishlist.py
@@ -324,7 +324,19 @@ class WishlistCase(CommonWishlistCase):
         self.assertEqual(res_line["id"], self.prod_set.set_line_ids[0].id)
         self.assertEqual(res_line["quantity"], 1)
         self.assertEqual(res_line["sequence"], 10)
-        self.assertEqual(res_line["product"], variant.get_shop_data())
+        self.assertEqual(
+            res_line["product"], dict(variant.get_shop_data(), available=True)
+        )
+
+    def test_jsonify_missing_variant_binding(self):
+        prod = self.env.ref("product.product_product_4b")
+        prod.shopinvader_bind_ids.unlink()
+        res = self.wishlist_service._to_json_one(self.prod_set)
+        res_line = res["lines"][0]
+        self.assertEqual(
+            res_line["product"],
+            {"id": prod.id, "name": prod.name, "available": False},
+        )
 
     def test_jsonify_data_mode(self):
         res = self.wishlist_service._to_json_one(


### PR DESCRIPTION
A user might delete bindings for a specific product
or add a product w/out bindings to a wishlist
and then archive the product which will lead to no binding as well.
Or, product and wishlists have been imported from CSVs
and the product was archived in the process or right after
before creating bindings.

In all the cases, you end up w/ broken reference.

When this happens, allow the frontend to show a nice message
to ask users to replace the product.
