### PR TITLE
[ADD] shopinvader_product_brand_tag

### DIFF
--- a/setup/shopinvader_product_brand_tag/odoo/addons/shopinvader_product_brand_tag
+++ b/setup/shopinvader_product_brand_tag/odoo/addons/shopinvader_product_brand_tag
@@ -1,0 +1,1 @@
+../../../../shopinvader_product_brand_tag

--- a/setup/shopinvader_product_brand_tag/setup.py
+++ b/setup/shopinvader_product_brand_tag/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopinvader_product_brand_tag/__init__.py
+++ b/shopinvader_product_brand_tag/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/shopinvader_product_brand_tag/__manifest__.py
+++ b/shopinvader_product_brand_tag/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Camptocamp SA
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Shopvinvader Product Brand Tag",
+    "summary": "Index Product Brand Tags in Shopinvader",
+    "version": "14.0.1.0.0",
+    "category": "e-Commerce",
+    "website": "https://github.com/shopinvader/odoo-shopinvader",
+    "author": "Camptocamp",
+    "license": "AGPL-3",
+    "depends": ["shopinvader_product_brand", "product_brand_tag"],
+    "data": [
+        "data/ir_export_product_brand.xml",
+        "data/ir_export_product.xml",
+    ],
+}

--- a/shopinvader_product_brand_tag/data/ir_export_product.xml
+++ b/shopinvader_product_brand_tag/data/ir_export_product.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Camptocamp (http://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@gmail.com>
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="ir_exp_shopinvader_variant_brand_tag_ids" model="ir.exports.line">
+        <field name="name">shopinvader_brand_id/serialized_tag_ids</field>
+        <field
+            name="target"
+        >shopinvader_brand_id:brand/serialized_tag_ids:tag_ids</field>
+        <field name="export_id" ref="shopinvader.ir_exp_shopinvader_variant" />
+    </record>
+
+</odoo>

--- a/shopinvader_product_brand_tag/data/ir_export_product_brand.xml
+++ b/shopinvader_product_brand_tag/data/ir_export_product_brand.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Camptocamp (http://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@gmail.com>
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="ir_exp_shopinvader_brand_tag_id" model="ir.exports.line">
+        <field name="name">tag_ids/id</field>
+        <field name="target">tag_ids:tags/id</field>
+        <field
+            name="export_id"
+            ref="shopinvader_product_brand.ir_exp_shopinvader_brand"
+        />
+    </record>
+
+    <record id="ir_exp_shopinvader_brand_tag_name" model="ir.exports.line">
+        <field name="name">tag_ids/name</field>
+        <field name="target">tag_ids:tags/name</field>
+        <field
+            name="export_id"
+            ref="shopinvader_product_brand.ir_exp_shopinvader_brand"
+        />
+    </record>
+
+</odoo>

--- a/shopinvader_product_brand_tag/models/__init__.py
+++ b/shopinvader_product_brand_tag/models/__init__.py
@@ -1,0 +1,1 @@
+from . import shopinvader_brand

--- a/shopinvader_product_brand_tag/models/shopinvader_brand.py
+++ b/shopinvader_product_brand_tag/models/shopinvader_brand.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Camptocamp (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+from odoo.addons.base_sparse_field.models.fields import Serialized
+
+
+class ShopinvaderBrand(models.Model):
+    _inherit = "shopinvader.brand"
+
+    serialized_tag_ids = Serialized(compute="_compute_serialized_tag_ids")
+
+    @api.depends("tag_ids")
+    def _compute_serialized_tag_ids(self):
+        for rec in self:
+            rec.serialized_tag_ids = rec.tag_ids.ids

--- a/shopinvader_product_brand_tag/readme/CONTRIBUTORS.rst
+++ b/shopinvader_product_brand_tag/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+     * Iván Todorovich <ivan.todorovich@camptocamp.com>

--- a/shopinvader_product_brand_tag/readme/DESCRIPTION.rst
+++ b/shopinvader_product_brand_tag/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+Index Product Brand Tags in Shopinvader.
+Tags are defined in OCA module `product_brand_tag`


### PR DESCRIPTION
Index Product Brand Tags in Shopinvader.

Tags are defined in OCA module `product_brand_tag`