### PR TITLE
[14.0][FIX+IMP] shopinvader_sale_profile

### DIFF
--- a/shopinvader_sale_profile/models/shopinvader_backend.py
+++ b/shopinvader_sale_profile/models/shopinvader_backend.py
@@ -73,4 +73,4 @@ class ShopinvaderBackend(models.Model):
 
     def _get_default_profile(self):
         self.ensure_one()
-        return self.sale_profile_ids.filtered("default")
+        return fields.first(self.sale_profile_ids.filtered("default"))

--- a/shopinvader_sale_profile/models/shopinvader_backend.py
+++ b/shopinvader_sale_profile/models/shopinvader_backend.py
@@ -1,9 +1,11 @@
 # Copyright 2018 Akretion (http://www.akretion.com).
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
-# @author Sébastien BEAU <sebastien.beau@akretion.com>
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
 # @author Simone Orsi <simahawk@gmail.com>
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from odoo import _, api, exceptions, fields, models
 
 
@@ -25,10 +27,10 @@ class ShopinvaderBackend(models.Model):
     @api.depends("use_sale_profile", "sale_profile_ids.default")
     def _compute_pricelist_id(self):
         for rec in self:
-            pricelist = rec._default_pricelist_id()
             if rec.use_sale_profile:
-                pricelist = rec._get_default_profile().pricelist_id
-            rec.pricelist_id = pricelist
+                rec.pricelist_id = rec._get_default_profile().pricelist_id
+            else:
+                rec.pricelist_id = rec._default_pricelist_id()
 
     def _compute_customer_default_role(self):
         for rec in self:

--- a/shopinvader_sale_profile/models/shopinvader_backend.py
+++ b/shopinvader_sale_profile/models/shopinvader_backend.py
@@ -72,4 +72,5 @@ class ShopinvaderBackend(models.Model):
         return default_profile.pricelist_id
 
     def _get_default_profile(self):
+        self.ensure_one()
         return self.sale_profile_ids.filtered("default")

--- a/shopinvader_sale_profile/models/shopinvader_backend.py
+++ b/shopinvader_sale_profile/models/shopinvader_backend.py
@@ -43,7 +43,7 @@ class ShopinvaderBackend(models.Model):
 
     @api.constrains("use_sale_profile", "pricelist_id")
     def _check_use_sale_profile(self):
-        if not self.pricelist_id and self.use_sale_profile:
+        if any(rec.use_sale_profile and not rec.pricelist_id for rec in self):
             raise exceptions.ValidationError(
                 _("You must have a default profile that provides a default pricelist.")
             )

--- a/shopinvader_sale_profile/models/shopinvader_backend.py
+++ b/shopinvader_sale_profile/models/shopinvader_backend.py
@@ -33,11 +33,13 @@ class ShopinvaderBackend(models.Model):
                 rec.pricelist_id = rec._default_pricelist_id()
 
     def _compute_customer_default_role(self):
-        for rec in self:
-            if rec.use_sale_profile:
-                rec.customer_default_role = rec._get_default_profile().code
-            else:
-                rec.customer_default_role = "default"
+        # Override. Get default role from default profile
+        # If the backend doesn't use_sale_profile, fallback to super()
+        using_sale_profile = self.filtered("use_sale_profile")
+        for rec in using_sale_profile:
+            rec.customer_default_role = rec._get_default_profile().code
+        other_records = self - using_sale_profile
+        super(ShopinvaderBackend, other_records)._compute_customer_default_role()
 
     @api.constrains("use_sale_profile", "pricelist_id")
     def _check_use_sale_profile(self):

--- a/shopinvader_sale_profile/models/shopinvader_partner.py
+++ b/shopinvader_sale_profile/models/shopinvader_partner.py
@@ -1,5 +1,6 @@
 # Copyright 2018 Akretion (http://www.akretion.com).
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com)
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # @author Iván Todorovich <ivan.todorovich@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
@@ -32,161 +33,102 @@ class ShopinvaderPartner(models.Model):
             return self.sale_profile_id.code
         return super()._get_role()
 
-    @api.depends(
-        "record_id.country_id",
-        "country_id",
-        "record_id.vat",
-        "vat",
-        "record_id.property_product_pricelist",
-        "property_product_pricelist",
-        "property_account_position_id",
-        "state_id",
-        "zip",
-        "backend_id.use_sale_profile",
-        "backend_id.sale_profile_ids",
-        "backend_id.company_id",
-    )
+    @api.model
+    def _compute_sale_profile_id_depends(self):
+        backend_fields = [
+            "backend_id.use_sale_profile",
+            "backend_id.sale_profile_ids",
+            "backend_id.company_id",
+        ]
+        # Using `_address_fields` gives us a lazy compatibility
+        # with modules like `base_address_city` or `base_location`
+        partner_address_fields = [
+            f"record_id.{fname}"
+            for fname in self.env["res.partner"]._address_fields()
+            if not fname.startswith("street")
+        ]
+        partner_fields = [
+            "record_id.vat",
+            "record_id.property_product_pricelist",
+            "record_id.property_account_position_id",
+        ]
+        return backend_fields + partner_address_fields + partner_fields
+
+    @api.depends(lambda self: self._compute_sale_profile_id_depends())
     def _compute_sale_profile_id(self):
-        """Compute function for the field sale_profile_id.
+        """Compute sale_profile_id"""
+        records = self.filtered("backend_id.use_sale_profile")
+        for company in records.company_id:
+            company_records = records.filtered(lambda rec: rec.company_id == company)
+            company_records = company_records.with_company(company)
+            for rec in company_records:
+                rec.sale_profile_id = rec._get_sale_profile()
+        # Records related to backends without use_sale_profile
+        (self - records).sale_profile_id = False
 
-        :return:
-        """
-        sale_profile_obj = self.env["shopinvader.sale.profile"]
-        # Only backends using profiles
-        backend_ids = (
-            self.mapped("backend_id")
-            .filtered(lambda b: b.use_sale_profile)
-            .with_prefetch(self._prefetch_ids)
-            .ids
+    def _get_fiscal_position(self):
+        """Get the partner's fiscal position"""
+        self.ensure_one()
+        return (
+            self.env["account.fiscal.position"]
+            .with_company(self.company_id)
+            .get_fiscal_position(self.record_id.id)
         )
-        partners = self.mapped("record_id")
-        pricelists = partners.mapped("property_product_pricelist")
-        default_sale_profiles = self._get_default_profiles(backend_ids)
-        # company_id field is mandatory so we don't have manage empty value
-        for company in self.mapped("backend_id.company_id"):
-            fposition_by_partner = self._get_fiscal_position_by_partner(
-                partners, company=company
-            )
-            # Get every fiscal position ids (without duplicates)
-            fposition_ids = list(set(fposition_by_partner.values()))
-            sale_profiles = self._get_sale_profiles(
-                backend_ids, pricelists, fposition_ids, company
-            )
-            shopinv_partners = self.filtered(
-                lambda p, c=company: p.backend_id.company_id.id == c.id
-            )
-            shopinv_partners = shopinv_partners.with_company(company)
-            for binding in shopinv_partners:
-                sale_profile = sale_profile_obj.browse()
-                # Only if the related backend use sale profiles
-                if binding.backend_id.use_sale_profile:
-                    partner = binding.record_id
-                    fposition_id = fposition_by_partner.get(partner.id, False)
-                    sale_profile = binding._sale_profile_with_backend(
-                        default_sale_profiles, fposition_id, sale_profiles
-                    )
-                binding.sale_profile_id = sale_profile
 
-    def _sale_profile_with_backend(
-        self, default_sale_profiles, fposition_id, sale_profiles
-    ):
-        """Get sale profile of current recordset.
+    def _get_sale_profile(self):
+        """Get the sale profile that matches this partner
 
-        Look it up based on default sale profiles given in parameters,
-        fiscal position id and every related profile of related backend
+        For better performance, set the company on the recordset before
+        calling this method, to avoid setting it record by record here.
 
-        :param default_sale_profiles: shopinvader.sale.profile recordset
-        :param fposition_id: int
-        :param sale_profiles: shopinvader.sale.profile recordset
-        :return: shopinvader.sale.profile recordset
+        The best match is selected according to the following preference:
+
+            1) profiles matching both fiscal_position_ids and pricelist_id
+            2) profiles without pricelist_id matching fiscal_position_ids
+            3) profiles without fiscal_position_ids matching pricelist_id
+            4) profiles without fiscal_position_ids nor pricelist_id
+            5) fallback to the backend's default sale profile
         """
         self.ensure_one()
-        sale_profile = self.env["shopinvader.sale.profile"].browse()
-        partner = self.record_id
-        backend = self.backend_id
-        if fposition_id:
-            # Get the sale profile using the fiscal position, pricelist,...
-            pricelist = partner.property_product_pricelist
-            sale_profile = sale_profiles.filtered(
-                lambda p, fpos=fposition_id, pl=pricelist, b=backend: fpos
-                in p.fiscal_position_ids.ids
-                and p.pricelist_id.id == pl.id
-                and p.backend_id.id == b.id
-            )
-            sale_profile = first(sale_profile.with_prefetch(self._prefetch_ids))
-        else:
-            pricelist = partner.property_product_pricelist
-            sale_profile = sale_profiles.filtered(
-                lambda p, pl=pricelist, b=backend: not p.fiscal_position_ids
-                and p.pricelist_id.id == pl.id
-                and p.backend_id.id == b.id
-            )
-            sale_profile = first(sale_profile.with_prefetch(self._prefetch_ids))
-        if not sale_profile:
-            # Get the default sale profile
-            sale_profile = default_sale_profiles.filtered(
-                lambda p, b=backend: p.backend_id.id == b.id
-            )
-            sale_profile = first(sale_profile.with_prefetch(self._prefetch_ids))
-            if not sale_profile:
-                message = (
-                    _("No default sale profile found for the backend" " %s")
-                    % self.backend_id.name
+        if self.env.company != self.company_id:
+            self = self.with_company(self.company_id)
+
+        fposition = self._get_fiscal_position()
+        pricelist = self.property_product_pricelist
+        profiles = self.backend_id.sale_profile_ids
+
+        pricelist_empty = profiles.filtered(lambda p: not p.pricelist_id)
+        pricelist_match = profiles.filtered(lambda p: pricelist == p.pricelist_id)
+        fposition_empty = profiles.filtered(lambda p: not p.fiscal_position_ids)
+        fposition_match = (
+            profiles.filtered(lambda p: fposition in p.fiscal_position_ids)
+            if fposition
+            else profiles.browse()
+        )
+
+        matches = False
+
+        # Case 1)
+        if fposition_match and pricelist_match:
+            matches = fposition_match & pricelist_match
+        # Case 2)
+        if not matches and fposition_match:
+            matches = fposition_match & pricelist_empty
+        # Case 3)
+        if not matches and pricelist_match:
+            matches = pricelist_match & fposition_empty
+        # Case 4)
+        if not matches:
+            matches = pricelist_empty & fposition_empty
+        # Case 5)
+        if not matches:
+            matches = self.backend_id._get_default_profile()
+            if not matches:
+                raise exceptions.UserError(
+                    _(
+                        "No default sale profile found for the backend %s",
+                        self.backend_id.name,
+                    )
                 )
-                raise exceptions.UserError(message)
-        return sale_profile
 
-    def _get_sale_profiles(self, backend_ids, pricelists, fposition_ids, company=False):
-        """Get sale profiles for given backends, fiscal positions, pricelists.
-
-        :param fposition_ids: list of int
-        :param backend_ids: list of int
-        :param pricelists: product.pricelist recordset
-        :param company: res.company recordset
-        :return: shopinvader.sale.profile recordset
-        """
-        sale_profile_obj = self.env["shopinvader.sale.profile"]
-        if company:
-            sale_profile_obj = sale_profile_obj.with_company(company)
-        domain = [
-            "|",
-            ("fiscal_position_ids", "in", fposition_ids),
-            ("fiscal_position_ids", "=", False),
-            ("pricelist_id", "in", pricelists.ids),
-            ("backend_id", "in", backend_ids),
-        ]
-        sale_profiles = sale_profile_obj.search(domain)
-        return sale_profiles
-
-    @api.model
-    def _get_default_profiles(self, backend_ids):
-        """Get every default profile for given backend IDS.
-
-        :param backend_ids: list of int
-        :return: shopinvader.sale.profile recordset
-        """
-        sale_profile_obj = self.env["shopinvader.sale.profile"]
-        domain_default_profiles = [
-            ("default", "=", True),
-            ("backend_id", "in", backend_ids),
-        ]
-        default_sale_profiles = sale_profile_obj.search(domain_default_profiles)
-        return default_sale_profiles
-
-    @api.model
-    def _get_fiscal_position_by_partner(self, partners, company=False):
-        """Get every fiscal position related to given partners.
-
-        :param partners: res.partner recordset
-        :param company_id: int
-        :return: account.fiscal.position recordset
-        """
-        fposition_obj = self.env["account.fiscal.position"]
-        if company:
-            fposition_obj = fposition_obj.with_company(company)
-        fposition_by_partner = {}
-        for partner in partners:
-            fpos = fposition_obj.get_fiscal_position(partner.id, delivery_id=partner.id)
-            if fpos:
-                fposition_by_partner[partner.id] = fpos.id
-        return fposition_by_partner
+        return first(matches.sorted())

--- a/shopinvader_sale_profile/models/shopinvader_partner.py
+++ b/shopinvader_sale_profile/models/shopinvader_partner.py
@@ -1,7 +1,9 @@
 # Copyright 2018 Akretion (http://www.akretion.com).
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from odoo import _, api, exceptions, fields, models
 from odoo.fields import first
 
@@ -26,10 +28,9 @@ class ShopinvaderPartner(models.Model):
 
     def _get_role(self):
         # Override to use the sale profile role/code when required
-        role = super()._get_role()
         if self.backend_id.use_sale_profile and self.sale_profile_id:
-            role = self.sale_profile_id.code
-        return role
+            return self.sale_profile_id.code
+        return super()._get_role()
 
     @api.depends(
         "record_id.country_id",

--- a/shopinvader_sale_profile/models/shopinvader_sale_profile.py
+++ b/shopinvader_sale_profile/models/shopinvader_sale_profile.py
@@ -2,6 +2,7 @@
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from odoo import _, api, exceptions, fields, models
 
 
@@ -13,7 +14,11 @@ class ShopinvaderSaleProfile(models.Model):
     _rec_name = "code"
 
     backend_id = fields.Many2one(
-        "shopinvader.backend", "Backend", required=True, index=True
+        "shopinvader.backend",
+        string="Backend",
+        required=True,
+        index=True,
+        ondelete="cascade",
     )
     pricelist_id = fields.Many2one(
         "product.pricelist",
@@ -36,11 +41,12 @@ class ShopinvaderSaleProfile(models.Model):
         "backend (only one default is authorized by backend)",
         index=True,
     )
+
     _sql_constraints = [
         (
             "constraint_unique_code",
             "unique(backend_id, code)",
-            _("Code must be unique per backend."),
+            "Code must be unique per backend.",
         )
     ]
 

--- a/shopinvader_sale_profile/models/shopinvader_variant.py
+++ b/shopinvader_sale_profile/models/shopinvader_variant.py
@@ -2,6 +2,7 @@
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from odoo import models
 from odoo.fields import first
 
@@ -10,11 +11,8 @@ class ShopinvaderVariant(models.Model):
     _inherit = "shopinvader.variant"
 
     def _get_all_price(self):
-        """Update prices with each sale profile of related backend
-
-        :return:
-        """
-        res = super(ShopinvaderVariant, self)._get_all_price()
+        # Override. Update prices with each sale profile of related backend
+        res = super()._get_all_price()
         for sale_profile in self.backend_id.sale_profile_ids:
             fposition = first(sale_profile.fiscal_position_ids)
             price = self._get_price(


### PR DESCRIPTION
Easier to review commit by commit I think

Motivation behind this was to solve an issue were in some cases the partner's `sale_profile_id` wasn't recomputed properly. I couldn't reproduce it with unit tests, but after the refactor it recomputes as expected. Hopefully, the compute is a bit easier to read too