### PR TITLE
[14.0] [FIX] shopinvader_search_engine: Add missing channel queue job functions

### DIFF
--- a/shopinvader_search_engine/__manifest__.py
+++ b/shopinvader_search_engine/__manifest__.py
@@ -21,6 +21,7 @@
         "views/shopinvader_variant_view.xml",
         "views/shopinvader_category_view.xml",
         "data/ir_export_product.xml",
+        "data/queue_job_function_data.xml",
     ],
     "installable": True,
     "application": True,

--- a/shopinvader_search_engine/data/queue_job_function_data.xml
+++ b/shopinvader_search_engine/data/queue_job_function_data.xml
@@ -1,0 +1,68 @@
+<odoo noupdate="1">
+    <record
+        id="job_function_shopinvader_category_jobify_recompute_json"
+        model="queue.job.function"
+    >
+        <field name="model_id" ref="model_shopinvader_category" />
+        <field name="method">jobify_recompute_json</field>
+        <field
+            name="channel_id"
+            ref="connector_search_engine.channel_search_engine_recompute"
+        />
+    </record>
+    <record
+        id="job_function_shopinvader_category_recompute_json"
+        model="queue.job.function"
+    >
+        <field name="model_id" ref="model_shopinvader_category" />
+        <field name="method">recompute_json</field>
+        <field
+            name="channel_id"
+            ref="connector_search_engine.channel_search_engine_recompute"
+        />
+    </record>
+    <record
+        id="job_function_shopinvader_category_synchronize"
+        model="queue.job.function"
+    >
+        <field name="model_id" ref="model_shopinvader_category" />
+        <field name="method">synchronize</field>
+        <field
+            name="channel_id"
+            ref="connector_search_engine.channel_search_engine_synchronize"
+        />
+    </record>
+    <record
+        id="job_function_shopinvader_variant_jobify_recompute_json"
+        model="queue.job.function"
+    >
+        <field name="model_id" ref="model_shopinvader_variant" />
+        <field name="method">jobify_recompute_json</field>
+        <field
+            name="channel_id"
+            ref="connector_search_engine.channel_search_engine_recompute"
+        />
+    </record>
+    <record
+        id="job_function_shopinvader_variant_recompute_json"
+        model="queue.job.function"
+    >
+        <field name="model_id" ref="model_shopinvader_variant" />
+        <field name="method">recompute_json</field>
+        <field
+            name="channel_id"
+            ref="connector_search_engine.channel_search_engine_recompute"
+        />
+    </record>
+    <record
+        id="job_function_shopinvader_variant_synchronize"
+        model="queue.job.function"
+    >
+        <field name="model_id" ref="model_shopinvader_variant" />
+        <field name="method">synchronize</field>
+        <field
+            name="channel_id"
+            ref="connector_search_engine.channel_search_engine_synchronize"
+        />
+    </record>
+</odoo>


### PR DESCRIPTION
When `connector_search_engine` calls `with_delay` on shopinvader category and variant records, here for instance :

https://github.com/OCA/search-engine/blob/84fc1e36f00bea914c88b92d703811106c904125/connector_search_engine/models/se_binding.py#L112

the job runner tries to find channels with `<shopinvader.category>.*`, `<shopinvader.variant>.*` in their names but only `<se.binding>.*` has been registered leading to defaulting the channel name to `root`.

