### PR TITLE
[FIX] fix binding view on product.template form

### DIFF
--- a/shopinvader/views/product_view.xml
+++ b/shopinvader/views/product_view.xml
@@ -3,11 +3,43 @@
 
     <record id="view_product_template_form" model="ir.ui.view">
         <field name="model">product.template</field>
-         <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
             <xpath expr="/form/sheet/notebook" position="inside">
                 <page name="shopinvader" string="ShopInvader">
-                    <field name="shopinvader_bind_ids" />
+                    <field
+                        name="shopinvader_bind_ids"
+                        context="{'hide_record_id': True}"
+                    >
+                        <tree
+                            decoration-danger="active != True"
+                            decoration-success="active == True"
+                        >
+
+                            <field name="backend_id" />
+                            <field name="lang_id" />
+                            <field name="sync_date" />
+                            <field name="active" invisible="True" />
+                            <button
+                                name="toggle_active"
+                                type="object"
+                                help="Click to publish"
+                                title=""
+                                icon="fa-close"
+                                aria-label="Publish"
+                                attrs="{'invisible': [('active', '=', True)]}"
+                            />
+                            <button
+                                name="toggle_active"
+                                type="object"
+                                help="Click to unpublish"
+                                title=""
+                                icon="fa-check"
+                                aria-label="Unpublish"
+                                attrs="{'invisible': [('active', '!=', True)]}"
+                            />
+                        </tree>
+                    </field>
                 </page>
             </xpath>
             <page name="sales" position="inside">

--- a/shopinvader/views/shopinvader_product_view.xml
+++ b/shopinvader/views/shopinvader_product_view.xml
@@ -91,8 +91,11 @@
                                 groups="base.group_multi_company"
                             />
                         </group>
-                        <group name="record">
-                            <field name="record_id" />
+                        <group name="record" invisible="context.get('hide_record_id')">
+                            <field
+                                name="record_id"
+                                required="not context.get('hide_record_id')"
+                            />
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
In the PR #1060 the view on binding (for the menu shopinvader have been improved) but the view on the product.template is now broken. Fix it
@simahawk @ivantodorovich 

![image](https://user-images.githubusercontent.com/1164578/129149817-d62caf4c-cff1-41b8-afa2-947dd8494877.png)
