### PR TITLE
[13.0][IMP] shopinvader: limit unique email constrain on res.partner to shopinvader users

### DIFF
--- a/shopinvader/models/res_partner.py
+++ b/shopinvader/models/res_partner.py
@@ -177,10 +177,11 @@ class ResPartner(models.Model):
             else:
                 partner.address_type = "profile"
 
-    @api.constrains("email")
+    @api.constrains("email", "has_shopinvader_user_active")
     def _check_unique_email(self):
         if self._is_partner_duplicate_allowed():
             return True
+        self.env["res.partner"].flush(["email", "has_shopinvader_user_active"])
         self.env.cr.execute(
             """
             SELECT
@@ -192,7 +193,9 @@ class ResPartner(models.Model):
                     ROW_NUMBER() OVER (PARTITION BY email) AS Row
                 FROM
                     res_partner
-                WHERE email is not null and active = True
+                WHERE email is not null
+                    and active = True
+                    and has_shopinvader_user_active = True
                 ) dups
             WHERE dups.Row > 1;
         """

--- a/shopinvader/tests/test_res_partner.py
+++ b/shopinvader/tests/test_res_partner.py
@@ -14,34 +14,75 @@ class TestResPartner(SavepointComponentCase):
         super(TestResPartner, cls).setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.unique_email = datetime.now().isoformat() + "@test.com"
+        cls.backend1 = cls.env.ref("shopinvader.backend_1")
+        cls.backend2 = cls.env.ref("shopinvader.backend_2")
 
     def test_unique_email_partner(self):
         self.assertTrue(
             self.env["res.partner"]._is_partner_duplicate_allowed()
         )
         partner_1 = self.env["res.partner"].create(
-            {"email": self.unique_email, "name": "test partner"}
+            {
+                "email": self.unique_email,
+                "name": "test partner",
+                "shopinvader_bind_ids": [
+                    (0, False, {"backend_id": self.backend1.id})
+                ],
+            }
         )
-        # by default we can create partner with same email
+        # by default we can create partner with shopinvader user with same email
+        # as long as they are related to different backends
         partner_2 = self.env["res.partner"].create(
-            {"email": self.unique_email, "name": "test partner 2"}
+            {
+                "email": self.unique_email,
+                "name": "test partner 2",
+                "shopinvader_bind_ids": [
+                    (0, False, {"backend_id": self.backend2.id})
+                ],
+            }
         )
+
+        # unlink partner_2 to validate the constrain after, to avoid having
+        # to create a new backend for the test
+        partner_2.shopinvader_bind_ids.unlink()
+        partner_2.unlink()
+
+        # activate no partner duplicate parameter
         self.env["ir.config_parameter"].create(
             {"key": "shopinvader.no_partner_duplicate", "value": "True"}
         )
         self.assertFalse(
             self.env["res.partner"]._is_partner_duplicate_allowed()
         )
-        # once you've changed the config to dispable duplicate partner
-        # it's no more possible to create a partner with the same email
+
+        # once you've changed the config to disable duplicate partner
+        # it's no more possible to create a partner with shopinvader user
+        # with the same email
         with self.assertRaises(ValidationError), self.cr.savepoint():
             self.env["res.partner"].create(
-                {"email": self.unique_email, "name": "test partner 3"}
+                {
+                    "email": self.unique_email,
+                    "name": "test partner 2",
+                    "shopinvader_bind_ids": [
+                        (0, False, {"backend_id": self.backend2.id})
+                    ],
+                }
             )
 
-        # unicity constrains is only applicable on active records
-        partners = partner_1 | partner_2
-        partners.write({"active": False})
+        # unicity constrains is only applicable on partners with
+        # shopinvader user
         self.env["res.partner"].create(
-            {"email": self.unique_email, "name": "test partner 3"}
+            {"email": self.unique_email, "name": "test partner 2"}
+        )
+
+        # unicity constrains is also only applicable on active records
+        partner_1.write({"active": False})
+        self.env["res.partner"].create(
+            {
+                "email": self.unique_email,
+                "name": "test partner 3",
+                "shopinvader_bind_ids": [
+                    (0, False, {"backend_id": self.backend2.id})
+                ],
+            }
         )


### PR DESCRIPTION
The unique email constrain in res partner currently implies that it will be globally applied to Odoo, which affects the standard behavior. In fact, there is a specific OCA Module that adds this type of constrain if desired (https://github.com/OCA/partner-contact/tree/13.0/partner_email_check).

Furthermore, when creating new addresses, we should allow having duplicate email values so customers can decide where they want to be notified for each of them.

With this PR, the intention is to only perform the check for the constrain within the partners that are shopinvader users, in order to deal with the two points explained above.