### PR TITLE
[14.0] [FIX] shopinvader_auth_api_key: Fix openapi doc generation

### DIFF
--- a/shopinvader_auth_api_key/services/service.py
+++ b/shopinvader_auth_api_key/services/service.py
@@ -19,3 +19,4 @@ class BaseShopinvaderService(AbstractComponent):
                 "style": "simple",
             }
         )
+        return defaults


### PR DESCRIPTION
_get_openapi_default_parameters method must return values...

fixes #1050