### PR TITLE
[14.0][IMP] shopinvader: product view

### DIFF
--- a/shopinvader/views/product_view.xml
+++ b/shopinvader/views/product_view.xml
@@ -65,7 +65,7 @@
         <field name="priority" eval="90" />
         <field name="arch" type="xml">
             <field name="shopinvader_backend_ids" position="before">
-                <field name="is_shopinvader_binded" string="Binded" />
+                <field name="is_shopinvader_binded" string="Bound" />
             </field>
         </field>
     </record>

--- a/shopinvader/views/product_view.xml
+++ b/shopinvader/views/product_view.xml
@@ -40,13 +40,22 @@
                             />
                         </tree>
                     </field>
+                    <group name="shopinvader">
+                        <group name="shopinvader_bindings" string="Bindings">
+                            <field
+                                name="shopinvader_backend_ids"
+                                string="Backends"
+                                widget="many2many_tags"
+                            />
+                        </group>
+                        <group
+                            name="shopinvader_options"
+                            string="Options"
+                            invisible="1"
+                        />
+                    </group>
                 </page>
             </xpath>
-            <page name="sales" position="inside">
-                <group name="shopinvader" string="Shopinvader">
-                    <field name="shopinvader_backend_ids" widget="many2many_tags" />
-                </group>
-            </page>
         </field>
     </record>
 
@@ -55,14 +64,10 @@
         <field name="inherit_id" ref="product.product_normal_form_view" />
         <field name="priority" eval="90" />
         <field name="arch" type="xml">
-            <field name="shopinvader_bind_ids" position="before">
-                <group>
-                    <group>
-                        <field name="is_shopinvader_binded" />
-                    </group>
-                    <group />
-                </group>
+            <field name="shopinvader_backend_ids" position="before">
+                <field name="is_shopinvader_binded" string="Binded" />
             </field>
         </field>
     </record>
+
 </odoo>

--- a/shopinvader_quotation/views/product_view.xml
+++ b/shopinvader_quotation/views/product_view.xml
@@ -5,9 +5,12 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
-            <field name="shopinvader_backend_ids" position="before">
+            <group name="shopinvader_options" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </group>
+            <group name="shopinvader_options" position="inside">
                 <field name="only_quotation" />
-            </field>
+            </group>
         </field>
     </record>
 


### PR DESCRIPTION
- Move shopinvader fields into the ShopInvader tab.
- Added some group placeholders for other modules to add fields into (see shopinvader_quotation change)

**Result:**
![captura_2](https://user-images.githubusercontent.com/1914185/134556569-77162e99-4caa-4ca2-a5c7-fd2ae6bd4985.png)


Inspired by the core "Purchase" page, where labeled groups are added right after the vendors one2many. This way the look n feel is closer to std



