### PR TITLE
[14.0] shopinvader_invoice: fix _to_json signature

### DIFF
--- a/shopinvader_invoice/services/invoice.py
+++ b/shopinvader_invoice/services/invoice.py
@@ -118,7 +118,7 @@ class InvoiceService(Component):
         )
         return values
 
-    def _to_json(self, invoices):
+    def _to_json(self, invoices, **kw):
         res = []
         for invoice in invoices:
             res.append(self._to_json_invoice(invoice))


### PR DESCRIPTION
Calling methods my propagate params.

Currenlty is broken as the paginate_search propagates params:

` 500 Internal Server Error: _to_json() got an unexpected keyword argument 'page'`