### PR TITLE
s_sale_by_packaging: adapt to packaging calc updates

### DIFF
--- a/shopinvader_sale_packaging/__manifest__.py
+++ b/shopinvader_sale_packaging/__manifest__.py
@@ -6,7 +6,7 @@
     "Summary": """
         Sell products by packaging.
     """,
-    "version": "13.0.2.3.0",
+    "version": "13.0.2.4.0",
     "license": "AGPL-3",
     "author": "Camptocamp SA",
     "website": "https://github.com/shopinvader/odoo-shopinvader",
@@ -14,7 +14,7 @@
         "shopinvader",
         "sale_stock",
         "sale_by_packaging",
-        "stock_packaging_calculator",
+        "stock_packaging_calculator_packaging_type",
     ],
     "data": ["data/ir_export_product.xml"],
 }

--- a/shopinvader_sale_packaging/migrations/13.0.2.4.0/post-migrate.py
+++ b/shopinvader_sale_packaging/migrations/13.0.2.4.0/post-migrate.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    _logger.info("Recompute packaging info")
+    # Ensure stored packaging info gets refreshed
+    env["shopinvader.variant"].search([])._compute_packaging()
+    # NOTE: recommended to run `recompute_json` cron

--- a/shopinvader_sale_packaging/models/shopinvader_variant.py
+++ b/shopinvader_sale_packaging/models/shopinvader_variant.py
@@ -47,7 +47,4 @@ class ShopinvaderVariant(models.Model):
             "lang": self.lang_id.code,
             # consider only packaging that can be sold
             "_packaging_filter": lambda x: x.can_be_sold,
-            # to support multilang shop we rely on packaging type's name
-            # which is already translatable.
-            "_packaging_name_getter": lambda x: x.packaging_type_id.name,
         }

--- a/shopinvader_sale_packaging/services/packaging_mixin.py
+++ b/shopinvader_sale_packaging/services/packaging_mixin.py
@@ -33,9 +33,6 @@ class PackagingServiceMixin(AbstractComponent):
         return {
             # consider only packaging that can be sold
             "_packaging_filter": lambda x: x.can_be_sold,
-            # to support multilang shop we rely on packaging type's name
-            # which is already translatable.
-            "_packaging_name_getter": lambda x: x.packaging_type_id.name,
         }
 
     def _packaging_values_from_params(self, params):

--- a/shopinvader_sale_packaging/tests/test_product_data.py
+++ b/shopinvader_sale_packaging/tests/test_product_data.py
@@ -59,27 +59,14 @@ class TestProductPackagingData(CommonCase):
         return [
             make_pkg_values(
                 self.pkg_pallet,
-                name=self.type_pallet.name,
-                contained=[
-                    make_pkg_values(
-                        self.pkg_big_box,
-                        name=self.type_transport_box.name,
-                        qty=10,
-                    )
-                ],
+                contained=[make_pkg_values(self.pkg_big_box, qty=10,)],
             ),
             make_pkg_values(
                 self.pkg_big_box,
-                name=self.type_transport_box.name,
-                contained=[
-                    make_pkg_values(
-                        self.pkg_box, name=self.type_retail_box.name, qty=4
-                    )
-                ],
+                contained=[make_pkg_values(self.pkg_box, qty=4)],
             ),
             make_pkg_values(
                 self.pkg_box,
-                name=self.type_retail_box.name,
                 contained=[make_pkg_values(self.product.uom_id, qty=50)],
             ),
             make_pkg_values(self.product.uom_id, qty=1, contained=None),


### PR DESCRIPTION
Relies on https://github.com/OCA/stock-logistics-warehouse/pull/1168
Thanks to `stock_packaging_calculator_packaging_type` overriding the name is not required anymore.