### PR TITLE
[14.0][ADD] shopinvader_customer_multi_user_company_group

### DIFF
--- a/setup/shopinvader_customer_multi_user_company_group/odoo/addons/shopinvader_customer_multi_user_company_group
+++ b/setup/shopinvader_customer_multi_user_company_group/odoo/addons/shopinvader_customer_multi_user_company_group
@@ -1,0 +1,1 @@
+../../../../shopinvader_customer_multi_user_company_group

--- a/setup/shopinvader_customer_multi_user_company_group/setup.py
+++ b/setup/shopinvader_customer_multi_user_company_group/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopinvader_customer_multi_user_company_group/__init__.py
+++ b/shopinvader_customer_multi_user_company_group/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/shopinvader_customer_multi_user_company_group/__manifest__.py
+++ b/shopinvader_customer_multi_user_company_group/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Shopinvader Customer Multi User Company Group",
+    "summary": "Share shopinvader records within the Company Group",
+    "version": "14.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "Camptocamp SA",
+    "website": "https://github.com/shopinvader/odoo-shopinvader",
+    "depends": ["shopinvader_customer_multi_user", "partner_company_group"],
+    "data": ["views/shopinvader_partner.xml"],
+}

--- a/shopinvader_customer_multi_user_company_group/models/__init__.py
+++ b/shopinvader_customer_multi_user_company_group/models/__init__.py
@@ -1,0 +1,1 @@
+from . import shopinvader_partner

--- a/shopinvader_customer_multi_user_company_group/models/shopinvader_partner.py
+++ b/shopinvader_customer_multi_user_company_group/models/shopinvader_partner.py
@@ -1,0 +1,82 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+from odoo.osv import expression
+
+
+class ShopinvaderPartner(models.Model):
+    _inherit = "shopinvader.partner"
+
+    is_company_group_user = fields.Boolean(
+        compute="_compute_is_company_group_user",
+        help="If true, means the partner belongs to the main company group",
+    )
+
+    @api.depends("company_group_id", "main_partner_id")
+    def _compute_is_company_group_user(self):
+        for rec in self:
+            rec.is_company_group_user = (
+                rec.main_partner_id == rec.company_group_id or not rec.company_group_id
+            )
+
+    def _make_partner_domain(self, partner_field, operator="="):
+        res = super()._make_partner_domain(partner_field, operator=operator)
+        if not self.is_company_group_user:
+            return res
+        # The hierarchy when dealing with company_groups is trickier as company_group
+        # is not really a part of the parent_id / child_ids hierarchy.
+        # More often than not, the company group partner won't have a company_group_id
+        # set itself. One would expect a circular reference to itself there, so:
+        company_group = self.company_group_id or self.commercial_partner_id
+        domain_field = (
+            f"{partner_field}.company_group_id"
+            if partner_field != "id"
+            else "company_group_id"
+        )
+        # Main users can always see everything down their hierarchy and companies
+        # belonging to the group hierarchy.
+        if self.is_admin_account or self.is_main_account:
+            return expression.OR(
+                [
+                    res,
+                    [(domain_field, "child_of", company_group.id)],
+                ]
+            )
+        # If we are logged as or in the company group itself, we can see all the
+        # public records down our group member's hierarchies.
+        return expression.OR(
+            [
+                res,
+                [(domain_field, operator, company_group.id)],
+            ]
+        )
+
+    def _make_address_domain(self):
+        res = super()._make_address_domain()
+        if not self.is_company_group_user:
+            return res
+        # The hierarchy when dealing with company_groups is trickier as company_group
+        # is not really a part of the parent_id / child_ids hierarchy.
+        # More often than not, the company group partner won't have a company_group_id
+        # set itself. One would expect a circular reference to itself there, so:
+        company_group = self.company_group_id or self.commercial_partner_id
+        # Main users can always see everything down their hierarchy and companies
+        # belonging to the group hierarchy.
+        if self.is_admin_account or self.is_main_account:
+            return expression.OR(
+                [res, [("company_group_id", "child_of", company_group.id)]]
+            )
+        # If we are logged as or in the company group itself, we can see all the
+        # public records down our group member's hierarchies.
+        return expression.OR(
+            [
+                res,
+                [
+                    ("company_group_id", "child_of", company_group.id),
+                    ("shopinvader_bind_ids", "=", False),
+                    ("invader_address_share_policy", "=", "public"),
+                ],
+            ]
+        )

--- a/shopinvader_customer_multi_user_company_group/readme/CONTRIBUTORS.rst
+++ b/shopinvader_customer_multi_user_company_group/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+  * Iván Todorovich <ivan.todorovich@gmail.com>

--- a/shopinvader_customer_multi_user_company_group/readme/DESCRIPTION.rst
+++ b/shopinvader_customer_multi_user_company_group/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+Allows setting backend policies to share records among the company group
+introduced by OCA module `partner_company_group`.

--- a/shopinvader_customer_multi_user_company_group/tests/__init__.py
+++ b/shopinvader_customer_multi_user_company_group/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_multi_user_service_partner_domain

--- a/shopinvader_customer_multi_user_company_group/tests/test_multi_user_service_partner_domain.py
+++ b/shopinvader_customer_multi_user_company_group/tests/test_multi_user_service_partner_domain.py
@@ -1,0 +1,309 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.shopinvader.tests.test_customer import TestCustomerCommon
+
+
+class TestMultiUserServicePartnerDomain(TestCustomerCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Enable multi-user
+        cls.backend.customer_multi_user = True
+        # Create companies
+        cls.company_group_binding = cls._create_partner(
+            cls.env,
+            name="Company Group",
+            external_id="company-group",
+            email="info@company-group.org",
+            is_company=True,
+        )
+        cls.company_a_binding = cls._create_partner(
+            cls.env,
+            name="Company A",
+            external_id="company-a",
+            email="info@company-a.org",
+            invader_user_token="COMPANY_A_TOKEN",
+            company_group_id=cls.company_group_binding.record_id.id,
+            is_company=True,
+        )
+        cls.company_b_binding = cls._create_partner(
+            cls.env,
+            name="Company B",
+            external_id="company-b",
+            email="info@company-b.org",
+            invader_user_token="COMPANY_B_TOKEN",
+            company_group_id=cls.company_group_binding.record_id.id,
+            is_company=True,
+        )
+        # Create users
+        cls.user_g_binding = cls._create_partner(
+            cls.env,
+            name="User G",
+            external_id="user-g",
+            email="user-g@company-group.org",
+            parent_id=cls.company_group_binding.record_id.id,
+        )
+        cls.user_a_binding = cls._create_partner(
+            cls.env,
+            name="User A",
+            external_id="user-a",
+            email="user-a@company-a.org",
+            parent_id=cls.company_a_binding.record_id.id,
+        )
+        cls.user_b_binding = cls._create_partner(
+            cls.env,
+            name="User B",
+            external_id="user-b",
+            email="user-b@company-b.org",
+            parent_id=cls.company_b_binding.record_id.id,
+        )
+        cls.company_group = cls.company_group_binding.record_id
+        cls.company_a = cls.company_a_binding.record_id
+        cls.company_b = cls.company_b_binding.record_id
+        cls.user_g = cls.user_g_binding.record_id
+        cls.user_a = cls.user_a_binding.record_id
+        cls.user_b = cls.user_b_binding.record_id
+        # Some quick recordset accessors
+        cls.all_companies = cls.company_group + cls.company_a + cls.company_b
+        cls.all_users = cls.user_g + cls.user_a + cls.user_b
+        cls.all_partners = cls.all_companies + cls.all_users
+        # Create Sale Orders per each user
+        # For maintenance reasons, loop and setattr on the fly
+        cls.all_sales = cls.env["sale.order"]
+        base_sale_order = cls.env.ref("shopinvader.sale_order_2")
+        for partner in cls.all_users:
+            partner_key = partner.name.lower().replace(" ", "_")
+            sale = base_sale_order.copy({"partner_id": partner.id})
+            setattr(cls, f"sale_{partner_key}", sale)
+            cls.all_sales |= sale
+        # Create invoices per each order
+        cls.all_invoices = cls.env["account.move"]
+        for sale in cls.all_sales:
+            sale.action_confirm()
+            for line in sale.order_line:
+                line.write({"qty_delivered": line.product_uom_qty})
+            cls.all_invoices |= sale._create_invoices()
+        # Create public and private addresses for each user
+        # For maintenance reasons, loop and setattr on the fly
+        ResPartner = cls.env["res.partner"]
+        cls.all_public_addresses = cls.env["res.partner"]
+        cls.all_private_addresses = cls.env["res.partner"]
+        for partner in cls.all_partners:
+            partner_key = partner.name.lower().replace(" ", "_")
+            public_address = ResPartner.create(
+                {
+                    "name": f"Delivery Address {partner.name} (Public)",
+                    "parent_id": partner.id,
+                    "type": "delivery",
+                    "invader_address_share_policy": "public",
+                }
+            )
+            private_address = ResPartner.create(
+                {
+                    "name": f"Delivery Address {partner.name} (Private)",
+                    "parent_id": partner.id,
+                    "type": "delivery",
+                    "invader_address_share_policy": "private",
+                }
+            )
+            setattr(cls, f"address_{partner_key}_public", public_address)
+            setattr(cls, f"address_{partner_key}_private", private_address)
+            cls.all_public_addresses |= public_address
+            cls.all_private_addresses |= private_address
+        cls.all_addresses = cls.all_public_addresses + cls.all_private_addresses
+
+    @staticmethod
+    def _create_partner(env, **kw):
+        values = {
+            "backend_id": env.ref("shopinvader.backend_1").id,
+            "name": "ACME ltd",
+            "external_id": "acme",
+            "email": "company@test.com",
+            "ref": "#ACME",
+        }
+        values.update(kw)
+        return env["shopinvader.partner"].create(values)
+
+    @staticmethod
+    def _get_partner_expected_versus_found_message(
+        partner, expected, found, mapper=None
+    ):
+        if mapper is None:
+
+            def mapper(x):
+                return "%s (%d)" % (x.name, x.id)
+
+        return """
+            For partner:
+                {partner}
+            Expected:
+                {expected}
+            Found:
+                {found}
+            """.format(
+            partner=partner.name,
+            expected=("\n" + " " * 16).join(expected.mapped(mapper)),
+            found=("\n" + " " * 16).join(found.mapped(mapper)),
+        )
+
+    def _get_service(self, partner, usage):
+        with self.work_on_services(
+            partner=partner.get_shop_partner(self.backend),
+            partner_user=partner,
+            shopinvader_session=self.shopinvader_session,
+        ) as work:
+            return work.component(usage=usage)
+
+    # Test Helpers
+
+    def _test_address(self, partner, expected):
+        service = self._get_service(partner, "addresses")
+        res = service.search(per_page=100)
+        res_ids = [x["id"] for x in res["data"]]
+        found = self.env[expected._name].browse(res_ids).sorted(key="id")
+        expected = expected.sorted(key="id")
+        self.assertEqual(
+            found.ids,
+            expected.ids,
+            self._get_partner_expected_versus_found_message(partner, expected, found),
+        )
+
+    def _test_sale(self, partner, expected):
+        service = self._get_service(partner, "sales")
+        res = service.search()
+        res_ids = [x["id"] for x in res["data"]]
+        found = self.env[expected._name].browse(res_ids).sorted(key="id")
+        expected = expected.sorted(key="id")
+        self.assertEqual(
+            found.ids,
+            expected.ids,
+            self._get_partner_expected_versus_found_message(
+                partner,
+                expected,
+                found,
+                mapper=lambda x: "%s (%d) :: %s (%d)"
+                % (x.name, x.id, x.partner_id.name, x.partner_id.id),
+            ),
+        )
+
+    def _test_invoice(self, partner, expected):
+        service = self._get_service(partner, "invoice")
+        found = service._get_available_invoices().sorted(key="id")
+        expected = expected.sorted(key="id")
+        self.assertEqual(
+            found.ids,
+            expected.ids,
+            self._get_partner_expected_versus_found_message(
+                partner,
+                expected,
+                found,
+                mapper=lambda x: "%s (%d) :: %s (%d)"
+                % (x.name, x.id, x.partner_id.name, x.partner_id.id),
+            ),
+        )
+
+    # Tests
+
+    def test_company_group_level(self):
+        """The company group sees all"""
+        # Case 1: The company group itself
+        partner = self.company_group
+        self._test_address(partner, self.all_partners + self.all_addresses)
+        self._test_sale(partner, self.all_sales)
+        self._test_invoice(partner, self.all_invoices)
+        # Case 2: The company group user, same but only public addresses
+        partner = self.user_g
+        self._test_address(
+            partner,
+            (
+                self.user_g
+                | self.company_group
+                | self.all_public_addresses
+                | self.address_user_g_private
+            ),
+        )
+        self._test_sale(partner, self.all_sales)
+        self._test_invoice(partner, self.all_invoices)
+
+    def test_company_level(self):
+        """The company sees only its own records"""
+        # Case 1: Company A
+        partner = self.company_a
+        self._test_address(
+            partner,
+            (
+                partner
+                | self.user_a
+                | self.address_user_a_public
+                | self.address_user_a_private
+                | self.address_company_a_public
+                | self.address_company_a_private
+            ),
+        )
+        sales = self.sale_user_a
+        self._test_sale(partner, sales)
+        self._test_invoice(partner, sales.mapped("invoice_ids"))
+        # Case 2: Same but without admin user
+        partner = self.user_a
+        self._test_address(
+            partner,
+            (
+                partner
+                | self.company_a
+                | self.address_user_a_public
+                | self.address_user_a_private
+                | self.address_company_a_public
+            ),
+        )
+        sales = self.sale_user_a
+        self._test_sale(partner, sales)
+        self._test_invoice(partner, sales.mapped("invoice_ids"))
+
+    def test_company_level_with_child(self):
+        """The company sees only its own records and its childs records"""
+        self.company_b.parent_id = self.company_a
+        # Case 1: Company A
+        partner = self.company_a
+        self._test_address(
+            partner,
+            (
+                # Sees company A
+                self.company_a
+                | self.user_a
+                | self.address_user_a_public
+                | self.address_user_a_private
+                | self.address_company_a_public
+                | self.address_company_a_private
+                # And company B
+                | self.company_b
+                | self.user_b
+                | self.address_user_b_public
+                | self.address_user_b_private
+                | self.address_company_b_public
+                | self.address_company_b_private
+            ),
+        )
+        sales = self.sale_user_a | self.sale_user_b
+        self._test_sale(partner, sales)
+        self._test_invoice(partner, sales.mapped("invoice_ids"))
+        # Case 2: Same but without admin user
+        partner = self.user_a
+        self._test_address(
+            partner,
+            (
+                # Sees company A
+                self.company_a
+                | self.user_a
+                | self.address_user_a_public
+                | self.address_user_a_private
+                | self.address_company_a_public
+                # And company B
+                | self.address_user_b_public
+                | self.address_company_b_public
+            ),
+        )
+        sales = self.sale_user_a
+        self._test_sale(partner, sales)
+        self._test_invoice(partner, sales.mapped("invoice_ids"))

--- a/shopinvader_customer_multi_user_company_group/views/shopinvader_partner.xml
+++ b/shopinvader_customer_multi_user_company_group/views/shopinvader_partner.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright 2021 Camptocamp (http://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@gmail.com>
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="shopinvader_partner_view_form" model="ir.ui.view">
+        <field name="model">shopinvader.partner</field>
+        <field
+            name="inherit_id"
+            ref="shopinvader_customer_multi_user.shopinvader_partner_view_form"
+        />
+        <field name="arch" type="xml">
+            <field name="main_partner_id" position="after">
+                <field name="company_group_id" />
+            </field>
+        </field>
+    </record>
+
+    <record id="shopinvader_partner_view_tree" model="ir.ui.view">
+        <field name="model">shopinvader.partner</field>
+        <field
+            name="inherit_id"
+            ref="shopinvader_customer_multi_user.shopinvader_partner_view_tree"
+        />
+        <field name="arch" type="xml">
+            <field name="main_partner_id" position="after">
+                <field name="company_group_id" />
+            </field>
+        </field>
+    </record>
+
+    <record id="shopinvader_partner_view_search" model="ir.ui.view">
+        <field name="model">shopinvader.partner</field>
+        <field
+            name="inherit_id"
+            ref="shopinvader_customer_multi_user.shopinvader_partner_view_search"
+        />
+        <field name="arch" type="xml">
+            <field name="main_partner_id" position="after">
+                <field name="company_group_id" />
+            </field>
+            <filter name="group_by_main_partner_id" position="after">
+                <filter
+                    name="group_by_company_group_id"
+                    string="Company Group"
+                    domain="[]"
+                    context="{'group_by': 'company_group_id'}"
+                />
+            </filter>
+          </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This module allows to share records among the company group introduced by OCA module `partner_company_group`.

Depends (and includes):
- [x] https://github.com/shopinvader/odoo-shopinvader/pull/1038

Review only the last commit