### PR TITLE
[14.0][ADD] shopinvader_customer_invoicing_mode

### DIFF
--- a/setup/shopinvader_customer_invoicing_mode/odoo/addons/shopinvader_customer_invoicing_mode
+++ b/setup/shopinvader_customer_invoicing_mode/odoo/addons/shopinvader_customer_invoicing_mode
@@ -1,0 +1,1 @@
+../../../../shopinvader_customer_invoicing_mode

--- a/setup/shopinvader_customer_invoicing_mode/setup.py
+++ b/setup/shopinvader_customer_invoicing_mode/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopinvader_customer_invoicing_mode/__init__.py
+++ b/shopinvader_customer_invoicing_mode/__init__.py
@@ -1,0 +1,1 @@
+from . import services

--- a/shopinvader_customer_invoicing_mode/__manifest__.py
+++ b/shopinvader_customer_invoicing_mode/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Camptocamp SA
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Shopinvader Customer Invoicing Mode",
+    "summary": "Glue module to expose the invoicing_mode field to shopinvader",
+    "version": "14.0.1.0.0",
+    "category": "e-commerce",
+    "website": "https://github.com/shopinvader/odoo-shopinvader",
+    "author": "Camptocamp",
+    "license": "AGPL-3",
+    "depends": ["shopinvader", "account_invoice_base_invoicing_mode"],
+}

--- a/shopinvader_customer_invoicing_mode/readme/CONTRIBUTORS.rst
+++ b/shopinvader_customer_invoicing_mode/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Iván Todorovich <ivan.todorovich@gmail.com>

--- a/shopinvader_customer_invoicing_mode/readme/DESCRIPTION.rst
+++ b/shopinvader_customer_invoicing_mode/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module exposes the `invoicing_mode` field added by OCA module
+`account_invoice_base_invoicing_mode` to the customer service.

--- a/shopinvader_customer_invoicing_mode/services/__init__.py
+++ b/shopinvader_customer_invoicing_mode/services/__init__.py
@@ -1,0 +1,1 @@
+from . import customer

--- a/shopinvader_customer_invoicing_mode/services/customer.py
+++ b/shopinvader_customer_invoicing_mode/services/customer.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Camptocamp SA
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.component.core import Component
+
+
+class CustomerService(Component):
+    _inherit = "shopinvader.customer.service"
+
+    def _validator_create(self):
+        res = super()._validator_create()
+        res.update(
+            {
+                "invoicing_mode": {"type": "string", "required": False},
+            }
+        )
+        return res
+
+    def _json_parser(self):
+        res = super()._json_parser()
+        res.append("invoicing_mode")
+        return res

--- a/shopinvader_customer_invoicing_mode/tests/__init__.py
+++ b/shopinvader_customer_invoicing_mode/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_customer

--- a/shopinvader_customer_invoicing_mode/tests/test_customer.py
+++ b/shopinvader_customer_invoicing_mode/tests/test_customer.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Camptocamp SA
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.shopinvader.tests.test_customer import TestCustomerCommon
+
+
+class TestCustomer(TestCustomerCommon):
+    def setUp(self, *args, **kwargs):
+        super().setUp(*args, **kwargs)
+        # TODO: Move to setUpClass in shopinvader's TestCustomerCommon.
+        self.data["invoicing_mode"] = "standard"
+
+    def test_create_customer(self):
+        self.data["external_id"] = "D5CdkqOEL"
+        res = self.service.dispatch("create", params=self.data)["data"]
+        partner = self.env["res.partner"].browse(res["id"])
+        self._test_partner_data(partner, self.data)


### PR DESCRIPTION
This module exposes to the customer service the `invoicing_mode` field added by OCA module `account_invoice_base_invoicing_mode` .

Depends on:
- https://github.com/OCA/account-invoicing/pull/844

:warning: **Do not merge until dependency's merged and test-requirement removed** :warning: 