### PR TITLE
[14.0] s_quotation: improve behavior

### DIFF
--- a/shopinvader_quotation/__manifest__.py
+++ b/shopinvader_quotation/__manifest__.py
@@ -17,6 +17,7 @@
     "data": [
         "views/product_view.xml",
         "views/sale_view.xml",
+        "views/shopinvader_backend_view.xml",
         "data/ir_export_product.xml",
     ],
     "installable": True,

--- a/shopinvader_quotation/models/__init__.py
+++ b/shopinvader_quotation/models/__init__.py
@@ -2,3 +2,4 @@ from . import product_product
 from . import product_template
 from . import sale_order
 from . import shopinvader_notification
+from . import shopinvader_backend

--- a/shopinvader_quotation/models/sale_order.py
+++ b/shopinvader_quotation/models/sale_order.py
@@ -55,8 +55,11 @@ class SaleOrder(models.Model):
                 rec.shopinvader_backend_id._send_notification("quotation_request", rec)
         return True
 
-    def action_quotation_sent(self):
-        res = super().action_quotation_sent()
-        # If the order is sent from the backend make it visible to the shop.
-        self.typology = "quotation"
-        return res
+    def write(self, vals):
+        # Set the typology to "quotation" when the quotation is sent.
+        # Normally there are two cases where this happens:
+        # * When the :meth:`action_quotation_sent` is called.
+        # * When a message is posted with context `mark_so_as_sent=True`.
+        if vals.get("state") == "sent":
+            vals["typology"] = "quotation"
+        return super().write(vals)

--- a/shopinvader_quotation/models/shopinvader_backend.py
+++ b/shopinvader_quotation/models/shopinvader_backend.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo import fields, models
+
+
+class ShopinvaderBackend(models.Model):
+    _inherit = "shopinvader.backend"
+
+    quotation_expose_all = fields.Boolean(
+        string="Expose all quotations",
+        help="Include quotations not bound to specific backends. ",
+        default=True,
+    )

--- a/shopinvader_quotation/readme/CONFIGURE.rst
+++ b/shopinvader_quotation/readme/CONFIGURE.rst
@@ -1,0 +1,4 @@
+Go to "Shopinvader -> Websites -> Select your backend".
+In the "Sale" tab, find the "Expose all quotations" flag.
+When this is set, all quotations for the customer will be visible once sent,
+even if not bound to a specific backend record.

--- a/shopinvader_quotation/readme/CONTRIBUTORS.rst
+++ b/shopinvader_quotation/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Sebastien BEAU <sebastien.beau@akretion.com>
 * Benoît GUILLOT <benoit.guillot@akretion.com>
 * Iván Todorovich <ivan.todorovich@gmail.com>
+* Simone Orsi <simone.orsi@camptocamp.com>

--- a/shopinvader_quotation/readme/DESCRIPTION.rst
+++ b/shopinvader_quotation/readme/DESCRIPTION.rst
@@ -3,9 +3,15 @@ This module adds a REST API for shopinvader to manage quotations.
 The Customer can convert a cart into a quotation (the typology of the sale
 order is set to quotation).
 
-Initialy, the quotation has the `shopinvader_state` "estimating".
+Initially, the quotation has the `shopinvader_state` "estimating".
 After updating the price manually when the button "sent" on Odoo backend
 is summited, the quotation will be sent by email (native behaviour) and the
 shopinvader_state will switch to "estimated".
 
 On Shopinvader site, the customer can see the state, the amount ... of quotation.
+
+When the backend user sends the quotation, this is visible to the shop
+if the backend is set to "Expose all quotations".
+
+If a quotation, previously not bound to any backend, is confirmed from the shop,
+then it gets bound to the shop backend automatically.

--- a/shopinvader_quotation/services/quotation.py
+++ b/shopinvader_quotation/services/quotation.py
@@ -1,6 +1,7 @@
 # Copyright 2016 Akretion (http://www.akretion.com)
-# Copyright 2021 Camptocamp (http://www.camptocamp.com).
 # @author Benoît GUILLOT <benoit.guillot@akretion.com>
+# Copyright 2021 Camptocamp (http://www.camptocamp.com)
+# @author Simone Orsi <simone.orsi@camptocamp.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.addons.component.core import Component
@@ -54,9 +55,26 @@ class QuotationService(Component):
     # All params are trusted as they have been checked before
 
     def _get_base_search_domain(self):
-        return self._default_domain_for_partner_records() + [
-            ("typology", "=", "quotation"),
-        ]
+        show_all = self.shopinvader_backend.quotation_expose_all
+        if show_all:
+            # Expose all records bound to current backend or not bound at all.
+            backend_domain = [
+                "|",
+                ("shopinvader_backend_id", "=", self.shopinvader_backend.id),
+                ("shopinvader_backend_id", "=", False),
+            ]
+        return (
+            self._default_domain_for_partner_records(with_backend=not show_all)
+            + [
+                ("typology", "=", "quotation"),
+            ]
+            + backend_domain
+        )
 
     def _confirm(self, order):
+        # If user can see all quotations, bind the order to current backend if not set yet.
+        show_all = self.shopinvader_backend.quotation_expose_all
+        if show_all and not order.shopinvader_backend_id:
+            order = order.with_context(_skip_cart_check=True)
+            order.shopinvader_backend_id = self.shopinvader_backend
         return order.action_confirm_cart()

--- a/shopinvader_quotation/services/quotation.py
+++ b/shopinvader_quotation/services/quotation.py
@@ -4,6 +4,7 @@
 # @author Simone Orsi <simone.orsi@camptocamp.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
 
 
@@ -49,6 +50,12 @@ class QuotationService(Component):
 
     def _validator_confirm(self):
         return {}
+
+    def _validator_search(self):
+        res = self._default_validator_search()
+        res.pop("domain", None)
+        res.update({"id": {"coerce": to_int, "type": "integer"}})
+        return res
 
     # The following method are 'private' and should be never never NEVER call
     # from the controller.

--- a/shopinvader_quotation/tests/test_quotation.py
+++ b/shopinvader_quotation/tests/test_quotation.py
@@ -1,5 +1,7 @@
 # Copyright 2017 Akretion (http://www.akretion.com).
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
+# Copyright 2021 Camptocamp (http://www.camptocamp.com)
+# @author Simone Orsi <simone.orsi@camptocamp.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.addons.shopinvader.tests.test_cart import CommonConnectedCartCase
@@ -26,3 +28,55 @@ class ShopinvaderCartQuotationCase(CommonConnectedCartCase):
         self.assertIn(
             "only_quotation", response["data"]["lines"]["items"][0]["product"]
         )
+
+    def test_send(self):
+        order = self.cart.copy({"typology": "sale"})
+        self.assertEqual(order.typology, "sale")
+        order.action_quotation_sent()
+        self.assertEqual(order.state, "sent")
+        self.assertEqual(order.typology, "quotation")
+
+    def test_visibility(self):
+        order = self.cart.copy({"typology": "sale"})
+        response = self.quotation_service.dispatch("search")
+        self.assertNotIn(order.id, [x["id"] for x in response["data"]])
+        self.backend.quotation_expose_all = True
+        response = self.quotation_service.dispatch("search")
+        self.assertNotIn(order.id, [x["id"] for x in response["data"]])
+        order.action_quotation_sent()
+        response = self.quotation_service.dispatch("search")
+        self.assertIn(order.id, [x["id"] for x in response["data"]])
+
+    def test_visibility_multi_backends(self):
+        backend2 = self.env.ref("shopinvader.backend_2")
+        self.backend.quotation_expose_all = True
+        backend2.quotation_expose_all = True
+        order = self.cart.copy({"typology": "quotation"})
+        order2 = self.cart.copy(
+            {"typology": "quotation", "shopinvader_backend_id": backend2.id}
+        )
+        order_not_bound = self.cart.copy(
+            {"typology": "quotation", "shopinvader_backend_id": False}
+        )
+
+        response = self.quotation_service.dispatch("search")
+        self.assertIn(order.id, [x["id"] for x in response["data"]])
+        self.assertIn(order_not_bound.id, [x["id"] for x in response["data"]])
+        self.assertNotIn(order2.id, [x["id"] for x in response["data"]])
+
+        # Switch backend
+        self.quotation_service.work.shopinvader_backend = backend2
+        response = self.quotation_service.dispatch("search")
+        self.assertIn(order2.id, [x["id"] for x in response["data"]])
+        self.assertIn(order_not_bound.id, [x["id"] for x in response["data"]])
+        self.assertNotIn(order.id, [x["id"] for x in response["data"]])
+
+    def test_confirm_from_shop(self):
+        order = self.cart.copy(
+            {"typology": "quotation", "shopinvader_backend_id": False}
+        )
+        self.assertEqual(order.typology, "quotation")
+        self.assertFalse(order.shopinvader_backend_id)
+        self.quotation_service.dispatch("confirm", order.id)
+        self.assertEqual(order.typology, "sale")
+        self.assertEqual(order.shopinvader_backend_id, self.backend)

--- a/shopinvader_quotation/tests/test_quotation.py
+++ b/shopinvader_quotation/tests/test_quotation.py
@@ -89,3 +89,14 @@ class ShopinvaderCartQuotationCase(CommonConnectedCartCase):
         self.quotation_service.dispatch("confirm", order.id)
         self.assertEqual(order.typology, "sale")
         self.assertEqual(order.shopinvader_backend_id, self.backend)
+
+    def test_search_pagination(self):
+        quotation = self.cart.copy({"typology": "quotation"})
+        quotation.copy()
+        quotation.copy()
+        params = {"per_page": 2}
+        res = self.quotation_service.dispatch("search", params=params)["data"]
+        self.assertEqual(len(res), 2)
+        params = {"per_page": 2, "page": 2}
+        res = self.quotation_service.dispatch("search", params=params)["data"]
+        self.assertEqual(len(res), 1)

--- a/shopinvader_quotation/tests/test_quotation.py
+++ b/shopinvader_quotation/tests/test_quotation.py
@@ -36,6 +36,15 @@ class ShopinvaderCartQuotationCase(CommonConnectedCartCase):
         self.assertEqual(order.state, "sent")
         self.assertEqual(order.typology, "quotation")
 
+    def test_send_message_post(self):
+        order = self.cart.copy({"typology": "sale"})
+        self.assertEqual(order.typology, "sale")
+        action = order.action_quotation_send()
+        # pylint: disable=translation-required
+        order.with_context(action["context"]).message_post(body="Test")
+        self.assertEqual(order.state, "sent")
+        self.assertEqual(order.typology, "quotation")
+
     def test_visibility(self):
         order = self.cart.copy({"typology": "sale"})
         response = self.quotation_service.dispatch("search")

--- a/shopinvader_quotation/views/shopinvader_backend_view.xml
+++ b/shopinvader_quotation/views/shopinvader_backend_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record model="ir.ui.view" id="shopinvader_backend_form_view">
+        <field name="model">shopinvader.backend</field>
+        <field name="inherit_id" ref="shopinvader.shopinvader_backend_view_form" />
+        <field name="arch" type="xml">
+            <page name="sale" position="inside">
+                <group name="quotation" string="Quotation">
+                    <field name="quotation_expose_all" />
+                </group>
+            </page>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
When quotations are created from the backend and not from a cart
they won't be available on the shop.

These changes allow to expose them once they are sent.