### PR TITLE
[REF][14.0] shopinvader_multi_cart: Use typology

### DIFF
--- a/shopinvader_multi_cart/__init__.py
+++ b/shopinvader_multi_cart/__init__.py
@@ -1,1 +1,2 @@
+from . import models
 from . import services

--- a/shopinvader_multi_cart/__manifest__.py
+++ b/shopinvader_multi_cart/__manifest__.py
@@ -1,6 +1,6 @@
-# Copyright 2021 Camptocamp SA
-# @author Iván Todorovich <ivan.todorovich@gmail.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
     "name": "Shopinvader Multi-Cart",
@@ -10,5 +10,5 @@
     "author": "Camptocamp SA",
     "website": "https://github.com/shopinvader/odoo-shopinvader",
     "depends": ["shopinvader"],
-    "installable": True,
+    "data": ["views/sale_order.xml"],
 }

--- a/shopinvader_multi_cart/models/__init__.py
+++ b/shopinvader_multi_cart/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/shopinvader_multi_cart/models/sale_order.py
+++ b/shopinvader_multi_cart/models/sale_order.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    typology = fields.Selection(
+        selection_add=[("saved", "Saved Cart")],
+        ondelete={"saved": "cascade"},
+    )

--- a/shopinvader_multi_cart/readme/DESCRIPTION.rst
+++ b/shopinvader_multi_cart/readme/DESCRIPTION.rst
@@ -1,4 +1,9 @@
 This allows to manage multiple carts per user.
 
-It exposes a new service `carts` to fetch the user's carts, read them,
-select as current cart and/or delete them.
+It exposes a new service `carts` to fetch the user's saved carts, read them,
+delete them, or select any of them as the current cart.
+
+It also adds a new method `save` on the `cart` service, to store the current
+cart. It can later be accessed and eventually restored from the `carts` service.
+
+Saved carts are identified with the typology `saved`.

--- a/shopinvader_multi_cart/services/__init__.py
+++ b/shopinvader_multi_cart/services/__init__.py
@@ -1,1 +1,2 @@
+from . import cart
 from . import carts

--- a/shopinvader_multi_cart/services/cart.py
+++ b/shopinvader_multi_cart/services/cart.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.addons.component.core import Component
+
+
+class CartService(Component):
+    _inherit = "shopinvader.cart.service"
+
+    def save(self, **params):
+        """Saves the current cart"""
+        cart = self._get(create_if_not_found=False)
+        if not cart or not self._is_logged_in():
+            return {}
+        self._save(cart, **params)
+        return self._to_json(self.env["sale.order"].browse())
+
+    def _save(self, cart, **params):
+        """Saves the given cart"""
+        cart.typology = "saved"
+
+    def _validator_save(self):
+        return {}

--- a/shopinvader_multi_cart/tests/test_carts.py
+++ b/shopinvader_multi_cart/tests/test_carts.py
@@ -1,6 +1,6 @@
-# Copyright 2021 Camptocamp SA
-# @author Iván Todorovich <ivan.todorovich@gmail.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import MissingError
 
@@ -14,10 +14,11 @@ class CommonConnectedMultiCartCase(CommonConnectedCartCase):
         super().setUp(*args, **kwargs)
         # TODO: This should be done in setUpClass, but it needs
         # to be changed in shopinvader's CommonConnectedCartCase
-        # Link sale_order_1 to our partner
-        self.cart_2 = self.env.ref("shopinvader.sale_order_1")
-        self.cart_2.partner_id = self.partner
-        self.carts = self.cart | self.cart_2
+        self.saved_cart = self.cart.copy(
+            {
+                "typology": "saved",
+            }
+        )
         # rename service -> cart_service
         self.cart_service = self.service
         # multiple carts service
@@ -30,58 +31,85 @@ class CommonConnectedMultiCartCase(CommonConnectedCartCase):
         if "set_session" in response:
             self.shopinvader_session.update(response["set_session"])
 
+    def _search(self):
+        """Wrapper around `search` to return only cart_ids"""
+        res = self.service.dispatch("search")
+        cart_ids = list({cart["id"] for cart in res["data"]})
+        return cart_ids
+
+    def _select(self, cart_id):
+        """Wrapper around `select` that updates shopinvader_session"""
+        res = self.service.dispatch("select", cart_id)
+        self._update_shopinvader_session_from_response(res)
+        return res
+
+    def _delete(self, cart_id):
+        """Wrapper around `delete` that updates shopinvader_session"""
+        res = self.service.dispatch("delete", cart_id)
+        self._update_shopinvader_session_from_response(res)
+        return res
+
+    def _save(self):
+        """Wrapper around cart_service's `save` that updates shopinvader_session"""
+        res = self.cart_service.dispatch("save")
+        self._update_shopinvader_session_from_response(res)
+        return res
+
 
 class TestCarts(CommonConnectedMultiCartCase):
     def test_carts_search(self):
-        res = self.service.dispatch("search")
-        cart_ids = {cart["id"] for cart in res["data"]}
-        self.assertEqual(cart_ids, set(self.carts.ids))
+        self.assertEqual(self._search(), self.saved_cart.ids)
 
     def test_carts_search_unauthorized(self):
-        # cart_2 now belongs to another partner
-        self.cart_2.partner_id = self.env.ref("shopinvader.anonymous")
-        res = self.service.dispatch("search")
-        cart_ids = {cart["id"] for cart in res["data"]}
-        self.assertEqual(cart_ids, set(self.cart.ids))
+        # saved_cart now belongs to another partner
+        self.saved_cart.partner_id = self.env.ref("shopinvader.anonymous")
+        self.assertFalse(self._search())
 
     def test_carts_select(self):
-        self.assertEqual(self.cart_service.cart_id, self.cart.id)
-        res = self.service.dispatch("select", self.cart_2.id)
-        self._update_shopinvader_session_from_response(res)
+        self._select(self.saved_cart.id)
         self.assertEqual(
             self.cart_service.cart_id,
-            self.cart_2.id,
+            self.saved_cart.id,
             "Current cart should've been changed from session",
+        )
+        self.assertEqual(
+            self._search(), self.cart.ids, "The previous cart should've been saved"
         )
 
     def test_carts_select_unauthorized(self):
-        # cart_2 now belongs to another partner
-        self.cart_2.partner_id = self.env.ref("shopinvader.anonymous")
+        # saved_cart now belongs to another partner
+        self.saved_cart.partner_id = self.env.ref("shopinvader.anonymous")
         with self.assertRaises(MissingError):
-            self.service.dispatch("select", self.cart_2.id)
+            self._select(self.saved_cart.id)
+        self.assertEqual(
+            self.cart_service.cart_id,
+            self.cart.id,
+            "Current cart shouldn't have been changed from session",
+        )
 
     def test_carts_delete(self):
-        # Case 1: Delete secondary cart
-        res = self.service.dispatch("delete", self.cart_2.id)
-        self._update_shopinvader_session_from_response(res)
-        self.assertEqual(len(self.carts.exists()), 1, "Only one cart should be left")
+        self._delete(self.saved_cart.id)
+        self.assertFalse(self.saved_cart.exists())
         self.assertEqual(
             self.cart_service.cart_id,
             self.cart.id,
             "Current cart should remain unchanged from session",
         )
-        # Case 2: Delete the main cart
-        res = self.service.dispatch("delete", self.cart.id)
-        self._update_shopinvader_session_from_response(res)
-        self.assertEqual(len(self.carts.exists()), 0, "All carts removed")
-        self.assertEqual(
-            self.cart_service.cart_id,
-            0,
-            "Current cart should've been cleared from session",
-        )
 
     def test_carts_delete_unauthorized(self):
-        # cart_2 now belongs to another partner
-        self.cart_2.partner_id = self.env.ref("shopinvader.anonymous")
+        # saved_cart now belongs to another partner
+        self.saved_cart.partner_id = self.env.ref("shopinvader.anonymous")
         with self.assertRaises(MissingError):
-            self.service.dispatch("delete", self.cart_2.id)
+            self._delete(self.saved_cart.id)
+
+    def test_cart_save(self):
+        self._save()
+        self.assertFalse(
+            self.cart_service.cart_id,
+            "The cart should've been cleared from session",
+        )
+        self.assertIn(self.cart.id, self._search(), "The cart should've been saved")
+
+    def test_cart_save_without_cart(self):
+        self.cart.unlink()
+        self._save()  # nothing should happen

--- a/shopinvader_multi_cart/views/sale_order.xml
+++ b/shopinvader_multi_cart/views/sale_order.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="view_sales_order_filter" model="ir.ui.view">
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="shopinvader.view_sales_order_filter" />
+        <field name="arch" type="xml">
+            <filter name="shopinvader_cart" position="after">
+                <filter
+                    string="Shopinvader Saved Carts"
+                    name="shopinvader_saved"
+                    domain="[('typology', '=', 'saved')]"
+                />
+            </filter>
+        </field>
+    </record>
+
+    <record id="action_saved_carts" model="ir.actions.act_window">
+        <field name="name">Saved Carts</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">sale.order</field>
+        <field name="view_mode">tree,kanban,form,calendar,pivot,graph,activity</field>
+        <field name="view_id" ref="shopinvader.view_shop_quotation_tree" />
+        <field
+            name="search_view_id"
+            ref="sale.sale_order_view_search_inherit_quotation"
+        />
+        <field name="context">{"default_typology": "saved"}</field>
+        <field name="domain">[("typology", "=", "saved")]</field>
+    </record>
+
+    <menuitem
+        action="action_saved_carts"
+        id="menu_saved_cart"
+        parent="shopinvader.menu_shopinvader_orders"
+        sequence="11"
+    />
+
+</odoo>

--- a/shopinvader_multi_cart/views/sale_order.xml
+++ b/shopinvader_multi_cart/views/sale_order.xml
@@ -14,7 +14,7 @@
                 <filter
                     string="Shopinvader Saved Carts"
                     name="shopinvader_saved"
-                    domain="[('typology', '=', 'saved')]"
+                    domain="[('typology', '=', 'saved'), ('shopinvader_backend_id', '!=', False)]"
                 />
             </filter>
         </field>
@@ -31,7 +31,9 @@
             ref="sale.sale_order_view_search_inherit_quotation"
         />
         <field name="context">{"default_typology": "saved"}</field>
-        <field name="domain">[("typology", "=", "saved")]</field>
+        <field
+            name="domain"
+        >[("typology", "=", "saved"), ("shopinvader_backend_id", "!=", False)]</field>
     </record>
 
     <menuitem


### PR DESCRIPTION
Refactor `shopinvader_multi_cart` to make use of a new sale.order `typology`.
Without this, carts and stored carts where mixed and they weren't easily identified.
