### PR TITLE
14.0 fix shopinvader product template multi link

### DIFF
--- a/shopinvader_product_template_multi_link/data/ir_exports_line.xml
+++ b/shopinvader_product_template_multi_link/data/ir_exports_line.xml
@@ -2,7 +2,8 @@
 <odoo>
 
     <record id="ir_exp_shopinvader_variant_links" model="ir.exports.line">
-        <field name="name">product_links:links</field>
+        <field name="name">product_links</field>
+        <field name="target">product_links:links</field>
         <field name="export_id" ref="shopinvader.ir_exp_shopinvader_variant" />
     </record>
 

--- a/shopinvader_product_template_multi_link/models/shopinvader_product_link_mixin.py
+++ b/shopinvader_product_template_multi_link/models/shopinvader_product_link_mixin.py
@@ -61,7 +61,7 @@ class ShopinvaderProductLinkMixin(models.AbstractModel):
             return {}
         variant = self._product_link_target_variant(target)
         if variant:
-            return {"id": variant.id}
+            return {"id": variant.record_id.id}
         return {}
 
     def _product_link_target(self, link):

--- a/shopinvader_product_template_multi_link/tests/test_product.py
+++ b/shopinvader_product_template_multi_link/tests/test_product.py
@@ -19,8 +19,8 @@ class ProductLinkCase(ProductLinkCaseBase):
         ).filtered(lambda x: x.main)
 
         expected = {
-            "up_selling": [{"id": main2.id}],
-            "cross_selling": [{"id": main3.id}],
+            "up_selling": [{"id": main2.record_id.id}],
+            "cross_selling": [{"id": main3.record_id.id}],
         }
         self.assertEqual(
             self.shopinvader_variant_1_1.shopinvader_product_id.product_links,
@@ -32,8 +32,8 @@ class ProductLinkCase(ProductLinkCaseBase):
         )
 
         expected = {
-            "cross_selling": [{"id": main3.id}],
-            "up_selling": [{"id": main1.id}],
+            "cross_selling": [{"id": main3.record_id.id}],
+            "up_selling": [{"id": main1.record_id.id}],
         }
         self.assertEqual(
             self.shopinvader_variant_2_1.shopinvader_product_id.product_links,
@@ -44,9 +44,12 @@ class ProductLinkCase(ProductLinkCaseBase):
             expected,
         )
         expected = {
-            "cross_selling": [{"id": main1.id}, {"id": main2.id}],
+            "cross_selling": [
+                {"id": main1.record_id.id},
+                {"id": main2.record_id.id},
+            ],
         }
-        expected["one_way"] = [{"id": main2.id}]
+        expected["one_way"] = [{"id": main2.record_id.id}]
         self.assertEqual(
             self.shopinvader_variant_3_2.shopinvader_product_id.product_links,
             expected,


### PR DESCRIPTION
Something wrong have been done during the rebase of PR https://github.com/shopinvader/odoo-shopinvader/pull/1073
So I cherry-pick my fix from here : https://github.com/acsone/odoo-shopinvader/pull/4
