### PR TITLE
[14.0][FIX] shopinvader: invoices payment states

### DIFF
--- a/shopinvader/services/invoice.py
+++ b/shopinvader/services/invoice.py
@@ -34,9 +34,9 @@ class InvoiceService(Component):
 
         :return: list of str
         """
-        states = ["paid"]
+        states = ["paid", "reversed"]
         if self.shopinvader_backend.invoice_access_open:
-            states += ["not_paid", "in_payment"]
+            states += ["not_paid", "in_payment", "partial"]
         return states
 
     def _get_base_search_domain(self):


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/8e4158a, two new payment states have been added: "partial" and "reversed".

"reversed" is a subset of the previous "paid" state, only applicable when the invoice/move has been fully reconciled with another (inverse) move (ie: a credit note).