### PR TITLE
[14.0][FIX] shopinvader_invoice number could be empty.

### DIFF
--- a/shopinvader_invoice/services/invoice.py
+++ b/shopinvader_invoice/services/invoice.py
@@ -76,7 +76,11 @@ class InvoiceService(Component):
                 "nullable": True,
             },
             "date_invoice": {"type": "string"},
-            "date_due": {"type": "string"},
+            "date_due": {
+                "type": "string",
+                "required": False,
+                "nullable": True,
+            },
             "amount_total": {"type": "float"},
             "amount_total_signed": {"type": "float"},
             "amount_tax": {"type": "float"},

--- a/shopinvader_invoice/services/invoice.py
+++ b/shopinvader_invoice/services/invoice.py
@@ -70,6 +70,11 @@ class InvoiceService(Component):
         invoice_schema = {
             "invoice_id": {"type": "integer"},
             "number": {"type": "string"},
+            "payment_reference": {
+                "type": "string",
+                "required": False,
+                "nullable": True,
+            },
             "date_invoice": {"type": "string"},
             "date_due": {"type": "string"},
             "amount_total": {"type": "float"},
@@ -109,7 +114,8 @@ class InvoiceService(Component):
         """
         to_parse = [
             "id:invoice_id",
-            "payment_reference:number",
+            "name:number",
+            "payment_reference",
             "invoice_date:date_invoice",
             "invoice_date_due:date_due",
             "amount_total",

--- a/shopinvader_invoice/tests/test_invoice_service.py
+++ b/shopinvader_invoice/tests/test_invoice_service.py
@@ -101,6 +101,23 @@ class TestInvoiceService(CommonInvoiceCase):
         self.assertTrue(data.get("number"))
         self.assertFalse(data.get("payment_reference"))
 
+    def test_get_invoice_no_date_due(self):
+        """
+        Test the get on an invoice without date_due ("date_due" into json result)
+        :return:
+        """
+        # Check first without invoice related to the partner
+        result = self.service.dispatch("search")
+        data = result.get("data", [])
+        self.assertFalse(data)
+        # Then create a invoice related to partner
+        invoice = self._confirm_and_invoice_sale(self.sale, payment=False)
+        self._make_payment(invoice)
+        invoice.write({"invoice_date_due": False})
+        result = self.service.dispatch("get", invoice.id)
+        data = result.get("data", [])
+        self.assertFalse(data.get("date_due"))
+
     def test_get_multi_invoice(self):
         """
         Test the get on a logged user.

--- a/shopinvader_invoice/tests/test_invoice_service.py
+++ b/shopinvader_invoice/tests/test_invoice_service.py
@@ -83,6 +83,24 @@ class TestInvoiceService(CommonInvoiceCase):
         self._check_data_content(data, invoice)
         return
 
+    def test_get_invoice_no_number(self):
+        """
+        Test the get on an invoice without payment_reference ("number" into json result)
+        :return:
+        """
+        # Check first without invoice related to the partner
+        result = self.service.dispatch("search")
+        data = result.get("data", [])
+        self.assertFalse(data)
+        # Then create a invoice related to partner
+        invoice = self._confirm_and_invoice_sale(self.sale, payment=False)
+        self._make_payment(invoice)
+        invoice.write({"payment_reference": False})
+        result = self.service.dispatch("get", invoice.id)
+        data = result.get("data", [])
+        self.assertTrue(data.get("number"))
+        self.assertFalse(data.get("payment_reference"))
+
     def test_get_multi_invoice(self):
         """
         Test the get on a logged user.


### PR DESCRIPTION
The number of json data should be the name and we should have a new json key about the payement reference