### PR TITLE
[ADD][14.0] shopinvader_product_price_tax

### DIFF
--- a/setup/shopinvader_product_price_tax/odoo/addons/shopinvader_product_price_tax
+++ b/setup/shopinvader_product_price_tax/odoo/addons/shopinvader_product_price_tax
@@ -1,0 +1,1 @@
+../../../../shopinvader_product_price_tax

--- a/setup/shopinvader_product_price_tax/setup.py
+++ b/setup/shopinvader_product_price_tax/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopinvader/models/shopinvader_variant.py
+++ b/shopinvader/models/shopinvader_variant.py
@@ -157,7 +157,7 @@ class ShopinvaderVariant(models.Model):
         default_role = self.backend_id.customer_default_role
         if pricelist:
             res[default_role] = self._get_price(
-                pricelist, None, self.backend_id.company_id
+                pricelist=pricelist, company=self.backend_id.company_id
             )
         return res
 
@@ -176,60 +176,95 @@ class ShopinvaderVariant(models.Model):
                 variant_attributes[sanitized_key] = att_value.name
             record.variant_attributes = variant_attributes
 
-    def _get_price(self, pricelist, fposition, company=None):
-        self.ensure_one()
-        return self._get_price_per_qty(1, pricelist, fposition, company)
+    def _get_price(self, qty=1.0, pricelist=None, fposition=None, company=None):
+        """Computes the product prices
 
-    def _get_price_per_qty(self, qty, pricelist, fposition, company=None):
-        product_id = self.record_id
-        taxes = product_id.taxes_id.sudo().filtered(
-            lambda r: not company or r.company_id == company
+        :param qty:         The product quantity, used to apply pricelist rules.
+        :param pricelist:   Optional. Get prices for a specific pricelist.
+        :param fposition:   Optional. Apply fiscal position to product taxes.
+        :param company:     Optional.
+
+        :returns: dict with the following keys:
+
+            <value>                 The product unitary price
+            <tax_included>          True if product taxes are included in <price>.
+
+            If the pricelist.discount_policy is "without_discount":
+            <original_value>        The original price (before pricelist is applied).
+            <discount>              The discounted percentage.
+        """
+        self.ensure_one()
+        AccountTax = self.env["account.tax"]
+        product = self.record_id
+        # Apply company
+        product = product.with_company(company) if company else product
+        company = company or self.env.company
+        # Always filter taxes by the company
+        taxes = product.taxes_id.filtered(lambda tax: tax.company_id == company)
+        # Apply fiscal position
+        taxes = fposition.map_tax(taxes, product) if fposition else taxes
+        # Set context. Some of the methods used here depend on these values
+        product_context = dict(
+            self.env.context,
+            quantity=qty,
+            pricelist=pricelist.id if pricelist else None,
+            fiscal_position=fposition,
         )
-        # get the expeced tax to apply from the fiscal position
-        tax_id = fposition.map_tax(taxes, product_id) if fposition else taxes
-        tax_id = tax_id and tax_id[0]
-        product = product_id.with_context(
-            quantity=qty, pricelist=pricelist.id, fiscal_position=fposition
-        )
-        final_price, rule_id = pricelist.get_product_price_rule(
-            product, qty or 1.0, None
-        )
-        tax_included = tax_id.price_include
-        account_tax_obj = self.env["account.tax"]
-        # fix tax on the price
-        value = account_tax_obj._fix_tax_included_price_company(
-            final_price, product.taxes_id, tax_id, company
+        product = product.with_context(**product_context)
+        pricelist = pricelist.with_context(**product_context) if pricelist else None
+        # If we have a pricelist, use product.price as it already accounts
+        # for pricelist rules and quantity (in context)
+        price_unit = product.price if pricelist else product.lst_price
+        price_unit = AccountTax._fix_tax_included_price_company(
+            price_unit, product.taxes_id, taxes, company
         )
         res = {
-            "value": value,
-            "tax_included": tax_included,
-            "original_value": value,
+            "value": price_unit,
+            "tax_included": any(tax.price_include for tax in taxes),
+            # Default values in case price.discuont_policy != "without_discount"
+            "original_value": price_unit,
             "discount": 0.0,
         }
-        if pricelist.discount_policy == "without_discount":
-            sol = self.env["sale.order.line"]
-            new_list_price, currency_id = sol._get_real_price_currency(
-                product, rule_id, qty or 1.0, product.uom_id, pricelist.id
+        # Handle pricelists.discount_policy == "without_discount"
+        if pricelist and pricelist.discount_policy == "without_discount":
+            # Get the price rule
+            price_unit, rule_id = pricelist.get_product_price_rule(product, qty, None)
+            # Get the price before applying the pricelist
+            SaleOrderLine = self.env["sale.order.line"].with_context(**product_context)
+            original_price_unit, currency = SaleOrderLine._get_real_price_currency(
+                product, rule_id, qty, product.uom_id, pricelist.id
             )
-            # fix tax on the real price
-            new_list_price = account_tax_obj._fix_tax_included_price_company(
-                new_list_price, product.taxes_id, tax_id, company
-            )
-            product_precision = self.env["decimal.precision"].precision_get(
-                "Product Price"
-            )
-            if (
-                float_compare(new_list_price, value, precision_digits=product_precision)
-                == 0
+            # Convert currency if necessary
+            if original_price_unit != 0 and pricelist.currency_id != currency:
+                original_price_unit = currency._convert(
+                    original_price_unit,
+                    pricelist.currency_id,
+                    company or self.env.company,
+                    fields.Date.today(),
+                )
+            # Compute discount
+            price_dp = self.env["decimal.precision"].precision_get("Product Price")
+            if float_compare(
+                original_price_unit, price_unit, precision_digits=price_dp
             ):
-                # Both prices are equals. Product is wihout discount, avoid
-                # divide by 0 exception
-                return res
-            discount = (new_list_price - value) / new_list_price * 100
-            # apply the right precision on discount
-            dicount_precision = self.env["decimal.precision"].precision_get("Discount")
-            discount = float_round(discount, dicount_precision)
-            res.update({"original_value": new_list_price, "discount": discount})
+                discount = (
+                    (original_price_unit - price_unit) / original_price_unit * 100
+                )
+                # Apply the right precision on discount
+                discount_dp = self.env["decimal.precision"].precision_get("Discount")
+                discount = float_round(discount, discount_dp)
+            else:
+                discount = 0.00
+            # Compute prices
+            original_price_unit = AccountTax._fix_tax_included_price_company(
+                original_price_unit, product.taxes_id, taxes, company
+            )
+            res.update(
+                {
+                    "original_value": original_price_unit,
+                    "discount": discount,
+                }
+            )
         return res
 
     def _compute_main_product(self):

--- a/shopinvader_product_price_tax/__init__.py
+++ b/shopinvader_product_price_tax/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/shopinvader_product_price_tax/__manifest__.py
+++ b/shopinvader_product_price_tax/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Camptocamp SA
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Shopinvader Product Price Tax",
+    "summary": "Exposes product prices with and without taxes",
+    "version": "14.0.1.0.0",
+    "category": "e-commerce",
+    "website": "https://github.com/shopinvader/odoo-shopinvader",
+    "author": "Camptocamp SA",
+    "license": "AGPL-3",
+    "depends": ["shopinvader"],
+}

--- a/shopinvader_product_price_tax/models/__init__.py
+++ b/shopinvader_product_price_tax/models/__init__.py
@@ -1,0 +1,1 @@
+from . import shopinvader_variant

--- a/shopinvader_product_price_tax/models/shopinvader_variant.py
+++ b/shopinvader_product_price_tax/models/shopinvader_variant.py
@@ -1,0 +1,53 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class ShopinvaderVariant(models.Model):
+    _inherit = "shopinvader.variant"
+
+    def _get_price(self, qty=1.0, pricelist=None, fposition=None, company=None):
+        res = super()._get_price(
+            qty=qty, pricelist=pricelist, fposition=fposition, company=company
+        )
+        # Apply company
+        product = self.record_id
+        product = product.with_company(company) if company else product
+        company = company or self.env.company
+        # Always filter taxes by the company
+        taxes = product.taxes_id.filtered(lambda tax: tax.company_id == company)
+        # Apply fiscal position
+        taxes = fposition.map_tax(taxes, product) if fposition else taxes
+        # Compute tax amounts
+        prices = taxes.compute_all(
+            res["value"],
+            product=product,
+            quantity=1.0,  # only use quantity for pricelist rules, not here
+            currency=pricelist.currency_id if pricelist else None,
+        )
+        res.update(
+            {
+                "value_untaxed": prices["total_excluded"],
+                "value_taxed": prices["total_included"],
+                "original_value_untaxed": prices["total_excluded"],
+                "original_value_taxed": prices["total_included"],
+            }
+        )
+        # Handle pricelists.discount_policy == "without_discount"
+        if pricelist and pricelist.discount_policy == "without_discount":
+            # Compute tax amounts
+            prices = taxes.compute_all(
+                res["original_value"],
+                product=product,
+                quantity=1.0,  # only use quantity for pricelist rules, not here
+                currency=pricelist.currency_id if pricelist else None,
+            )
+            res.update(
+                {
+                    "original_value_untaxed": prices["total_excluded"],
+                    "original_value_taxed": prices["total_included"],
+                }
+            )
+        return res

--- a/shopinvader_product_price_tax/readme/CONTRIBUTORS.rst
+++ b/shopinvader_product_price_tax/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Iván Todorovich <ivan.todorovich@gmail.com>

--- a/shopinvader_product_price_tax/readme/DESCRIPTION.rst
+++ b/shopinvader_product_price_tax/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module exposes the product prices with and without tax.

--- a/shopinvader_product_price_tax/tests/__init__.py
+++ b/shopinvader_product_price_tax/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product

--- a/shopinvader_product_price_tax/tests/test_product.py
+++ b/shopinvader_product_price_tax/tests/test_product.py
@@ -1,0 +1,196 @@
+# Copyright 2021 Camptocamp SA
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.shopinvader.tests.common import ProductCommonCase
+
+
+class ProductCase(ProductCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, test_queue_job_no_delay=True))
+        cls.backend = cls.backend.with_context(test_queue_job_no_delay=True)
+
+    def _assertDictContains(self, source, values, msg=None):
+        if msg is None:
+            msg = ""
+        for key, value in values.items():
+            self.assertEqual(source[key], value, f"key='{key}' {msg}")
+
+    def test_product_price(self):
+        self._assertDictContains(
+            self.shopinvader_variant.price["default"],
+            {
+                "value_taxed": 750.0,
+                "value_untaxed": 652.17,
+                "original_value_taxed": 750.0,
+                "original_value_untaxed": 652.17,
+            },
+        )
+
+    def test_product_get_price(self):
+        # self.base_pricelist doesn't define a tax mapping. We are tax included
+        fiscal_position_fr = self.env.ref("shopinvader.fiscal_position_0")
+        price = self.shopinvader_variant._get_price(
+            pricelist=self.base_pricelist, fposition=fiscal_position_fr
+        )
+        self._assertDictContains(
+            price,
+            {
+                "value_taxed": 750.0,
+                "value_untaxed": 652.17,
+                "original_value_taxed": 750.0,
+                "original_value_untaxed": 652.17,
+            },
+        )
+        # promotion price list define a discount of 20% on all product
+        promotion_price_list = self.env.ref("shopinvader.pricelist_1")
+        price = self.shopinvader_variant._get_price(
+            pricelist=promotion_price_list, fposition=fiscal_position_fr
+        )
+        self._assertDictContains(
+            price,
+            {
+                "value_taxed": 600.0,
+                "value_untaxed": 521.74,
+                "original_value_taxed": 600.0,
+                "original_value_untaxed": 521.74,
+            },
+        )
+        # use a fiscal position defining a mapping from tax included to tax
+        # excluded
+        tax_exclude_fiscal_position = self.env.ref("shopinvader.fiscal_position_1")
+        price = self.shopinvader_variant._get_price(
+            pricelist=self.base_pricelist, fposition=tax_exclude_fiscal_position
+        )
+        self._assertDictContains(
+            price,
+            {
+                "value_taxed": 750.0,
+                "value_untaxed": 652.17,
+                "original_value_taxed": 750.0,
+                "original_value_untaxed": 652.17,
+            },
+        )
+        price = self.shopinvader_variant._get_price(
+            pricelist=promotion_price_list, fposition=tax_exclude_fiscal_position
+        )
+        self._assertDictContains(
+            price,
+            {
+                "value_taxed": 600.0,
+                "value_untaxed": 521.74,
+                "original_value_taxed": 600.0,
+                "original_value_untaxed": 521.74,
+            },
+        )
+
+    def test_product_get_price_per_qty(self):
+        # Define a promotion price for the product with min_qty = 10
+        fposition = self.env.ref("shopinvader.fiscal_position_0")
+        pricelist = self.base_pricelist
+        self.env["product.pricelist.item"].create(
+            {
+                "name": "Discount on Product when Qty >= 10",
+                "pricelist_id": pricelist.id,
+                "base": "list_price",
+                "compute_price": "percentage",
+                "percent_price": "20",
+                "applied_on": "0_product_variant",
+                "product_id": self.shopinvader_variant.record_id.id,
+                "min_quantity": 10.0,
+            }
+        )
+        # Case 1 (qty = 1.0). No discount is applied
+        price = self.shopinvader_variant._get_price(
+            qty=1.0, pricelist=pricelist, fposition=fposition
+        )
+        self._assertDictContains(
+            price,
+            {
+                "value_taxed": 750.0,
+                "value_untaxed": 652.17,
+                "original_value_taxed": 750.0,
+                "original_value_untaxed": 652.17,
+            },
+        )
+        # Case 2 (qty = 10.0). Discount is applied
+        # promotion price list define a discount of 20% on all product
+        price = self.shopinvader_variant._get_price(
+            qty=10.0, pricelist=pricelist, fposition=fposition
+        )
+        self._assertDictContains(
+            price,
+            {
+                "value_taxed": 600.0,
+                "value_untaxed": 521.74,
+                "original_value_taxed": 600.0,
+                "original_value_untaxed": 521.74,
+            },
+        )
+
+    def test_product_get_price_discount_policy(self):
+        # Ensure that discount is with 2 digits
+        self.env.ref("product.decimal_discount").digits = 2
+        # self.base_pricelist doesn't define a tax mapping. We are tax included
+        # we modify the discount_policy
+        self.base_pricelist.discount_policy = "without_discount"
+        fiscal_position_fr = self.env.ref("shopinvader.fiscal_position_0")
+        price = self.shopinvader_variant._get_price(
+            pricelist=self.base_pricelist, fposition=fiscal_position_fr
+        )
+        self._assertDictContains(
+            price,
+            {
+                "value_taxed": 750.0,
+                "value_untaxed": 652.17,
+                "original_value_taxed": 750.0,
+                "original_value_untaxed": 652.17,
+            },
+        )
+        # promotion price list define a discount of 20% on all product
+        # we modify the discount_policy
+        promotion_price_list = self.env.ref("shopinvader.pricelist_1")
+        promotion_price_list.discount_policy = "without_discount"
+        price = self.shopinvader_variant._get_price(
+            pricelist=promotion_price_list, fposition=fiscal_position_fr
+        )
+        self._assertDictContains(
+            price,
+            {
+                "value_taxed": 600.0,
+                "value_untaxed": 521.74,
+                "original_value_taxed": 750.0,
+                "original_value_untaxed": 652.17,
+            },
+        )
+        # use the fiscal position defining a mapping from tax included to tax
+        # excluded
+        # Tax mapping should not impact the computation of the discount and
+        # the original value
+        tax_exclude_fiscal_position = self.env.ref("shopinvader.fiscal_position_1")
+        price = self.shopinvader_variant._get_price(
+            pricelist=self.base_pricelist, fposition=tax_exclude_fiscal_position
+        )
+        self._assertDictContains(
+            price,
+            {
+                "value_taxed": 750.0,
+                "value_untaxed": 652.17,
+                "original_value_taxed": 750.0,
+                "original_value_untaxed": 652.17,
+            },
+        )
+        price = self.shopinvader_variant._get_price(
+            pricelist=promotion_price_list, fposition=tax_exclude_fiscal_position
+        )
+        self._assertDictContains(
+            price,
+            {
+                "value_taxed": 600.0,
+                "value_untaxed": 521.74,
+                "original_value_taxed": 750.0,
+                "original_value_untaxed": 652.17,
+            },
+        )

--- a/shopinvader_sale_profile/models/shopinvader_variant.py
+++ b/shopinvader_sale_profile/models/shopinvader_variant.py
@@ -18,9 +18,9 @@ class ShopinvaderVariant(models.Model):
         for sale_profile in self.backend_id.sale_profile_ids:
             fposition = first(sale_profile.fiscal_position_ids)
             price = self._get_price(
-                sale_profile.pricelist_id,
-                fposition,
-                self.backend_id.company_id,
+                pricelist=sale_profile.pricelist_id,
+                fposition=fposition,
+                company=self.backend_id.company_id,
             )
             res.update({sale_profile.code: price})
         return res


### PR DESCRIPTION
**1st commit - Refactor `_get_price` in `shopinvader`.**

* Handle multiple taxes in product, not just the first.
* Correctly set the company (with_company).
* Convert currency, if necessary, when computing pricelist discount.
* ~Rename returned keys from *value to *price.~
* Use keyword arguments and merge with `_get_price_per_qty`.
* Rename some variables and comment things out - readability improvement.
* Add test cases for pricelist rules

Tried to be as explicit as possible in the comments, hopefully now it's easier to understand.

~Note that I renamed *value to *price, while keeping backwards compatibility. It's a small change and I get it's not really necessary but IMO it makes more sense to call things by its name. (value is subjective, price isn't)~

---

**2nd commit - New module to expose tax and untaxed prices to shopinvader**

