### PR TITLE
[14.0][FIX] shopinvader: Multi-company rules

### DIFF
--- a/shopinvader/migrations/14.0.4.1.0/post-migrate.py
+++ b/shopinvader/migrations/14.0.4.1.0/post-migrate.py
@@ -1,0 +1,40 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import SUPERUSER_ID, api
+
+
+def _fix_multicompany_ir_rules(env):
+    """Fix Multi-Company ir.rules
+
+    These rules are set as noupdate=1, but they weren't migrated properly
+    as they don't account for multiple companies set in context.
+    """
+    refs = [
+        "shopinvader_backend_comp_rule",
+        "shopinvader_category_comp_rule",
+        "shopinvader_partner_comp_rule",
+        "shopinvader_product_comp_rule",
+        "shopinvader_variant_comp_rule",
+    ]
+    for ref in refs:
+        xmlid = "shopinvader.{}".format(ref)
+        rule = env.ref(xmlid, raise_if_not_found=False)
+        if not rule:
+            continue
+        rule.domain_force = """
+            [
+                '|',
+                ('company_id', '=', False),
+                ('company_id', 'in', company_ids),
+            ]
+        """
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        _fix_multicompany_ir_rules(env)

--- a/shopinvader/models/shopinvader_binding.py
+++ b/shopinvader/models/shopinvader_binding.py
@@ -10,6 +10,7 @@ class ShopinvaderBinding(models.AbstractModel):
     _description = "Shopinvader Binding"
 
     backend_id = fields.Many2one("shopinvader.backend", string="Backend", required=True)
+    company_id = fields.Many2one(related="backend_id.company_id", store=True)
     external_id = fields.Char(string="External ID")
     sync_date = fields.Datetime(string="Last synchronization date")
     redirect_url_key = fields.Serialized(

--- a/shopinvader/models/shopinvader_category.py
+++ b/shopinvader/models/shopinvader_category.py
@@ -20,7 +20,10 @@ class ShopinvaderCategory(models.Model):
     _order = "sequence"
 
     record_id = fields.Many2one(
-        "product.category", required=True, ondelete="cascade", index=True
+        "product.category",
+        required=True,
+        ondelete="cascade",
+        index=True,
     )
     sequence = fields.Integer()
     meta_description = fields.Char()

--- a/shopinvader/models/shopinvader_partner.py
+++ b/shopinvader/models/shopinvader_partner.py
@@ -13,9 +13,14 @@ class ShopinvaderPartner(models.Model):
     _description = "Shopinvader Partner"
     _inherit = "shopinvader.binding"
     _inherits = {"res.partner": "record_id"}
+    _check_company_auto = True
 
     record_id = fields.Many2one(
-        "res.partner", string="Partner", required=True, ondelete="restrict"
+        "res.partner",
+        string="Partner",
+        required=True,
+        ondelete="restrict",
+        check_company=True,
     )
     partner_email = fields.Char(
         related="record_id.email",

--- a/shopinvader/models/shopinvader_product.py
+++ b/shopinvader/models/shopinvader_product.py
@@ -10,9 +10,14 @@ class ShopinvaderProduct(models.Model):
     _description = "Shopinvader Product"
     _inherit = ["shopinvader.binding", "abstract.url", "seo.title.mixin"]
     _inherits = {"product.template": "record_id"}
+    _check_company_auto = True
 
     record_id = fields.Many2one(
-        "product.template", required=True, ondelete="cascade", index=True
+        "product.template",
+        required=True,
+        ondelete="cascade",
+        index=True,
+        check_company=True,
     )
     meta_description = fields.Char()
     meta_keywords = fields.Char()

--- a/shopinvader/models/shopinvader_variant.py
+++ b/shopinvader/models/shopinvader_variant.py
@@ -21,16 +21,22 @@ class ShopinvaderVariant(models.Model):
         "shopinvader.product": "shopinvader_product_id",
         "product.product": "record_id",
     }
+    _check_company_auto = True
 
     default_code = fields.Char(related="record_id.default_code", store=True)
     shopinvader_product_id = fields.Many2one(
-        "shopinvader.product", required=True, ondelete="cascade", index=True
+        "shopinvader.product",
+        required=True,
+        ondelete="cascade",
+        index=True,
+        check_company=True,
     )
     tmpl_record_id = fields.Many2one(
         string="Product template",
         related="shopinvader_product_id.record_id",
         store=True,
         index=True,
+        check_company=True,
     )
     record_id = fields.Many2one(
         string="Product",
@@ -38,6 +44,7 @@ class ShopinvaderVariant(models.Model):
         required=True,
         ondelete="cascade",
         index=True,
+        check_company=True,
     )
     variant_count = fields.Integer(
         related="product_variant_count", string="Shopinvader Variant Count"
@@ -55,7 +62,8 @@ class ShopinvaderVariant(models.Model):
     price = fields.Serialized(compute="_compute_price", string="Shopinvader Price")
     short_name = fields.Char(compute="_compute_names")
     full_name = fields.Char(compute="_compute_names")
-
+    # Special case for company_id, as it's present in both inherits models
+    company_id = fields.Many2one(related="shopinvader_product_id.company_id")
     # As field is defined on product.template, avoid 'inherits' bypass
     description = fields.Html(
         related="shopinvader_product_id.description", readonly=False

--- a/shopinvader/security/shopinvader_backend_security.xml
+++ b/shopinvader/security/shopinvader_backend_security.xml
@@ -8,9 +8,9 @@
         <field name="name">Shopinvader Backend multi-company</field>
         <field name="model_id" ref="model_shopinvader_backend" />
         <field name="global" eval="True" />
-        <field
-            name="domain_force"
-        >['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+        <field name="domain_force">
+            ['|', ('company_id','=',False), ('company_id','in',company_ids)]
+        </field>
     </record>
 
 </odoo>

--- a/shopinvader/security/shopinvader_category_security.xml
+++ b/shopinvader/security/shopinvader_category_security.xml
@@ -8,9 +8,9 @@
         <field name="name">Shopinvader Category multi-company</field>
         <field name="model_id" ref="model_shopinvader_category" />
         <field name="global" eval="True" />
-        <field
-            name="domain_force"
-        >['|',('backend_id.company_id','=',False),('backend_id.company_id','child_of',[user.company_id.id])]</field>
+        <field name="domain_force">
+            ['|', ('company_id','=',False), ('company_id','in',company_ids)]
+        </field>
     </record>
 
 </odoo>

--- a/shopinvader/security/shopinvader_partner_security.xml
+++ b/shopinvader/security/shopinvader_partner_security.xml
@@ -8,9 +8,9 @@
         <field name="name">Shopinvader Partner multi-company</field>
         <field name="model_id" ref="model_shopinvader_partner" />
         <field name="global" eval="True" />
-        <field
-            name="domain_force"
-        >['|',('backend_id.company_id','=',False),('backend_id.company_id','child_of',[user.company_id.id])]</field>
+        <field name="domain_force">
+            ['|', ('company_id','=',False), ('company_id','in',company_ids)]
+        </field>
     </record>
 
 </odoo>

--- a/shopinvader/security/shopinvader_product_security.xml
+++ b/shopinvader/security/shopinvader_product_security.xml
@@ -8,9 +8,9 @@
         <field name="name">Shopinvader Product multi-company</field>
         <field name="model_id" ref="model_shopinvader_product" />
         <field name="global" eval="True" />
-        <field
-            name="domain_force"
-        >['|',('backend_id.company_id','=',False),('backend_id.company_id','child_of',[user.company_id.id])]</field>
+        <field name="domain_force">
+            ['|', ('company_id','=',False), ('company_id','in',company_ids)]
+        </field>
     </record>
 
 </odoo>

--- a/shopinvader/security/shopinvader_variant_security.xml
+++ b/shopinvader/security/shopinvader_variant_security.xml
@@ -8,9 +8,9 @@
         <field name="name">Shopinvader Variant multi-company</field>
         <field name="model_id" ref="model_shopinvader_variant" />
         <field name="global" eval="True" />
-        <field
-            name="domain_force"
-        >['|',('backend_id.company_id','=',False),('backend_id.company_id','child_of',[user.company_id.id])]</field>
+        <field name="domain_force">
+            ['|', ('company_id','=',False), ('company_id','in',company_ids)]
+        </field>
     </record>
 
 </odoo>

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -81,7 +81,11 @@
                                 <field name="pricelist_id" required="1" />
                             </group>
                             <group name="sale_conf" string="Sale configuration">
-                                <field name="company_id" />
+                                <field
+                                    name="company_id"
+                                    widget="selection"
+                                    groups="base.group_multi_company"
+                                />
                                 <field name="sequence_id" />
                                 <field name="account_analytic_id" />
                             </group>
@@ -213,7 +217,12 @@
                 <field name="name" />
                 <field name="tech_name" />
                 <field name="location" />
-                <field name="company_id" />
+                <field
+                    name="company_id"
+                    widget="selection"
+                    groups="base.group_multi_company"
+                    optional="show"
+                />
             </tree>
         </field>
     </record>

--- a/shopinvader/views/shopinvader_category_view.xml
+++ b/shopinvader/views/shopinvader_category_view.xml
@@ -22,6 +22,11 @@
                     <group name="backend">
                         <field name="backend_id" />
                         <field name="lang_id" />
+                        <field
+                                name="company_id"
+                                widget="selection"
+                                groups="base.group_multi_company"
+                            />
                     </group>
                     <group name="record">
                         <field name="record_id" />
@@ -73,6 +78,12 @@
             <field name="sequence" widget="handle" />
             <field name="display_name" />
             <field name="backend_id" />
+            <field
+                    name="company_id"
+                    widget="selection"
+                    groups="base.group_multi_company"
+                    optional="show"
+                />
         </tree>
     </field>
 </record>
@@ -83,6 +94,7 @@
         <search string="Shopinvader Product">
             <field name="name" />
             <field name="backend_id" />
+            <field name="company_id" groups="base.group_multi_company" />
             <group string="Group By">
                 <filter
                         name="group_by_backend_id"

--- a/shopinvader/views/shopinvader_partner_view.xml
+++ b/shopinvader/views/shopinvader_partner_view.xml
@@ -14,6 +14,11 @@
                     <field name="backend_id" />
                     <field name="external_id" />
                     <field name="create_date" readonly="1" />
+                    <field
+                        name="company_id"
+                        widget="selection"
+                        groups="base.group_multi_company"
+                    />
                     <field name="sync_date" />
                 </group>
             </form>
@@ -33,6 +38,12 @@
                 <field name="backend_id" />
                 <field name="external_id" />
                 <field name="create_date" readonly="1" />
+                <field
+                    name="company_id"
+                    widget="selection"
+                    groups="base.group_multi_company"
+                    optional="show"
+                />
                 <field name="sync_date" />
             </tree>
         </field>
@@ -46,6 +57,7 @@
                 <field name="email" />
                 <field name="external_id" />
                 <field name="parent_id" />
+                <field name="company_id" groups="base.group_multi_company" />
                 <group string="Group By">
                     <filter
                         name="group_by_backend_id"

--- a/shopinvader/views/shopinvader_product_view.xml
+++ b/shopinvader/views/shopinvader_product_view.xml
@@ -16,6 +16,7 @@
                 <field name="lang_id" string="Lang" />
                 <field name="default_code" string="Code" />
                 <field name="record_id" string="Product Template" />
+                <field name="company_id" groups="base.group_multi_company" />
                 <separator />
                 <filter name="active" string="Active" domain="[('active','=',True)]" />
                 <filter
@@ -51,6 +52,12 @@
                 <field name="backend_id" />
                 <field name="lang_id" optional="show" />
                 <field name="record_id" optional="hide" />
+                <field
+                    name="company_id"
+                    widget="selection"
+                    groups="base.group_multi_company"
+                    optional="show"
+                />
                 <field name="sync_date" />
             </tree>
         </field>
@@ -78,6 +85,11 @@
                         <group name="backend">
                             <field name="backend_id" widget="selection" />
                             <field name="lang_id" widget="selection" />
+                            <field
+                                name="company_id"
+                                widget="selection"
+                                groups="base.group_multi_company"
+                            />
                         </group>
                         <group name="record">
                             <field name="record_id" />

--- a/shopinvader/views/shopinvader_variant_view.xml
+++ b/shopinvader/views/shopinvader_variant_view.xml
@@ -14,6 +14,7 @@
                 <field name="default_code" string="Code" />
                 <field name="record_id" string="Name" />
                 <field name="tmpl_record_id" string="Template" />
+                <field name="company_id" groups="base.group_multi_company" />
                 <separator />
                 <filter name="active" string="Active" domain="[('active','=',True)]" />
                 <filter
@@ -63,6 +64,12 @@
                 <field name="record_id" optional="hide" />
                 <field name="tmpl_record_id" optional="hide" />
                 <field name="lang_id" optional="show" />
+                <field
+                    name="company_id"
+                    widget="selection"
+                    groups="base.group_multi_company"
+                    optional="show"
+                />
              </tree>
         </field>
     </record>
@@ -90,6 +97,11 @@
                             <field name="backend_id" />
                             <field name="lang_id" />
                             <field name="shopinvader_product_id" />
+                            <field
+                                name="company_id"
+                                widget="selection"
+                                groups="base.group_multi_company"
+                            />
                         </group>
                         <group name="variant">
                             <field name="default_code" />


### PR DESCRIPTION
IrRules didn't account for multiple companies set in context (the new odoo way of managing companies)

Also:

- Added `company_id` related, stored field in bindings (stored for performance, as it's used by ir.rules)
- Make use of `check_company` to get multi-company consistency among records and bindings