### PR TITLE
[14.0][IMP] shopinvader_customer_multi_user : Address sharing policy

### DIFF
--- a/shopinvader_customer_multi_user/models/res_partner.py
+++ b/shopinvader_customer_multi_user/models/res_partner.py
@@ -29,6 +29,17 @@ class ResPartner(models.Model):
         compute="_compute_has_invader_user",
         help="At least one backend has an invader user for this partner.",
     )
+    invader_address_share_policy = fields.Selection(
+        [
+            ("public", "Public"),
+            ("private", "Private"),
+        ],
+        string="Shop Address Share Policy",
+        help="In a multi user environment, controls who can view this address\n\n"
+        "* `Public`: Shared among all company's users.\n"
+        "* `Private`: Only the user who created it and company's admin users.\n",
+        default="public",
+    )
 
     _sql_constraints = [
         (

--- a/shopinvader_customer_multi_user/services/address.py
+++ b/shopinvader_customer_multi_user/services/address.py
@@ -37,3 +37,32 @@ class AddressService(Component):
             self.invader_partner_user._make_address_domain(),
         ]
         return expression.AND(domains)
+
+    def _get_allowed_share_policy_values(self):
+        field = self.env["res.partner"]._fields["invader_address_share_policy"]
+        return [x[0] for x in field.selection]
+
+    def _validator_create(self):
+        res = super()._validator_create()
+        res.update(
+            {
+                "share_policy": {
+                    "type": "string",
+                    "required": False,
+                    "empty": False,
+                    "allowed": self._get_allowed_share_policy_values(),
+                }
+            }
+        )
+        return res
+
+    def _json_parser(self):
+        res = super()._json_parser()
+        res.append("invader_address_share_policy:share_policy")
+        return res
+
+    def _prepare_params(self, params, mode="create"):
+        res = super()._prepare_params(params, mode=mode)
+        if res.get("share_policy"):
+            res["invader_address_share_policy"] = res.pop("share_policy")
+        return res

--- a/shopinvader_customer_multi_user/services/customer.py
+++ b/shopinvader_customer_multi_user/services/customer.py
@@ -9,7 +9,7 @@ class CustomerService(Component):
     _inherit = "shopinvader.customer.service"
 
     def _prepare_params(self, params, mode="create"):
-        vals = super()._prepare_params(params)
+        vals = super()._prepare_params(params, mode=mode)
         company_token = vals.pop("company_token", None)
         if company_token and self.shopinvader_backend.customer_multi_user:
             # retrieve the company

--- a/shopinvader_customer_multi_user/views/partner_view.xml
+++ b/shopinvader_customer_multi_user/views/partner_view.xml
@@ -20,6 +20,11 @@
                         string="Re-generate token"
                         attrs="{'invisible': [('invader_user_token','=',False)]}"
                     />
+          <field
+                        name="invader_address_share_policy"
+                        options="{'horizontal': True}"
+                        attrs="{'invisible': [('address_type', '!=', 'address')]}"
+                    />
         </group>
       </field>
       <xpath


### PR DESCRIPTION
This PR introduces an address sharing policy for addresses within a company, in a multi-user environment.
With it, users can choose to share (or not) invoicing and delivery addresses with their collaborators.
