### PR TITLE
[UPD] 14.0 requests_mock -> request-mock

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 openupgradelib @ git+https://github.com/OCA/openupgradelib.git
 locomotivecms @ git+https://github.com/akretion/locomotivecms-python-client.git
 # test requirements
-requests_mock
+requests-mock
 vcrpy
 vcrpy-unittest
 unittest2 # For shopinvader test_controller, which inherits component


### PR DESCRIPTION
It looks like pip does not allow to install requests_mock but only requests-mock now. CI is broken by this