### PR TITLE
[14.0] FIX shopinvader_customer_validate view

### DIFF
--- a/shopinvader_customer_validate/views/partner_view.xml
+++ b/shopinvader_customer_validate/views/partner_view.xml
@@ -103,6 +103,7 @@
                     class="float-right"
                 >
                     <a
+                        role="button"
                         class="btn btn-sm btn-success"
                         name="action_shopinvader_validate_address"
                         type="object"


### PR DESCRIPTION
Add 'role="button"' to '<a>' tag in res.partner view to avoid triggering warning