### PR TITLE
[14.0][ADD] shopinvader_product_template_tags

### DIFF
--- a/setup/shopinvader_product_template_tags/odoo/addons/shopinvader_product_template_tags
+++ b/setup/shopinvader_product_template_tags/odoo/addons/shopinvader_product_template_tags
@@ -1,0 +1,1 @@
+../../../../shopinvader_product_template_tags

--- a/setup/shopinvader_product_template_tags/setup.py
+++ b/setup/shopinvader_product_template_tags/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopinvader_product_template_tags/__manifest__.py
+++ b/shopinvader_product_template_tags/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Camptocamp SA
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Shopvinvader Product Template Tags",
+    "summary": "Index Product Template Tags in Shopinvader",
+    "version": "14.0.1.0.0",
+    "category": "e-Commerce",
+    "website": "https://github.com/shopinvader/odoo-shopinvader",
+    "author": "Camptocamp",
+    "license": "AGPL-3",
+    "depends": ["shopinvader", "product_template_tags"],
+    "data": ["data/ir_export_product.xml"],
+}

--- a/shopinvader_product_template_tags/data/ir_export_product.xml
+++ b/shopinvader_product_template_tags/data/ir_export_product.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Camptocamp (http://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@gmail.com>
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="ir_exp_shopinvader_variant_tags_id" model="ir.exports.line">
+        <field name="name">tag_ids/id</field>
+        <field name="target">tag_ids:tags/id</field>
+        <field name="export_id" ref="shopinvader.ir_exp_shopinvader_variant" />
+    </record>
+
+    <record id="ir_exp_shopinvader_variant_tags_name" model="ir.exports.line">
+        <field name="name">tag_ids/name</field>
+        <field name="target">tag_ids:tags/name</field>
+        <field name="export_id" ref="shopinvader.ir_exp_shopinvader_variant" />
+    </record>
+
+    <record id="ir_exp_shopinvader_variant_tags_sequence" model="ir.exports.line">
+        <field name="name">tag_ids/sequence</field>
+        <field name="target">tag_ids:tags/sequence</field>
+        <field name="export_id" ref="shopinvader.ir_exp_shopinvader_variant" />
+    </record>
+
+</odoo>

--- a/shopinvader_product_template_tags/readme/CONTRIBUTORS.rst
+++ b/shopinvader_product_template_tags/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Iván Todorovich <ivan.todorovich@gmail.com>

--- a/shopinvader_product_template_tags/readme/DESCRIPTION.rst
+++ b/shopinvader_product_template_tags/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+Index Product Template Tags in Shopinvader.
+Tags are defined in OCA module `product_template_tags`


### PR DESCRIPTION
Index Product Template Tags, defined in OCA module `product_template_tags`

Depends on:
- https://github.com/OCA/product-attribute/pull/880