### PR TITLE
[FWD][14.0] Unify work context management

### DIFF
--- a/shopinvader/components/access_info.py
+++ b/shopinvader/components/access_info.py
@@ -22,8 +22,16 @@ class PartnerAccess(Component):
         return getattr(self.work, "partner", None)
 
     @property
+    def invader_partner(self):
+        return getattr(self.work, "invader_partner", None)
+
+    @property
     def partner_user(self):
         return getattr(self.work, "partner_user", self.partner)
+
+    @property
+    def invader_partner_user(self):
+        return getattr(self.work, "invader_partner_user", self.partner)
 
     def is_main_partner(self):
         return self.partner == self.partner_user

--- a/shopinvader/controllers/main.py
+++ b/shopinvader/controllers/main.py
@@ -97,9 +97,22 @@ class InvaderController(main.RestController):
         # rather than the real partner
         shopinvader_partner = self._get_partner_from_headers(headers)
         res["invader_partner"] = shopinvader_partner
-        partner = shopinvader_partner.record_id
-        res["partner_user"] = partner
+        res["invader_partner_user"] = shopinvader_partner
+        partner_user = shopinvader_partner.record_id
+        res["partner_user"] = partner_user
         # The partner user for the main account or for sale order may differ.
-        res["partner"] = partner.get_shop_partner(res["shopinvader_backend"])
-        res["shopinvader_session"] = self._get_shopinvader_session_from_headers(headers)
+        partner_shop = partner_user.get_shop_partner(
+            res["shopinvader_backend"]
+        )
+        res["partner"] = partner_shop
+        if partner_shop != partner_user:
+            # Invader partner must rappresent the same partner as the shop
+            invader_partner_shop = partner_shop._get_invader_partner(
+                res["shopinvader_backend"]
+            )
+            if invader_partner_shop:
+                res["invader_partner"] = invader_partner_shop
+        res[
+            "shopinvader_session"
+        ] = self._get_shopinvader_session_from_headers(headers)
         return res

--- a/shopinvader/controllers/main.py
+++ b/shopinvader/controllers/main.py
@@ -99,7 +99,5 @@ class InvaderController(main.RestController):
         # rather than the real partner
         shopinvader_partner = self._get_partner_from_headers(headers)
         res.update(get_partner_work_context(shopinvader_partner))
-        res[
-            "shopinvader_session"
-        ] = self._get_shopinvader_session_from_headers(headers)
+        res["shopinvader_session"] = self._get_shopinvader_session_from_headers(headers)
         return res

--- a/shopinvader/controllers/main.py
+++ b/shopinvader/controllers/main.py
@@ -12,6 +12,8 @@ from odoo.http import request, route
 
 from odoo.addons.base_rest.controllers import main
 
+from ..utils import get_partner_work_context
+
 _logger = logging.getLogger(__name__)
 
 
@@ -96,22 +98,7 @@ class InvaderController(main.RestController):
         # TODO: all services should rely on shopinvader partner
         # rather than the real partner
         shopinvader_partner = self._get_partner_from_headers(headers)
-        res["invader_partner"] = shopinvader_partner
-        res["invader_partner_user"] = shopinvader_partner
-        partner_user = shopinvader_partner.record_id
-        res["partner_user"] = partner_user
-        # The partner user for the main account or for sale order may differ.
-        partner_shop = partner_user.get_shop_partner(
-            res["shopinvader_backend"]
-        )
-        res["partner"] = partner_shop
-        if partner_shop != partner_user:
-            # Invader partner must rappresent the same partner as the shop
-            invader_partner_shop = partner_shop._get_invader_partner(
-                res["shopinvader_backend"]
-            )
-            if invader_partner_shop:
-                res["invader_partner"] = invader_partner_shop
+        res.update(get_partner_work_context(shopinvader_partner))
         res[
             "shopinvader_session"
         ] = self._get_shopinvader_session_from_headers(headers)

--- a/shopinvader/services/customer.py
+++ b/shopinvader/services/customer.py
@@ -31,9 +31,7 @@ class CustomerService(Component):
     def create(self, **params):
         vals = self._prepare_params(params)
         binding = self.env["shopinvader.partner"].create(vals)
-        # TODO: move to `service._[init|update]_context` to centralize it
-        self.work.invader_partner = binding
-        self.work.partner = binding.record_id
+        self._load_partner_work_context(binding)
         self._post_create(self.work.partner)
         return self._prepare_create_response(binding)
 
@@ -121,8 +119,8 @@ class CustomerService(Component):
     def _prepare_create_response(self, binding):
         response = self._assign_cart_and_get_store_cache()
         response["data"] = {
-            "id": self.partner.id,
-            "name": self.partner.name,
+            "id": binding.record_id.id,
+            "name": binding.name,
             "role": binding.role,
         }
         return response

--- a/shopinvader/services/partner_mixin.py
+++ b/shopinvader/services/partner_mixin.py
@@ -26,6 +26,8 @@ class PartnerServiceMixin(AbstractComponent):
             "res.partner",
             partner=self.partner,
             partner_user=self.partner_user,
+            invader_partner=self.invader_partner,
+            invader_partner_user=self.invader_partner_user,
             service_work=self.work,
         ) as work:
             return work.component(usage="access.info")

--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -45,6 +45,10 @@ class BaseShopinvaderService(AbstractComponent):
         return getattr(self.work, "partner_user", self.partner)
 
     @property
+    def invader_partner_user(self):
+        return self.work.invader_partner_user
+
+    @property
     def shopinvader_session(self):
         return self.work.shopinvader_session
 

--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -12,7 +12,7 @@ from odoo.osv import expression
 from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import AbstractComponent
 
-from .. import shopinvader_response
+from .. import shopinvader_response, utils
 
 _logger = logging.getLogger(__name__)
 
@@ -22,6 +22,13 @@ class BaseShopinvaderService(AbstractComponent):
     _name = "base.shopinvader.service"
     _collection = "shopinvader.backend"
     _expose_model = None
+
+    def _load_partner_work_context(self, invader_partner, force=False):
+        utils.load_partner_work_ctx(self, invader_partner, force=force)
+
+    def _reset_partner_work_context(self):
+        # Basically like logging out a user
+        utils.reset_partner_work_ctx(self)
 
     @property
     def partner(self):

--- a/shopinvader/tests/__init__.py
+++ b/shopinvader/tests/__init__.py
@@ -22,3 +22,4 @@ from . import test_shopinvader_partner_binding
 from . import test_notification
 from . import test_salesman_notification
 from . import test_search
+from . import test_utils

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -99,30 +99,36 @@ class CommonMixin(RegistryMixin, ComponentMixin, UtilsMixin):
 
     @contextmanager
     def work_on_services(self, **params):
-        params = params or {}
-        if params.get("partner") and not params.get("partner_user"):
-            params["partner_user"] = params["partner"]
-        if "shopinvader_backend" not in params:
-            params["shopinvader_backend"] = self.backend
-        if "shopinvader_session" not in params:
-            params["shopinvader_session"] = {}
-        if not params.get("partner_user") and params.get("partner"):
-            params["partner_user"] = params["partner"]
-        if params.get("partner_user"):
-            params["invader_partner"] = params["partner_user"]._get_invader_partner(
-                self.backend
-            )
-        # Safe defaults as these keys are mandatory for work ctx
-        if "partner" not in params:
-            params["partner"] = self.env["res.partner"].browse()
-        if "partner_user" not in params:
-            params["partner_user"] = self.env["res.partner"].browse()
-        if "invader_partner" not in params:
-            params["invader_partner"] = self.env["shopinvader.partner"].browse()
+        params = self._work_on_services_default_params(self, **params)
         collection = _PseudoCollection("shopinvader.backend", self.env)
         yield WorkContext(
             model_name="rest.service.registration", collection=collection, **params
         )
+
+    @staticmethod
+    def _work_on_services_default_params(class_or_instance, **params):
+        if "shopinvader_backend" not in params:
+            params["shopinvader_backend"] = class_or_instance.backend
+        if "shopinvader_session" not in params:
+            params["shopinvader_session"] = {}
+        if params.get("partner") and not params.get("partner_user"):
+            params["partner_user"] = params["partner"]
+
+        # Safe defaults as these keys are mandatory for work ctx
+        for k in ("partner", "partner_user"):
+            if not params.get(k):
+                params[k] = class_or_instance.env["res.partner"].browse()
+            if not params.get("invader_" + k):
+                params["invader_" + k] = params[k]._get_invader_partner(
+                    class_or_instance.backend
+                )
+        return params
+
+    def _update_work_ctx(self, service, **params):
+        params = self._work_on_services_default_params(self, **params)
+        for k, v in params.items():
+            if not getattr(service.work, k, None) and v:
+                setattr(service.work, k, v)
 
     def _init_job_counter(self):
         self.existing_jobs = self.env["queue.job"].search([])

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -11,13 +11,11 @@ from odoo import fields
 from odoo.exceptions import MissingError
 from odoo.tests import SavepointCase
 
-from odoo.addons.base_rest.controllers.main import _PseudoCollection
 from odoo.addons.base_rest.tests.common import BaseRestCase, RegistryMixin
-from odoo.addons.component.core import WorkContext
 from odoo.addons.component.tests.common import ComponentMixin
 from odoo.addons.queue_job.job import Job
 
-from .. import shopinvader_response
+from .. import shopinvader_response, utils
 from ..services import abstract_download
 
 
@@ -100,10 +98,8 @@ class CommonMixin(RegistryMixin, ComponentMixin, UtilsMixin):
     @contextmanager
     def work_on_services(self, **params):
         params = self._work_on_services_default_params(self, **params)
-        collection = _PseudoCollection("shopinvader.backend", self.env)
-        yield WorkContext(
-            model_name="rest.service.registration", collection=collection, **params
-        )
+        with utils.work_on_service(self.env, **params) as work:
+            yield work
 
     @staticmethod
     def _work_on_services_default_params(class_or_instance, **params):
@@ -111,24 +107,14 @@ class CommonMixin(RegistryMixin, ComponentMixin, UtilsMixin):
             params["shopinvader_backend"] = class_or_instance.backend
         if "shopinvader_session" not in params:
             params["shopinvader_session"] = {}
-        if params.get("partner") and not params.get("partner_user"):
-            params["partner_user"] = params["partner"]
-
-        # Safe defaults as these keys are mandatory for work ctx
-        for k in ("partner", "partner_user"):
-            if not params.get(k):
-                params[k] = class_or_instance.env["res.partner"].browse()
-            if not params.get("invader_" + k):
-                params["invader_" + k] = params[k]._get_invader_partner(
-                    class_or_instance.backend
-                )
+        utils.partner_work_context_defaults(
+            class_or_instance.env, class_or_instance.backend, params
+        )
         return params
 
     def _update_work_ctx(self, service, **params):
         params = self._work_on_services_default_params(self, **params)
-        for k, v in params.items():
-            if not getattr(service.work, k, None) and v:
-                setattr(service.work, k, v)
+        utils.update_work_ctx(service, params)
 
     def _init_job_counter(self):
         self.existing_jobs = self.env["queue.job"].search([])

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -107,15 +107,16 @@ class AnonymousCartCase(CartCase, CartClearTest):
         ) as work:
             self.service = work.component(usage="cart")
 
-    def _sign_with(self, partner):
-        self.service.work.partner = partner
+    def _sign_with(self, invader_partner):
+        self.service._load_partner_work_context(invader_partner, force=True)
         service_sign = self.service.component("customer")
         service_sign.sign_in()
 
     def test_anonymous_cart_then_sign(self):
         cart = self.cart
-        partner = self.env.ref("shopinvader.partner_1")
-        self._sign_with(partner)
+        invader_partner = self.env.ref("shopinvader.shopinvader_partner_1")
+        partner = invader_partner.record_id
+        self._sign_with(invader_partner)
         self.assertEqual(cart.partner_id, partner)
         self.assertEqual(cart.partner_shipping_id, partner)
         self.assertEqual(cart.partner_invoice_id, partner)

--- a/shopinvader/tests/test_partner_access_info.py
+++ b/shopinvader/tests/test_partner_access_info.py
@@ -9,17 +9,22 @@ class TestPartnerAccessInfo(CommonCase):
     def setUpClass(cls):
         super(TestPartnerAccessInfo, cls).setUpClass()
         cls.partner = cls.env.ref("shopinvader.partner_1")
-        cls.contact = cls.partner.create(
-            {
-                "name": "Just an address",
-                "type": "contact",
-                "parent_id": cls.partner.id,
-            }
+        cls.invader_partner = cls.partner._get_invader_partner(cls.backend)
+        cls.invader_contact = cls._create_invader_partner(
+            cls.env,
+            name="Just A User",
+            parent_id=cls.partner.id,
+            email="just@auser.com",
         )
+        cls.contact = cls.invader_contact.record_id
 
     def test_access_info_owner1(self):
         with self.backend.work_on(
-            "res.partner", partner=self.partner, partner_user=self.partner
+            "res.partner",
+            partner=self.partner,
+            partner_user=self.partner,
+            invader_partner=self.invader_partner,
+            invader_partner_user=self.invader_partner,
         ) as work:
             info = work.component(usage="access.info")
 
@@ -38,7 +43,11 @@ class TestPartnerAccessInfo(CommonCase):
 
     def test_access_info_owner2(self):
         with self.backend.work_on(
-            "res.partner", partner=self.partner, partner_user=self.partner
+            "res.partner",
+            partner=self.partner,
+            partner_user=self.partner,
+            invader_partner=self.invader_partner,
+            invader_partner_user=self.invader_partner,
         ) as work:
             info = work.component(usage="access.info")
 
@@ -62,7 +71,11 @@ class TestPartnerAccessInfo(CommonCase):
 
     def test_access_info_non_owner1(self):
         with self.backend.work_on(
-            "res.partner", partner=self.partner, partner_user=self.contact
+            "res.partner",
+            partner=self.partner,
+            invader_partner=self.invader_partner,
+            partner_user=self.contact,
+            invader_partner_user=self.invader_contact,
         ) as work:
             info = work.component(usage="access.info")
 
@@ -82,7 +95,11 @@ class TestPartnerAccessInfo(CommonCase):
 
     def test_access_info_non_owner2(self):
         with self.backend.work_on(
-            "res.partner", partner=self.partner, partner_user=self.contact
+            "res.partner",
+            partner=self.partner,
+            invader_partner=self.invader_partner,
+            partner_user=self.contact,
+            invader_partner_user=self.invader_contact,
         ) as work:
             info = work.component(usage="access.info")
 

--- a/shopinvader/tests/test_salesman_notification.py
+++ b/shopinvader/tests/test_salesman_notification.py
@@ -48,8 +48,9 @@ class TestCustomer(CommonCase):
     def _create_customer(self, **kw):
         data = dict(self.base_data)
         data.update(kw)
-        res = self.customer_service.dispatch("create", params=data)["data"]
-        return self.env["res.partner"].browse(res["id"])
+        self.customer_service._reset_partner_work_context()
+        self.customer_service.dispatch("create", params=data)["data"]
+        return self.customer_service.partner
 
     def _create_address(self, partner=None, **kw):
         data = dict(self.base_data)

--- a/shopinvader/tests/test_utils.py
+++ b/shopinvader/tests/test_utils.py
@@ -1,0 +1,94 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import mock
+
+from odoo.addons.shopinvader import utils  # pylint: disable=W7950
+
+from .common import CommonCase
+
+
+class TestUtils(CommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.invader_partner = cls.env.ref("shopinvader.shopinvader_partner_1")
+
+    def test_partner_work_ctx(self):
+        ctx = utils.get_partner_work_context(self.invader_partner)
+        expected = {
+            "partner": self.invader_partner.record_id,
+            "partner_user": self.invader_partner.record_id,
+            "invader_partner": self.invader_partner,
+            "invader_partner_user": self.invader_partner,
+        }
+        self.assertEqual(ctx, expected)
+
+    def test_partner_work_ctx_custom(self):
+        new_invader_partner = self._create_invader_partner(
+            self.env,
+            name="Just A User",
+            email="just@auser.com",
+            parent_id=self.invader_partner.record_id.id,
+        )
+        # Simulate `get_shop_partner` give us another partner eg: the parent
+        with mock.patch.object(
+            type(new_invader_partner.record_id), "get_shop_partner"
+        ) as mocked:
+            mocked.return_value = new_invader_partner.record_id.parent_id
+            ctx = utils.get_partner_work_context(new_invader_partner)
+        expected = {
+            "partner": self.invader_partner.record_id,
+            "partner_user": new_invader_partner.record_id,
+            "invader_partner": self.invader_partner,
+            "invader_partner_user": new_invader_partner,
+        }
+        self.assertEqual(ctx, expected)
+
+    def test_load_partner_work_ctx(self):
+        with utils.work_on_service(
+            self.env, shopinvader_backend=self.backend
+        ) as work:
+            service = work.component(usage="customer")
+            service._load_partner_work_context(self.invader_partner)
+        expected = {
+            "partner": self.invader_partner.record_id,
+            "partner_user": self.invader_partner.record_id,
+            "invader_partner": self.invader_partner,
+            "invader_partner_user": self.invader_partner,
+        }
+        for k, v in expected.items():
+            self.assertEqual(getattr(service, k), v)
+
+    def test_reset_partner_work_ctx(self):
+        with utils.work_on_service(
+            self.env, shopinvader_backend=self.backend
+        ) as work:
+            service = work.component(usage="customer")
+            service._load_partner_work_context(self.invader_partner)
+        service.work.whatever_shall_be_kept = "something"
+        service._reset_partner_work_context()
+        expected = {
+            "partner": self.env["res.partner"].browse(),
+            "partner_user": self.env["res.partner"].browse(),
+            "invader_partner": self.env["shopinvader.partner"].browse(),
+            "invader_partner_user": self.env["shopinvader.partner"].browse(),
+        }
+        for k, v in expected.items():
+            self.assertEqual(getattr(service, k), v)
+
+    def test_work_on_service_with_partner(self):
+        with utils.work_on_service_with_partner(
+            self.env, self.invader_partner
+        ) as work:
+            service = work.component(usage="customer")
+            service._load_partner_work_context(self.invader_partner)
+        expected = {
+            "partner": self.invader_partner.record_id,
+            "partner_user": self.invader_partner.record_id,
+            "invader_partner": self.invader_partner,
+            "invader_partner_user": self.invader_partner,
+        }
+        for k, v in expected.items():
+            self.assertEqual(getattr(service, k), v)

--- a/shopinvader/tests/test_utils.py
+++ b/shopinvader/tests/test_utils.py
@@ -47,9 +47,7 @@ class TestUtils(CommonCase):
         self.assertEqual(ctx, expected)
 
     def test_load_partner_work_ctx(self):
-        with utils.work_on_service(
-            self.env, shopinvader_backend=self.backend
-        ) as work:
+        with utils.work_on_service(self.env, shopinvader_backend=self.backend) as work:
             service = work.component(usage="customer")
             service._load_partner_work_context(self.invader_partner)
         expected = {
@@ -62,9 +60,7 @@ class TestUtils(CommonCase):
             self.assertEqual(getattr(service, k), v)
 
     def test_reset_partner_work_ctx(self):
-        with utils.work_on_service(
-            self.env, shopinvader_backend=self.backend
-        ) as work:
+        with utils.work_on_service(self.env, shopinvader_backend=self.backend) as work:
             service = work.component(usage="customer")
             service._load_partner_work_context(self.invader_partner)
         service.work.whatever_shall_be_kept = "something"
@@ -79,9 +75,7 @@ class TestUtils(CommonCase):
             self.assertEqual(getattr(service, k), v)
 
     def test_work_on_service_with_partner(self):
-        with utils.work_on_service_with_partner(
-            self.env, self.invader_partner
-        ) as work:
+        with utils.work_on_service_with_partner(self.env, self.invader_partner) as work:
             service = work.component(usage="customer")
             service._load_partner_work_context(self.invader_partner)
         expected = {

--- a/shopinvader/utils.py
+++ b/shopinvader/utils.py
@@ -1,0 +1,85 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from contextlib import contextmanager
+
+from odoo.addons.base_rest.controllers.main import _PseudoCollection
+from odoo.addons.component.core import WorkContext
+
+
+def get_partner_work_context(shopinvader_partner):
+    """Retrieve service work context for given shopinvader.partner
+    """
+    ctx = {}
+    ctx["invader_partner"] = shopinvader_partner
+    ctx["invader_partner_user"] = shopinvader_partner
+    # TODO: `partner` and `partner_user` could be abandoned as soon as
+    # all `shopinvader` modules stop relying on `self.partner`.
+    partner_user = shopinvader_partner.record_id
+    ctx["partner_user"] = partner_user
+    # The partner user for the main account or for sale order may differ.
+    partner_shop = partner_user.get_shop_partner(
+        shopinvader_partner.backend_id
+    )
+    ctx["partner"] = partner_shop
+    if partner_shop != partner_user:
+        # Invader partner must represent the same partner as the shop
+        invader_partner_shop = partner_shop._get_invader_partner(
+            shopinvader_partner.backend_id
+        )
+        if invader_partner_shop:
+            ctx["invader_partner"] = invader_partner_shop
+    return ctx
+
+
+def load_partner_work_ctx(service, invader_partner, force=False):
+    """Update work context for given service loading given invader partner ctx."""
+    params = get_partner_work_context(invader_partner)
+    update_work_ctx(service, params, force=force)
+
+
+def reset_partner_work_ctx(service):
+    """Update work context flushing all partner keys."""
+    defaults = {}
+    partner_work_context_defaults(
+        service.env, service.shopinvader_backend, defaults
+    )
+    update_work_ctx(service, defaults, force=True)
+
+
+def update_work_ctx(service, params, force=False):
+    """Update work context for given service."""
+    for k, v in params.items():
+        # The attribute on the service could be None or empty recordset.
+        if force or not getattr(service.work, k, None):
+            setattr(service.work, k, v)
+
+
+def partner_work_context_defaults(env, backend, params):
+    """Inject defaults as these keys are mandatory for work ctx."""
+    if params.get("partner") and not params.get("partner_user"):
+        params["partner_user"] = params["partner"]
+    for k in ("partner", "partner_user"):
+        if not params.get(k):
+            params[k] = env["res.partner"].browse()
+        if not params.get("invader_" + k):
+            params["invader_" + k] = params[k]._get_invader_partner(backend)
+
+
+@contextmanager
+def work_on_service(env, **params):
+    """Work on a shopinvader service."""
+    collection = _PseudoCollection("shopinvader.backend", env)
+    yield WorkContext(
+        model_name="rest.service.registration", collection=collection, **params
+    )
+
+
+@contextmanager
+def work_on_service_with_partner(env, invader_partner, **kw):
+    """Work on a shopinvader service using given shopinvader.partner."""
+    params = get_partner_work_context(invader_partner)
+    params["shopinvader_backend"] = invader_partner.backend_id
+    params.update(kw)
+    with work_on_service(env, **params) as work:
+        yield work

--- a/shopinvader/utils.py
+++ b/shopinvader/utils.py
@@ -8,8 +8,7 @@ from odoo.addons.component.core import WorkContext
 
 
 def get_partner_work_context(shopinvader_partner):
-    """Retrieve service work context for given shopinvader.partner
-    """
+    """Retrieve service work context for given shopinvader.partner"""
     ctx = {}
     ctx["invader_partner"] = shopinvader_partner
     ctx["invader_partner_user"] = shopinvader_partner
@@ -18,9 +17,7 @@ def get_partner_work_context(shopinvader_partner):
     partner_user = shopinvader_partner.record_id
     ctx["partner_user"] = partner_user
     # The partner user for the main account or for sale order may differ.
-    partner_shop = partner_user.get_shop_partner(
-        shopinvader_partner.backend_id
-    )
+    partner_shop = partner_user.get_shop_partner(shopinvader_partner.backend_id)
     ctx["partner"] = partner_shop
     if partner_shop != partner_user:
         # Invader partner must represent the same partner as the shop
@@ -41,9 +38,7 @@ def load_partner_work_ctx(service, invader_partner, force=False):
 def reset_partner_work_ctx(service):
     """Update work context flushing all partner keys."""
     defaults = {}
-    partner_work_context_defaults(
-        service.env, service.shopinvader_backend, defaults
-    )
+    partner_work_context_defaults(service.env, service.shopinvader_backend, defaults)
     update_work_ctx(service, defaults, force=True)
 
 


### PR DESCRIPTION
fwd port of https://github.com/shopinvader/odoo-shopinvader/pull/957

The idea is that there should only one way to init the context.

For instance, now you can use `utils.work_on_service` or `utils.work_on_service_with_partner`.
Services now have a way to load a reload the ctx when needed (eg: sign in).

It also makes refactoring easier.