### PR TITLE
[14.0][FIX] shopinvader: Stable sort for shopinvader.category

### DIFF
--- a/shopinvader/models/shopinvader_category.py
+++ b/shopinvader/models/shopinvader_category.py
@@ -17,7 +17,7 @@ class ShopinvaderCategory(models.Model):
     _description = "Shopinvader Category"
     _inherit = ["shopinvader.binding", "abstract.url", "seo.title.mixin"]
     _inherits = {"product.category": "record_id"}
-    _order = "sequence"
+    _order = "sequence, id desc"
 
     record_id = fields.Many2one(
         "product.category",


### PR DESCRIPTION
When `sequence` isn't set, the generated json isn't stable which leads to unwanted updates.
Adding an id to the sort order fixes this. 