### PR TITLE
s_product_template_multi_link: fix indexed ID

### DIFF
--- a/shopinvader_product_template_multi_link/models/shopinvader_product_link_mixin.py
+++ b/shopinvader_product_template_multi_link/models/shopinvader_product_link_mixin.py
@@ -63,7 +63,7 @@ class ShopinvaderProductLinkMixin(models.AbstractModel):
             return {}
         variant = self._product_link_target_variant(target)
         if variant:
-            return {"id": variant.record_id.id}
+            return {"id": variant.id}
         return {}
 
     def _product_link_target(self, link):

--- a/shopinvader_product_template_multi_link/tests/test_product.py
+++ b/shopinvader_product_template_multi_link/tests/test_product.py
@@ -19,8 +19,8 @@ class ProductLinkCase(ProductLinkCaseBase):
         ).filtered(lambda x: x.main)
 
         expected = {
-            "up_selling": [{"id": main2.record_id.id}],
-            "cross_selling": [{"id": main3.record_id.id}],
+            "up_selling": [{"id": main2.id}],
+            "cross_selling": [{"id": main3.id}],
         }
         self.assertEqual(
             self.shopinvader_variant_1_1.shopinvader_product_id.product_links,
@@ -32,8 +32,8 @@ class ProductLinkCase(ProductLinkCaseBase):
         )
 
         expected = {
-            "cross_selling": [{"id": main3.record_id.id}],
-            "up_selling": [{"id": main1.record_id.id}],
+            "cross_selling": [{"id": main3.id}],
+            "up_selling": [{"id": main1.id}],
         }
         self.assertEqual(
             self.shopinvader_variant_2_1.shopinvader_product_id.product_links,
@@ -44,12 +44,9 @@ class ProductLinkCase(ProductLinkCaseBase):
             expected,
         )
         expected = {
-            "cross_selling": [
-                {"id": main1.record_id.id},
-                {"id": main2.record_id.id},
-            ],
+            "cross_selling": [{"id": main1.id}, {"id": main2.id}],
         }
-        expected["one_way"] = [{"id": main2.record_id.id}]
+        expected["one_way"] = [{"id": main2.id}]
         self.assertEqual(
             self.shopinvader_variant_3_2.shopinvader_product_id.product_links,
             expected,

--- a/shopinvader_product_variant_multi_link/tests/test_product.py
+++ b/shopinvader_product_variant_multi_link/tests/test_product.py
@@ -45,8 +45,8 @@ class ProductLinkCase(ProductVariantLinkCaseBase):
         self.assertEqual(self.shopinvader_variant_1_1.product_links, expected)
         # 2nd variant gets links w/ template 2 and 3 variants
         expected = {
-            "up_selling": [{"id": self.variant_2_2.id}],
-            "cross_selling": [{"id": self.variant_3_2.id}],
+            "up_selling": [{"id": self.shopinvader_variant_2_2.id}],
+            "cross_selling": [{"id": self.shopinvader_variant_3_2.id}],
         }
         self.assertEqual(self.shopinvader_variant_1_2.product_links, expected)
 
@@ -56,8 +56,8 @@ class ProductLinkCase(ProductVariantLinkCaseBase):
         self.assertEqual(self.shopinvader_variant_2_1.product_links, expected)
         # 2nd variant gets links w/ template 2 and 3 variants
         expected = {
-            "up_selling": [{"id": self.variant_1_2.id}],
-            "cross_selling": [{"id": self.variant_3_2.id}],
+            "up_selling": [{"id": self.shopinvader_variant_1_2.id}],
+            "cross_selling": [{"id": self.shopinvader_variant_3_2.id}],
         }
         self.assertEqual(self.shopinvader_variant_2_2.product_links, expected)
 
@@ -68,9 +68,9 @@ class ProductLinkCase(ProductVariantLinkCaseBase):
         # 2nd variant gets links w/ template 1 and 2 variants
         expected = {
             "cross_selling": [
-                {"id": self.variant_1_2.id},
-                {"id": self.variant_2_2.id},
+                {"id": self.shopinvader_variant_1_2.id},
+                {"id": self.shopinvader_variant_2_2.id},
             ],
-            "one_way": [{"id": self.variant_2_2.id}],
+            "one_way": [{"id": self.shopinvader_variant_2_2.id}],
         }
         self.assertEqual(self.shopinvader_variant_3_2.product_links, expected)


### PR DESCRIPTION
In the search engine we don't have the real product ID
hence it makes little sense to index it.

Instead we must index the s.variant ID
to be able to retrieve its data from the search engine easily.

ref: 2613