### PR TITLE
[13.0][IMP] shopinvader_product_variant_selector: multi_variation

### DIFF
--- a/shopinvader_product_variant_selector/models/shopinvader_variant.py
+++ b/shopinvader_product_variant_selector/models/shopinvader_variant.py
@@ -16,12 +16,13 @@ class ShopinvaderVariant(models.Model):
     # stock information
     # shopinvader_product_stock_variant_selector
     # should inherit this method
-    def _prepare_selector_value(self, variant, value):
+    def _prepare_selector_value(self, variant, value, multi_variation):
         return {
             "name": value.name,
             "sku": variant.default_code or "",
             "available": variant.active,
             "selected": variant == self,
+            "multi_variation": multi_variation,
         }
 
     def _get_matching_variant(self, values):
@@ -41,6 +42,7 @@ class ShopinvaderVariant(models.Model):
             lambda l: l.attribute_id == attribute
         ).value_ids
         for value in values:
+            multi_variation = False
             if value in self.attribute_value_ids:
                 variant = self
             else:
@@ -55,7 +57,11 @@ class ShopinvaderVariant(models.Model):
                     variant = self._get_matching_variant(
                         selected_values + value
                     )
-            res["values"].append(self._prepare_selector_value(variant, value))
+                    if variant:
+                        multi_variation = True
+            res["values"].append(
+                self._prepare_selector_value(variant, value, multi_variation)
+            )
 
         return res
 

--- a/shopinvader_product_variant_selector/tests/test_shopinvader_variant.py
+++ b/shopinvader_product_variant_selector/tests/test_shopinvader_variant.py
@@ -64,12 +64,14 @@ class ShopinvaderVariantCase(SavepointCase):
                     "values": [
                         {
                             "name": "Poster",
+                            "multi_variation": False,
                             "sku": "Poster",
                             "selected": True,
                             "available": True,
                         },
                         {
                             "name": "Wooden",
+                            "multi_variation": False,
                             "sku": "Wooden",
                             "selected": False,
                             "available": True,
@@ -90,12 +92,14 @@ class ShopinvaderVariantCase(SavepointCase):
                     "values": [
                         {
                             "name": "Poster",
+                            "multi_variation": False,
                             "sku": "Poster-White",
                             "selected": True,
                             "available": True,
                         },
                         {
                             "name": "Wooden",
+                            "multi_variation": False,
                             "sku": "Wooden-White",
                             "selected": False,
                             "available": True,
@@ -107,18 +111,21 @@ class ShopinvaderVariantCase(SavepointCase):
                     "values": [
                         {
                             "name": "White",
+                            "multi_variation": False,
                             "sku": "Poster-White",
                             "selected": True,
                             "available": True,
                         },
                         {
                             "name": "Black",
+                            "multi_variation": False,
                             "sku": "Poster-Black",
                             "selected": False,
                             "available": True,
                         },
                         {
                             "name": "Grey",
+                            "multi_variation": False,
                             "sku": "Poster-Grey",
                             "selected": False,
                             "available": True,
@@ -140,12 +147,14 @@ class ShopinvaderVariantCase(SavepointCase):
                     "values": [
                         {
                             "name": "Poster",
+                            "multi_variation": False,
                             "sku": "Poster-White",
                             "selected": True,
                             "available": True,
                         },
                         {
                             "name": "Wooden",
+                            "multi_variation": False,
                             "sku": "Wooden-White",
                             "selected": False,
                             "available": True,
@@ -157,18 +166,21 @@ class ShopinvaderVariantCase(SavepointCase):
                     "values": [
                         {
                             "name": "White",
+                            "multi_variation": False,
                             "sku": "Poster-White",
                             "selected": True,
                             "available": True,
                         },
                         {
                             "name": "Black",
+                            "multi_variation": False,
                             "sku": "",
                             "selected": False,
                             "available": False,
                         },
                         {
                             "name": "Grey",
+                            "multi_variation": False,
                             "sku": "Poster-Grey",
                             "selected": False,
                             "available": True,
@@ -189,12 +201,14 @@ class ShopinvaderVariantCase(SavepointCase):
                     "values": [
                         {
                             "name": "Poster",
+                            "multi_variation": False,
                             "sku": "Poster-White-70x50cm",
                             "selected": True,
                             "available": True,
                         },
                         {
                             "name": "Wooden",
+                            "multi_variation": False,
                             "sku": "Wooden-White-70x50cm",
                             "selected": False,
                             "available": True,
@@ -206,18 +220,21 @@ class ShopinvaderVariantCase(SavepointCase):
                     "values": [
                         {
                             "name": "White",
+                            "multi_variation": False,
                             "sku": "Poster-White-70x50cm",
                             "selected": True,
                             "available": True,
                         },
                         {
                             "name": "Black",
+                            "multi_variation": False,
                             "sku": "Poster-Black-70x50cm",
                             "selected": False,
                             "available": True,
                         },
                         {
                             "name": "Grey",
+                            "multi_variation": False,
                             "sku": "Poster-Grey-70x50cm",
                             "selected": False,
                             "available": True,
@@ -229,18 +246,21 @@ class ShopinvaderVariantCase(SavepointCase):
                     "values": [
                         {
                             "name": "45x30cm",
+                            "multi_variation": False,
                             "sku": "",
                             "selected": False,
                             "available": False,
                         },
                         {
                             "name": "70x50cm",
+                            "multi_variation": False,
                             "sku": "Poster-White-70x50cm",
                             "selected": True,
                             "available": True,
                         },
                         {
                             "name": "90x60cm",
+                            "multi_variation": False,
                             "sku": "Poster-White-90x60cm",
                             "selected": False,
                             "available": True,
@@ -274,12 +294,14 @@ class ShopinvaderVariantCase(SavepointCase):
                     "values": [
                         {
                             "name": "Poster",
+                            "multi_variation": False,
                             "sku": "Poster-White-70x50cm",
                             "selected": True,
                             "available": True,
                         },
                         {
                             "name": "Wooden",
+                            "multi_variation": True,
                             "sku": "Wooden-Black-45x30cm",
                             "selected": False,
                             "available": True,
@@ -291,18 +313,21 @@ class ShopinvaderVariantCase(SavepointCase):
                     "values": [
                         {
                             "name": "White",
+                            "multi_variation": False,
                             "sku": "Poster-White-70x50cm",
                             "selected": True,
                             "available": True,
                         },
                         {
                             "name": "Black",
+                            "multi_variation": True,
                             "sku": "Poster-Black-45x30cm",
                             "selected": False,
                             "available": True,
                         },
                         {
                             "name": "Grey",
+                            "multi_variation": False,
                             "sku": "Poster-Grey-70x50cm",
                             "selected": False,
                             "available": True,
@@ -314,18 +339,21 @@ class ShopinvaderVariantCase(SavepointCase):
                     "values": [
                         {
                             "name": "45x30cm",
+                            "multi_variation": False,
                             "sku": "",
                             "selected": False,
                             "available": False,
                         },
                         {
                             "name": "70x50cm",
+                            "multi_variation": False,
                             "sku": "Poster-White-70x50cm",
                             "selected": True,
                             "available": True,
                         },
                         {
                             "name": "90x60cm",
+                            "multi_variation": False,
                             "sku": "Poster-White-90x60cm",
                             "selected": False,
                             "available": True,


### PR DESCRIPTION
The goal of this PR is to achieve something similar to [amazon's feature](https://www.amazon.com/NOCCO-Carbonated-oriented-Caffeine-Flavored/dp/B07Y1VYP75/ref=sr_1_2?keywords=nocco+bcaa&qid=1636552304&sr=8-2)

multi_variation is a way to inform the customer that a combination does not exists and will need other attributes to change in order to satisfy his request.

I.e. considering the example given in the readme:

> Imagine a case where you have shoes with - 6 sizes: 15, 16, 17, 18, 19, 20 - 3 colors: Green, Red, Yellow
>
>and some exceptions: - Green is available in size: 18, 19 - Red is available in size: 15, 16, 17 - Yellow is available in size: 18, 19, 20

```
size : 15, 16, 17, [18], 19, 20
color : Green, (Red), [Yellow]

[] mean selected
() mean not available
```
In this case, size 16 is multi_variation=True, indicating that if you select size 16 not only the size will change but also the color since the shoes don't exist in Yellow 16.