### PR TITLE
[14.0][FIX] shopinvader_delivery_carrier fix availability

### DIFF
--- a/shopinvader_delivery_carrier/models/delivery_carrier.py
+++ b/shopinvader_delivery_carrier/models/delivery_carrier.py
@@ -55,25 +55,19 @@ class DeliveryCarrier(models.Model):
         """
         return self.env.context.get("delivery_force_zip_code", "")
 
-    def available_carriers(self, contact):
-        """
-        Inherit the function to force some values on the given contact
-        (only in cache).
-        :param contact: res.partner recordset
-        :return: False or self
-        """
+    def _match_address(self, partner):
         country = self._get_country_from_context()
         zip_code = self._get_zip_from_context()
         if country or zip_code:
-            with self._simulate_delivery_cost(contact):
+            with self._simulate_delivery_cost(partner):
                 # Edit country and zip
                 # Even if some info are not provided, we have to fill them
                 # Ex: if the zip code is not provided, we have to do the
                 # simulation with an empty zip code on the partner. Because his
                 # current zip could be related to another country and simulate
                 # a wrong price.
-                contact.update({"country_id": country.id, "zip": zip_code})
-                result = super(DeliveryCarrier, self).available_carriers(contact)
+                partner.update({"country_id": country.id, "zip": zip_code})
+                result = super()._match_address(partner)
         else:
-            result = super(DeliveryCarrier, self).available_carriers(contact)
+            result = super()._match_address(partner)
         return result

--- a/shopinvader_delivery_carrier/models/sale.py
+++ b/shopinvader_delivery_carrier/models/sale.py
@@ -37,3 +37,15 @@ class SaleOrder(models.Model):
             if self.partner_id
             else carriers
         )
+
+    def _set_carrier_and_price(self, carrier_id):
+        wizard = (
+            self.env["choose.delivery.carrier"]
+            .with_context(
+                {"default_order_id": self.id, "default_carrier_id": carrier_id}
+            )
+            .create({})
+        )
+        wizard._onchange_carrier_id()
+        wizard.button_confirm()
+        return wizard.delivery_price

--- a/shopinvader_delivery_carrier/models/sale.py
+++ b/shopinvader_delivery_carrier/models/sale.py
@@ -38,6 +38,12 @@ class SaleOrder(models.Model):
             else carriers
         )
 
+    def _invader_available_carriers(self):
+        self.ensure_one()
+        return self.shopinvader_available_carrier_ids.sorted(
+            lambda c: c.rate_shipment(self).get("price", 0.0)
+        )
+
     def _set_carrier_and_price(self, carrier_id):
         wizard = (
             self.env["choose.delivery.carrier"]

--- a/shopinvader_delivery_carrier/services/cart.py
+++ b/shopinvader_delivery_carrier/services/cart.py
@@ -121,8 +121,7 @@ class CartService(Component):
     def _set_carrier(self, cart, carrier_id):
         if carrier_id not in cart.shopinvader_available_carrier_ids.ids:
             raise UserError(_("This delivery method is not available for you order"))
-        carrier = self.env["delivery.carrier"].browse(carrier_id)
-        cart.set_delivery_line(carrier, carrier.rate_shipment(cart).get("price", 0.0))
+        cart._set_carrier_and_price(carrier_id)
 
     def _unset_carrier(self, cart):
         cart._remove_delivery_line()

--- a/shopinvader_delivery_carrier/tests/test_carrier.py
+++ b/shopinvader_delivery_carrier/tests/test_carrier.py
@@ -208,10 +208,7 @@ class CarrierCase(CommonCarrierCase):
         partner = self.cart.partner_id
         partner.write({"country_id": french_country.id})
         # set carrier
-        self.cart.set_delivery_line(
-            self.poste_carrier,
-            self.poste_carrier.rate_shipment(self.cart).get("price", 0.0),
-        )
+        self.cart._set_carrier_and_price(self.poste_carrier.id)
         # Force load every fields
         self.cart.read()
         cart_values_before = self.cart._convert_to_write(self.cart._cache)

--- a/shopinvader_delivery_carrier/tests/test_delivery_carrier.py
+++ b/shopinvader_delivery_carrier/tests/test_delivery_carrier.py
@@ -127,7 +127,7 @@ class TestDeliveryCarrier(CommonCarrierCase):
             "size": 1,
             "data": [
                 {
-                    "price": 0.0,
+                    "price": 20.0,
                     "description": self.poste_carrier.description,
                     "id": self.poste_carrier.id,
                     "name": self.poste_carrier.name,


### PR DESCRIPTION
- Revert 2 commits who do not work at all.
- Apply a fix about delivery carriers availability to use `success` key
- Apply a fix to execute the forcing of country/zip at the correct place.

It's better to directly check availability on the `_match_address()` who is at a lower level.
https://github.com/odoo/odoo/blob/14.0/addons/delivery/models/delivery_carrier.py#L96