### PR TITLE
s_sale_packaging: add flag to control visibility

### DIFF
--- a/shopinvader_sale_packaging/__manifest__.py
+++ b/shopinvader_sale_packaging/__manifest__.py
@@ -16,5 +16,9 @@
         "sale_by_packaging",
         "stock_packaging_calculator_packaging_type",
     ],
-    "data": ["data/ir_export_product.xml"],
+    "data": [
+        "data/ir_export_product.xml",
+        "views/product_packaging.xml",
+        "views/product_packaging_type.xml",
+    ],
 }

--- a/shopinvader_sale_packaging/models/__init__.py
+++ b/shopinvader_sale_packaging/models/__init__.py
@@ -1,1 +1,3 @@
 from . import shopinvader_variant
+from . import product_packaging
+from . import product_packaging_type

--- a/shopinvader_sale_packaging/models/product_packaging.py
+++ b/shopinvader_sale_packaging/models/product_packaging.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com).
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, fields, models
+
+
+class ProductPackaging(models.Model):
+
+    _inherit = "product.packaging"
+
+    shopinvader_display = fields.Boolean(
+        compute="_compute_shopinvader_display",
+        readonly=False,
+        store=True,
+        help="Include this packaging into Shopinvader product metadata.",
+    )
+
+    @api.depends("packaging_type_id.shopinvader_display")
+    def _compute_shopinvader_display(self):
+        for record in self:
+            record.shopinvader_display = (
+                record.packaging_type_id.shopinvader_display
+            )

--- a/shopinvader_sale_packaging/models/product_packaging_type.py
+++ b/shopinvader_sale_packaging/models/product_packaging_type.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com).
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ProductPackagingType(models.Model):
+    _inherit = "product.packaging.type"
+
+    shopinvader_display = fields.Boolean(
+        help="Include this packaging into Shopinvader product metadata.",
+        default=True,
+    )

--- a/shopinvader_sale_packaging/models/shopinvader_variant.py
+++ b/shopinvader_sale_packaging/models/shopinvader_variant.py
@@ -24,29 +24,38 @@ class ShopinvaderVariant(models.Model):
     def _compute_packaging_depends(self):
         return (
             "lang_id",
+            "record_id.sell_only_by_packaging",
             "record_id.packaging_ids.qty",
             "record_id.packaging_ids.can_be_sold",
+            "record_id.packaging_ids.shopinvader_display",
             "record_id.packaging_ids.barcode",
             "record_id.packaging_ids.packaging_type_id.name",
         )
 
     def _get_variant_packaging(self):
         res = []
-        ctx = self._get_variant_packaging_ctx()
+        ctx = self._get_variant_packaging_ctx(self.backend_id)
         rec = self.record_id.with_context(ctx)
         contained_mapping = rec.packaging_contained_mapping or {}
         packaging = rec._ordered_packaging()
+        can_be_sold_info = {
+            x["id"]: x["can_be_sold"]
+            for x in self.packaging_ids.read(["can_be_sold"])
+        }
         for pkg in packaging:
             pkg_info = self._prepare_qty_by_packaging_values(pkg, pkg.qty)
             pkg_info["contained"] = contained_mapping.get(str(pkg.id))
+            pkg_info["can_be_sold"] = can_be_sold_info.get(pkg.id, False)
+            if pkg.is_unit:
+                pkg_info["can_be_sold"] = not self.sell_only_by_packaging
             res.append(pkg_info)
         return res
 
-    def _get_variant_packaging_ctx(self):
+    def _get_variant_packaging_ctx(self, backend):
         return {
             "lang": self.lang_id.code,
-            # consider only packaging that can be sold
-            "_packaging_filter": lambda x: x.can_be_sold,
+            # consider only packaging that can be displayed
+            "_packaging_filter": lambda x: x.shopinvader_display,
             "_packaging_values_handler": self._prepare_qty_by_packaging_values,
         }
 

--- a/shopinvader_sale_packaging/views/product_packaging.xml
+++ b/shopinvader_sale_packaging/views/product_packaging.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="product_packaging_tree_view_inherit" model="ir.ui.view">
+        <field name="model">product.packaging</field>
+        <field name="inherit_id" ref="sale_by_packaging.product_packaging_tree_view_inherit" />
+        <field name="groups_id" eval="[(4, ref('shopinvader.group_shopinvader_manager'))]"/>
+        <field name="arch" type="xml">
+            <field name="force_sale_qty" position="after">
+                <field name="shopinvader_display" />
+            </field>
+        </field>
+    </record>
+    <record id="product_packaging_form_view_inherit" model="ir.ui.view">
+        <field name="model">product.packaging</field>
+        <field name="inherit_id" ref="sale_by_packaging.product_packaging_form_view_inherit" />
+        <field name="groups_id" eval="[(4, ref('shopinvader.group_shopinvader_manager'))]"/>
+        <field name="arch" type="xml">
+            <field name="force_sale_qty" position="after">
+                <field name="shopinvader_display" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/shopinvader_sale_packaging/views/product_packaging_type.xml
+++ b/shopinvader_sale_packaging/views/product_packaging_type.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_product_packaging_type_form" model="ir.ui.view">
+        <field name="model">product.packaging.type</field>
+        <field
+            name="inherit_id"
+            ref="sale_by_packaging.view_product_packaging_type_form"
+        />
+        <field name="arch" type="xml">
+            <field name="can_be_sold" position="after">
+                <field name="shopinvader_display" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Allow to display packaging that cannot be sold
by taking explicit control on which records get published on the site.