### PR TITLE
[14.0][ADD] shopinvader_sale_coupon

### DIFF
--- a/setup/shopinvader_sale_coupon/odoo/addons/shopinvader_sale_coupon
+++ b/setup/shopinvader_sale_coupon/odoo/addons/shopinvader_sale_coupon
@@ -1,0 +1,1 @@
+../../../../shopinvader_sale_coupon

--- a/setup/shopinvader_sale_coupon/setup.py
+++ b/setup/shopinvader_sale_coupon/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopinvader_sale_coupon/README.rst
+++ b/shopinvader_sale_coupon/README.rst
@@ -1,0 +1,24 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=======================
+Shopinvader Sale Coupon
+=======================
+
+This module extends the functionality of shopinvader to support Coupons
+and Promotions from `sale_coupon` core module.
+
+Not to be confused with `shopinvader_promotion_rule`, that implements
+promotion programs from OCA module `sale_promotion_rule`, an alternative
+to the core `sale_coupon` module.
+
+Credits
+=======
+
+Contributors
+------------
+
+* `Camptocamp <https://www.camptocamp.com>`_
+
+  * Iván Todorovich <ivan.todorovich@gmail.com>

--- a/shopinvader_sale_coupon/__init__.py
+++ b/shopinvader_sale_coupon/__init__.py
@@ -1,0 +1,1 @@
+from . import services

--- a/shopinvader_sale_coupon/__manifest__.py
+++ b/shopinvader_sale_coupon/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Camptocamp SA
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Shopvinvader Sale Coupon",
+    "summary": "Manage Promotion and Coupon programs in Shopinvader",
+    "version": "14.0.1.0.0",
+    "category": "Sale",
+    "website": "https://github.com/shopinvader/odoo-shopinvader",
+    "author": "Camptocamp",
+    "license": "AGPL-3",
+    "depends": ["shopinvader", "sale_coupon"],
+}

--- a/shopinvader_sale_coupon/services/__init__.py
+++ b/shopinvader_sale_coupon/services/__init__.py
@@ -1,0 +1,2 @@
+from . import abstract_sale
+from . import cart

--- a/shopinvader_sale_coupon/services/abstract_sale.py
+++ b/shopinvader_sale_coupon/services/abstract_sale.py
@@ -1,0 +1,57 @@
+# Copyright 2021 Camptocamp SA
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.component.core import AbstractComponent
+
+
+class AbstractSaleService(AbstractComponent):
+    _inherit = "shopinvader.abstract.sale.service"
+
+    def _is_item(self, line):
+        return super()._is_item(line) and not line.is_reward_line
+
+    def _convert_one_sale(self, sale):
+        res = super()._convert_one_sale(sale)
+        res.update(
+            {
+                "promo_code": sale.promo_code,
+                "reward_amount": sale.reward_amount,
+                "applied_coupon_ids": self._convert_coupon(sale.applied_coupon_ids),
+                "generated_coupon_ids": self._convert_coupon(sale.generated_coupon_ids),
+                "no_code_promo_program_ids": self._convert_coupon_programs(
+                    sale.no_code_promo_program_ids
+                ),
+                "code_promo_program_id": self._convert_coupon_programs(
+                    sale.code_promo_program_id
+                ),
+            }
+        )
+        return res
+
+    def _convert_one_line(self, line):
+        res = super()._convert_one_line(line)
+        res.update(
+            {
+                "is_reward_line": line.is_reward_line,
+            }
+        )
+        return res
+
+    def _parser_coupon(self):
+        return ["id", "code", "state", "expiration_date", "partner_id", "program_id"]
+
+    def _parser_coupon_program(self):
+        return ["id", "name"]
+
+    def _convert_coupon(self, coupons):
+        return {
+            "items": coupons.jsonify(self._parser_coupon()),
+            "count": len(coupons),
+        }
+
+    def _convert_coupon_programs(self, programs):
+        return {
+            "items": programs.jsonify(self._parser_coupon_program()),
+            "count": len(programs),
+        }

--- a/shopinvader_sale_coupon/services/cart.py
+++ b/shopinvader_sale_coupon/services/cart.py
@@ -1,0 +1,100 @@
+# Copyright 2021 Camptocamp SA
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.component.core import Component
+
+
+class CartService(Component):
+    _inherit = "shopinvader.cart.service"
+
+    # Public Methods
+
+    def apply_coupon(self, **params):
+        cart = self._get()
+        self._apply_coupon(cart, params)
+        return self._to_json(cart)
+
+    def recompute_coupon_lines(self, **params):
+        cart = self._get()
+        self._recompute_coupon_lines(cart, params)
+        return self._to_json(cart)
+
+    # Private Methods
+
+    def _apply_coupon(self, cart, params):
+        """Apply a coupon or promotion code.
+
+        It can raise UserError if coupon is not applicable.
+        """
+        return (
+            self.env["sale.coupon.apply.code"]
+            .with_context(active_id=cart.id)
+            .create({"coupon_code": params["code"]})
+            .process_coupon()
+        )
+
+    def _recompute_coupon_lines(self, cart, params):
+        cart.recompute_coupon_lines()
+
+    # Private Overrides
+
+    def _add_item(self, cart, params):
+        skip_coupon_recompute = params.pop("skip_coupon_recompute", None)
+        res = super()._add_item(cart, params)
+        if not skip_coupon_recompute:
+            self._recompute_coupon_lines(cart, params)
+        return res
+
+    def _update_item(self, cart, params, item=False):
+        skip_coupon_recompute = params.pop("skip_coupon_recompute", None)
+        res = super()._update_item(cart, params, item)
+        if not skip_coupon_recompute:
+            self._recompute_coupon_lines(cart, params)
+        return res
+
+    def _delete_item(self, cart, params):
+        skip_coupon_recompute = params.pop("skip_coupon_recompute", None)
+        res = super()._delete_item(cart, params)
+        if not skip_coupon_recompute:
+            self._recompute_coupon_lines(cart, params)
+        return res
+
+    def _get_lines_to_copy(self, cart):
+        return super()._get_lines_to_copy(cart).filtered(lambda l: not l.is_reward_line)
+
+    # Validator
+
+    def _validator_apply_coupon(self):
+        return {
+            "code": {
+                "type": "string",
+                "required": True,
+            }
+        }
+
+    def _validator_recompute_coupon_lines(self):
+        return {}
+
+    def _subvalidator_skip_coupon_recompute(self):
+        return {
+            "skip_coupon_recompute": {
+                "type": "boolean",
+                "required": False,
+            }
+        }
+
+    def _validator_add_item(self):
+        res = super()._validator_add_item()
+        res.update(self._subvalidator_skip_coupon_recompute())
+        return res
+
+    def _validator_update_item(self):
+        res = super()._validator_update_item()
+        res.update(self._subvalidator_skip_coupon_recompute())
+        return res
+
+    def _validator_delete_item(self):
+        res = super()._validator_delete_item()
+        res.update(self._subvalidator_skip_coupon_recompute())
+        return res

--- a/shopinvader_sale_coupon/tests/__init__.py
+++ b/shopinvader_sale_coupon/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_cart

--- a/shopinvader_sale_coupon/tests/test_cart.py
+++ b/shopinvader_sale_coupon/tests/test_cart.py
@@ -1,0 +1,159 @@
+# Copyright 2021 Camptocamp SA
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import UserError
+
+from odoo.addons.sale_coupon.tests.common import TestSaleCouponCommon
+from odoo.addons.shopinvader.tests.test_cart import CommonConnectedCartCase
+
+
+class TestCart(CommonConnectedCartCase, TestSaleCouponCommon):
+    def setUp(self, *args, **kwargs):
+        super().setUp(*args, **kwargs)
+        # TODO: This should be in setUpClass, but it has to be
+        # changed in shopinvader's CommonConnectedCartCase.
+        # Start with an empty cart
+        self.cart.order_line.unlink()
+        # Config programs
+        self.code_promotion_program.reward_type = "discount"
+
+    def _generate_coupons(self, program, qty=1):
+        existing_coupons = program.coupon_ids
+        # Create coupons
+        self.env["coupon.generate.wizard"].with_context(active_id=program.id).create(
+            {
+                "generation_type": "nbr_coupon",
+                "nbr_coupons": qty,
+            }
+        ).generate_coupon()
+        # Return only the created coupons
+        return program.coupon_ids - existing_coupons
+
+    def test_immediate_promotion_program(self):
+        # Test case 1 (1 A): Assert that no reward is given,
+        # as the product B is missing
+        self.service.dispatch(
+            "add_item",
+            params={
+                "product_id": self.product_A.id,
+                "item_qty": 1.0,
+            },
+        )
+        self.assertEqual(
+            len(self.cart.order_line),
+            1,
+            "The promo offer shouldn't have been applied as the product B "
+            "isn't in the order",
+        )
+        # Test case 2 (1 A 1 B): Assert that the reward is given,
+        # as the product B is now in the order
+        self.service.dispatch(
+            "add_item",
+            params={
+                "product_id": self.product_B.id,
+                "item_qty": 1.0,
+            },
+        )
+        self.assertEqual(
+            len(self.cart.order_line), 3, "The promo should've been applied"
+        )
+        # Test case 3 (1 B): Assert that the reward is removed when the order
+        # is modified and doesn't match the rules anymore
+        self.service.dispatch(
+            "delete_item",
+            params={
+                "item_id": self.cart.order_line[0].id,
+            },
+        )
+        self.assertEqual(
+            len(self.cart.order_line),
+            1,
+            "The promo reward should have been removed as the rules are not "
+            "matched anymore",
+        )
+        self.assertEqual(self.cart.order_line.product_id.id, self.product_B.id)
+
+    def test_code_promotion_program(self):
+        self.code_promotion_program.promo_code = "promocode"
+        # Buy 1 A + Enter code, 1 A is free
+        self.service.dispatch(
+            "add_item",
+            params={
+                "product_id": self.product_A.id,
+                "item_qty": 1.0,
+            },
+        )
+        self.assertEqual(
+            len(self.cart.order_line),
+            1,
+            "The promo offer shouldn't have been applied as the code hasn't "
+            "been entered yet",
+        )
+        # Enter an invalid code
+        with self.assertRaises(UserError):
+            self.service.dispatch("apply_coupon", params={"code": "fakecode"})
+        # Enter code
+        self.service.dispatch("apply_coupon", params={"code": "promocode"})
+        self.assertEqual(
+            len(self.cart.order_line.ids),
+            2,
+            "The promo should've been applied",
+        )
+
+    def test_code_promotion_program_coupons(self):
+        coupon = self._generate_coupons(self.code_promotion_program)
+        # Buy 1 A + Enter code, 1 A is free
+        self.service.dispatch(
+            "add_item",
+            params={
+                "product_id": self.product_A.id,
+                "item_qty": 1.0,
+            },
+        )
+        self.assertEqual(
+            len(self.cart.order_line),
+            1,
+            "The promo offer shouldn't have been applied as the code hasn't "
+            "been entered yet",
+        )
+        # Enter code
+        self.service.dispatch("apply_coupon", params={"code": coupon.code})
+        self.assertEqual(
+            len(self.cart.order_line.ids),
+            2,
+            "The promo should've been applied",
+        )
+        self.assertEqual(coupon.state, "used")
+        # Try to apply twice
+        with self.assertRaises(UserError):
+            self.service.dispatch("apply_coupon", params={"code": coupon.code})
+
+    def test_manual_recompute(self):
+        # Test case 1 (1 A 1 B): Assert that no reward is given because
+        # we're skipping the recompute
+        self.service.dispatch(
+            "add_item",
+            params={
+                "product_id": self.product_A.id,
+                "item_qty": 1.0,
+                "skip_coupon_recompute": True,
+            },
+        )
+        self.service.dispatch(
+            "add_item",
+            params={
+                "product_id": self.product_B.id,
+                "item_qty": 1.0,
+                "skip_coupon_recompute": True,
+            },
+        )
+        self.assertEqual(
+            len(self.cart.order_line),
+            2,
+            "The promo shouldn't have been applied as we're skipping recompute",
+        )
+        self.service.dispatch("recompute_coupon_lines")
+        self.assertEqual(
+            len(self.cart.order_line), 3, "The promo should've been applied"
+        )


### PR DESCRIPTION
This module extends the functionality of shopinvader to support Coupons
and Promotions from `sale_coupon` core module.

Not to be confused with `shopinvader_promotion_rule`, that implements
promotion programs from OCA module `sale_promotion_rule`, an alternative
to the core `sale_coupon` module.


NOTE: Please approve workflows, as it's my first contribution to the repo :sweat_smile: 