### PR TITLE
[14.0][IMP] shopinvader_quotation: move only_quotation to product.product

### DIFF
--- a/shopinvader_quotation/__manifest__.py
+++ b/shopinvader_quotation/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopinvader Quotation",
     "summary": "Shopinvader Quotation",
-    "version": "14.0.1.1.1",
+    "version": "14.0.2.0.0",
     "category": "e-commerce",
     "development_status": "Production/Stable",
     "website": "https://github.com/shopinvader/odoo-shopinvader",

--- a/shopinvader_quotation/data/ir_export_product.xml
+++ b/shopinvader_quotation/data/ir_export_product.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
 
-    <record id="ir_exp_shopinvader_only_quotation" model="ir.exports.line">
-        <field name="name">only_quotation</field>
+    <record id="ir_exp_shopinvader_shop_only_quotation" model="ir.exports.line">
+        <field name="name">shop_only_quotation</field>
+        <field name="target">shop_only_quotation:only_quotation</field>
         <field name="export_id" ref="shopinvader.ir_exp_shopinvader_variant" />
     </record>
 

--- a/shopinvader_quotation/migrations/14.0.2.0.0/pre-migrate.py
+++ b/shopinvader_quotation/migrations/14.0.2.0.0/pre-migrate.py
@@ -1,0 +1,29 @@
+# Copyright 2021 Camptocamp (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tools.sql import column_exists, create_column
+
+
+def migrate(cr, version):
+    """Migrate only_quotation field
+
+    - Copy product.template values to product.product
+    - Rename to shop_only_quotation
+    """
+    if (
+        not version
+        or column_exists(cr, "product_product", "shop_only_quotation")
+        or not column_exists(cr, "product_template", "only_quotation")
+    ):
+        return
+    create_column(cr, "product_product", "shop_only_quotation", "BOOLEAN")
+    cr.execute(
+        """
+            UPDATE product_product pp
+            SET shop_only_quotation = pt.only_quotation
+            FROM product_template pt
+            WHERE pp.product_tmpl_id = pt.id
+        """
+    )
+    cr.execute("ALTER TABLE product_template DROP COLUMN only_quotation")

--- a/shopinvader_quotation/models/__init__.py
+++ b/shopinvader_quotation/models/__init__.py
@@ -1,3 +1,4 @@
+from . import product_product
 from . import product_template
 from . import sale_order
 from . import shopinvader_notification

--- a/shopinvader_quotation/models/product_product.py
+++ b/shopinvader_quotation/models/product_product.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Camptocamp (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    shop_only_quotation = fields.Boolean(
+        string="Shopinvader: Only for Quotation",
+    )

--- a/shopinvader_quotation/models/product_template.py
+++ b/shopinvader_quotation/models/product_template.py
@@ -1,11 +1,42 @@
 # Copyright 2017-2018 Akretion (http://www.akretion.com).
+# Copyright 2021 Camptocamp (https://www.camptocamp.com).
 # @author Benoît GUILLOT <benoit.guillot@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    only_quotation = fields.Boolean("Only for quotation")
+    shop_only_quotation = fields.Boolean(
+        string="Shopinvader: Only for Quotation",
+        compute="_compute_shop_only_quotation",
+        inverse="_inverse_shop_only_quotation",
+        store=True,
+    )
+
+    @api.depends("product_variant_ids.shop_only_quotation")
+    def _compute_shop_only_quotation(self):
+        # True only if true for all its variants
+        for rec in self:
+            rec.shop_only_quotation = (
+                all(rec.product_variant_ids.mapped("shop_only_quotation"))
+                if rec.product_variant_ids
+                else False
+            )
+
+    def _inverse_shop_only_quotation(self):
+        # Sets the value on all its variants
+        for rec in self:
+            rec.product_variant_ids.shop_only_quotation = rec.shop_only_quotation
+
+    def _create_variant_ids(self):
+        # Make sure new variants have the same value than the template.
+        templates = self.filtered("shop_only_quotation")
+        res = super()._create_variant_ids()
+        products = templates.product_variant_ids.filtered(
+            lambda rec: not rec.shop_only_quotation
+        )
+        products.shop_only_quotation = True
+        return res

--- a/shopinvader_quotation/tests/__init__.py
+++ b/shopinvader_quotation/tests/__init__.py
@@ -1,3 +1,4 @@
-from . import test_quotation
 from . import test_notification
+from . import test_product
+from . import test_quotation
 from . import test_quotation_download

--- a/shopinvader_quotation/tests/test_product.py
+++ b/shopinvader_quotation/tests/test_product.py
@@ -1,0 +1,65 @@
+# Copyright 2021 Camptocamp (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+
+
+class TestProduct(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.attribute = cls.env.ref("product.product_attribute_2")
+        cls.value_1 = cls.env.ref("product.product_attribute_value_3")
+        cls.value_2 = cls.env.ref("product.product_attribute_value_4")
+        cls.product_template = cls.env["product.template"].create(
+            {
+                "name": "Test Product",
+            }
+        )
+
+    def test_simple_product(self):
+        # Back and forth flow, setting and reading on template and single variant
+        self.assertFalse(self.product_template.shop_only_quotation)
+        self.product_template.shop_only_quotation = True
+        self.assertTrue(self.product_template.product_variant_ids.shop_only_quotation)
+        self.product_template.product_variant_ids.shop_only_quotation = False
+        self.assertFalse(self.product_template.shop_only_quotation)
+
+    def test_multi_product(self):
+        # Configure product with multiple variants
+        self.product_template.attribute_line_ids = [
+            (
+                0,
+                0,
+                {
+                    "attribute_id": self.attribute.id,
+                    "value_ids": [(6, 0, [self.value_1.id, self.value_2.id])],
+                },
+            )
+        ]
+        self.assertEqual(len(self.product_template.product_variant_ids), 2)
+        template = self.product_template
+        product_1 = self.product_template.product_variant_ids[0]
+        product_2 = self.product_template.product_variant_ids[1]
+        # Set on the template should set all variants
+        template.shop_only_quotation = True
+        self.assertTrue(product_1.shop_only_quotation)
+        self.assertTrue(product_2.shop_only_quotation)
+        # Set a variant to false should set the template to false
+        # It's only true if it's true for all variants
+        product_1.shop_only_quotation = False
+        self.assertFalse(template.shop_only_quotation)
+        self.assertTrue(product_2.shop_only_quotation, "Other variant shouldn't change")
+        # Set false on template should set all variants to false
+        template.shop_only_quotation = False
+        self.assertFalse(product_1.shop_only_quotation)
+        self.assertFalse(product_2.shop_only_quotation)
+        # Create a new variant combination should copy the value from template
+        template.shop_only_quotation = True
+        value_3 = self.value_2.copy({"name": "Another color"})
+        template.attribute_line_ids.value_ids = [(4, value_3.id)]
+        self.assertEqual(len(self.product_template.product_variant_ids), 3)
+        product_3 = self.product_template.product_variant_ids - (product_1 | product_2)
+        self.assertTrue(product_3.shop_only_quotation)

--- a/shopinvader_quotation/views/product_view.xml
+++ b/shopinvader_quotation/views/product_view.xml
@@ -9,7 +9,7 @@
                 <attribute name="invisible">0</attribute>
             </group>
             <group name="shopinvader_options" position="inside">
-                <field name="only_quotation" />
+                <field name="shop_only_quotation" string="Only for Quotation" />
             </group>
         </field>
     </record>


### PR DESCRIPTION
- Renamed to `shop_*` so it's limited to the shopinvader scope.
- Moved field to `product.product` so that the user has more control.