### PR TITLE
[14.0][IMP] shopinvader: Restore type 'other' for addresses

### DIFF
--- a/shopinvader/services/address.py
+++ b/shopinvader/services/address.py
@@ -205,6 +205,8 @@ class AddressService(Component):
         return data
 
     def _prepare_params(self, params, mode="create"):
+        if not params.get("type"):
+            params["type"] = "other"
         for key in ["country", "state"]:
             if key in params:
                 val = params.pop(key)


### PR DESCRIPTION
If 'type' param is ignored, addresses are created as 'contact' and
address details are skipped to take the parent ones.

Restore behaviour from v10