### PR TITLE
[13.0][FIX] shopinvader: Sale Order UX 

### DIFF
--- a/shopinvader/views/sale_view.xml
+++ b/shopinvader/views/sale_view.xml
@@ -32,7 +32,7 @@
                 <filter
                     name="shopinvader_sale"
                     string="Shopinvader Orders"
-                    domain="[('typology', '=', 'sale')]"
+                    domain="[('typology', '=', 'sale'), ('shopinvader_backend_id','!=',False)]"
                 />
                 <separator />
             </filter>


### PR DESCRIPTION
It is not enough to use typology = sale on Shopinvader Order filter domain because this is set as default on any sale.order record (at least in v13)

Forcing Shopinvader Backend is set would work just fine

CC @ForgeFlow