### PR TITLE
[14.0][ADD] shopinvader_product_stock_forecast 📦 📈

### DIFF
--- a/setup/shopinvader_product_stock_forecast/odoo/addons/shopinvader_product_stock_forecast
+++ b/setup/shopinvader_product_stock_forecast/odoo/addons/shopinvader_product_stock_forecast
@@ -1,0 +1,1 @@
+../../../../shopinvader_product_stock_forecast

--- a/setup/shopinvader_product_stock_forecast/setup.py
+++ b/setup/shopinvader_product_stock_forecast/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopinvader_product_stock_forecast/__init__.py
+++ b/shopinvader_product_stock_forecast/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/shopinvader_product_stock_forecast/__manifest__.py
+++ b/shopinvader_product_stock_forecast/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Shopinvader Product Stock Forecast",
+    "summary": "Export Stock Forecast data along with product stocks.",
+    "version": "14.0.1.0.0",
+    "author": "Camptocamp SA",
+    "maintainers": ["ivantodorovich"],
+    "website": "https://github.com/shopinvader/odoo-shopinvader",
+    "license": "AGPL-3",
+    "category": "Shopinvader",
+    "depends": ["shopinvader_product_stock"],
+    "data": ["views/shopinvader_backend.xml"],
+}

--- a/shopinvader_product_stock_forecast/models/__init__.py
+++ b/shopinvader_product_stock_forecast/models/__init__.py
@@ -1,0 +1,2 @@
+from . import shopinvader_backend
+from . import shopinvader_variant

--- a/shopinvader_product_stock_forecast/models/shopinvader_backend.py
+++ b/shopinvader_product_stock_forecast/models/shopinvader_backend.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ShopinvaderBackend(models.Model):
+    _inherit = "shopinvader.backend"
+
+    product_stock_forecast = fields.Boolean(
+        string="Stock Forecast",
+        help="Index the list of stock planned operations.",
+    )
+    product_stock_forecast_horizon = fields.Integer(
+        string="Stock Forecast Horizon",
+        help="Maximum number of days in the future to forecast.\n"
+        "Set to 0 for unlimited forecasting.",
+    )
+    product_stock_field_name = fields.Char(
+        related="product_stock_field_id.name",
+        help="Technical field: Used only to display a warning on the view.",
+    )

--- a/shopinvader_product_stock_forecast/models/shopinvader_variant.py
+++ b/shopinvader_product_stock_forecast/models/shopinvader_variant.py
@@ -1,0 +1,115 @@
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from datetime import timedelta
+
+from psycopg2 import sql
+
+from odoo import fields, models
+
+
+class ShopinvaderVariant(models.Model):
+    _inherit = "shopinvader.variant"
+
+    def _prepare_stock_forecast_select(self):
+        return """
+            m.date AS date,
+            SUM(
+                CASE
+                WHEN whs.id IS NOT NULL AND whd.id IS NULL THEN -m.product_qty
+                WHEN whd.id IS NOT NULL AND whs.id IS NULL THEN m.product_qty
+                END
+            ) AS qty
+        """
+
+    def _prepare_stock_forecast_from(self):
+        return """
+            stock_move m
+            LEFT JOIN stock_location ls ON (ls.id=m.location_id)
+            LEFT JOIN stock_location ld ON (ld.id=m.location_dest_id)
+            LEFT JOIN stock_warehouse whs
+                ON ls.parent_path LIKE CONCAT('%%/', whs.view_location_id, '/%%')
+            LEFT JOIN stock_warehouse whd
+                ON ld.parent_path LIKE CONCAT('%%/', whd.view_location_id, '/%%')
+        """
+
+    def _prepare_stock_forecast_where_clause(self):
+        """Prepare the where and where params for the forecast query"""
+        where_clause = """
+            m.product_id = %s
+            AND m.state NOT IN ('cancel', 'draft', 'done')
+            AND (whs.id IS NOT NULL OR whd.id IS NOT NULL)
+            AND (whs.id IS NULL OR whd.id IS NULL OR whs.id != whd.id)
+        """
+        where_clause_params = [self.record_id.id]
+        # Warehouse
+        warehouse_ids = self.env.context.get("warehouse", [])
+        if warehouse_ids:
+            where_clause += """
+                AND (
+                    CASE
+                    WHEN whs.id IS NOT NULL AND whd.id IS NULL THEN whs.id
+                    WHEN whd.id IS NOT NULL AND whs.id IS NULL THEN whd.id
+                    END
+                ) IN %s
+            """
+            where_clause_params.append(tuple(warehouse_ids))
+        # Forecast Horizon
+        if self.backend_id.product_stock_forecast_horizon:
+            horizon = self.backend_id.product_stock_forecast_horizon
+            dt_end = fields.Datetime.now() + timedelta(days=horizon)
+            where_clause += "\nAND m.date <= %s"
+            where_clause_params.append(dt_end)
+        return where_clause, where_clause_params
+
+    def _prepare_stock_forecast_group_by(self):
+        return "m.date"
+
+    def _prepare_stock_forecast_order_by(self):
+        return "1 ASC"
+
+    def _prepare_stock_forecast_raw_data(self):
+        """Prepare the stock forecast raw data
+
+        :returns: list of dicts {date, qty}
+            date: date of the forecast move
+            qty: stock variation
+        """
+        query = sql.SQL(
+            """
+            SELECT {select}
+            FROM {from_clause}
+            WHERE {where_clause}
+            GROUP BY {group_by}
+            ORDER BY {order_by}
+            """
+        )
+        where_clause, params = self._prepare_stock_forecast_where_clause()
+        query = query.format(
+            select=sql.SQL(self._prepare_stock_forecast_select()),
+            from_clause=sql.SQL(self._prepare_stock_forecast_from()),
+            where_clause=sql.SQL(where_clause),
+            group_by=sql.SQL(self._prepare_stock_forecast_group_by()),
+            order_by=sql.SQL(self._prepare_stock_forecast_order_by()),
+        )
+        self.env["base"].flush()
+        self.env.cr.execute(query, params)
+        return self.env.cr.dictfetchall()
+
+    def _prepare_stock_forecast_data(self):
+        """Prepare the stock forecast data, ready to be serialized"""
+        data = self._prepare_stock_forecast_raw_data()
+        # Convert date to string, for it to be serializable
+        # TODO: Possibly use this encoder everywhere in shopinvader
+        # https://github.com/OCA/rest-framework/blob/e9bb95272/base_rest/http.py#L47
+        for row in data:
+            row["date"] = row["date"].isoformat()
+        return data
+
+    def _prepare_stock_data(self):
+        # OVERRIDE to add the stock forecast data
+        res = super()._prepare_stock_data()
+        if self.backend_id.product_stock_forecast:
+            res["forecast"] = self._prepare_stock_forecast_data()
+        return res

--- a/shopinvader_product_stock_forecast/readme/CONFIGURE.rst
+++ b/shopinvader_product_stock_forecast/readme/CONFIGURE.rst
@@ -1,0 +1,12 @@
+On the Shopinvader Backend, enable the **Stock Forecast**.
+
+Optionally, you can set a **Stock Forecast Horizon** in days to limit the
+number of days to forecast.
+
+.. warning::
+
+    The `shopinvader_product_stock` module will let you use a different field other than
+    `qty_available` to export the current stock.
+
+    The forecast may not make sense if you don't have the proper stock to start with, so
+    it's recommended not to use a different field there.

--- a/shopinvader_product_stock_forecast/readme/CONTRIBUTORS.rst
+++ b/shopinvader_product_stock_forecast/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+    * Iván Todorovich <ivan.todorovich@camptocamp.com>

--- a/shopinvader_product_stock_forecast/readme/DESCRIPTION.rst
+++ b/shopinvader_product_stock_forecast/readme/DESCRIPTION.rst
@@ -1,0 +1,25 @@
+This module exports the forecasted stock quantities for each product.
+This data can be used by the frontend to compute virtual stocks at any given date.
+
+The stock forecast data is a list of planned stock variations, like so:
+
+.. code-block:: python
+
+    [
+        {"date": "2021-12-01T08:00:00", "qty": 10},
+        {"date": "2021-12-02T10:00:00", "qty": -1},
+        {"date": "2021-12-03T15:00:00", "qty": -4},
+        {"date": "2021-12-04T11:00:00", "qty": 5},
+    ]
+
+
+This data can be used by aggregated and used by the frontend to compute the virtual
+stock of a product at any given date.
+
+For example, assuming the initial `qty_available` is `10`, and that today is
+`2021-12-01 00:00:00`, we can infer the following:
+
+* After `2021-12-01 08:00:00`, stock will be `20`
+* After `2021-12-02 10:00:00`, stock will be `19`
+* After `2021-12-03 15:00:00`, stock will be `15`
+* After `2021-12-04 11:00:00`, stock will be `20`

--- a/shopinvader_product_stock_forecast/readme/ROADMAP.rst
+++ b/shopinvader_product_stock_forecast/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+It may be a good idea to implement a `product_stock_forecast_interval` setting,
+to round and group forecasted lines.

--- a/shopinvader_product_stock_forecast/tests/__init__.py
+++ b/shopinvader_product_stock_forecast/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product

--- a/shopinvader_product_stock_forecast/tests/common.py
+++ b/shopinvader_product_stock_forecast/tests/common.py
@@ -1,0 +1,79 @@
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from datetime import datetime
+
+from freezegun import freeze_time
+
+from odoo import fields
+
+from odoo.addons.shopinvader_product_stock.tests.common import StockCommonCase
+
+
+def isoformat2odoo(datestr):
+    # replaces the fromisoformatm, not available in python 3.6
+    # in python >= 3.7 it could be done like this:
+    # return fields.Datetime.to_string(datetime.fromisoformat(datestr))
+    format_string = r"%Y-%m-%dT%H:%M:%S"
+    dt = datetime.strptime(datestr, format_string)
+    return fields.Datetime.to_string(dt)
+
+
+@freeze_time("2021-12-01 00:00:00")
+class StockForecastCommonCase(StockCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Differently than on super(), here we want to disable jobs delay
+        cls.env = cls.env(context=dict(cls.env.context, test_queue_job_no_delay=True))
+        # Prepare some stock.moves to forecast
+        cls.picking_type_out = cls.env.ref("stock.picking_type_out")
+        cls.loc_customers = cls.env.ref("stock.stock_location_customers")
+        # Make sure stock is always recomputed. If the state is "new", it"s ignored
+        cls.shopinvader_product = cls.product.shopinvader_bind_ids
+        cls.shopinvader_product.sync_state = "to_update"
+        cls.shopinvader_product.recompute_json()
+        # Enable Stock Forecast
+        cls.shopinvader_backend.product_stock_forecast = True
+
+    @classmethod
+    def _create_stock_moves(cls, moves_data, location=None, product=None):
+        if not location:
+            location = cls.loc_1
+        if not product:
+            product = cls.product
+
+        def prepare_out_vals():
+            return {
+                "picking_type_id": cls.picking_type_out.id,
+                "location_id": location.id,
+                "location_dest_id": cls.loc_customers.id,
+            }
+
+        def prepare_in_vals():
+            return {
+                "picking_type_id": cls.picking_type_in.id,
+                "location_id": cls.loc_supplier.id,
+                "location_dest_id": location.id,
+            }
+
+        def prepare_vals(data):
+            date, qty = data
+            vals = prepare_in_vals() if qty >= 0 else prepare_out_vals()
+            vals.update(
+                {
+                    "name": "Forecasted stock.move",
+                    "product_id": product.id,
+                    "product_uom": cls.product.uom_id.id,
+                    "product_uom_qty": abs(qty),
+                    "date": date,
+                }
+            )
+            return vals
+
+        vals_list = list(map(prepare_vals, moves_data))
+        return cls.env["stock.move"].create(vals_list)
+
+    def _to_moves_data(self, forecast_data):
+        return [(isoformat2odoo(d["date"]), d["qty"]) for d in forecast_data]

--- a/shopinvader_product_stock_forecast/tests/test_product.py
+++ b/shopinvader_product_stock_forecast/tests/test_product.py
@@ -1,0 +1,88 @@
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import tagged
+
+from .common import StockForecastCommonCase
+
+
+@tagged("post_install", "-at_install")
+class TestProductStockForecast(StockForecastCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Prepare some stock.moves to forecast
+        cls.moves_data = [
+            ("2021-12-01 06:00:00", 10),
+            ("2021-12-01 07:30:00", -5),
+            ("2021-12-01 08:00:00", 10),
+            ("2021-12-02 06:00:00", 20),
+            ("2021-12-02 10:30:00", -5),
+            ("2021-12-03 06:00:00", 20),
+            ("2021-12-04 10:30:00", -5),
+            ("2021-12-05 07:30:00", -10),
+        ]
+        cls._create_stock_moves(cls.moves_data)._action_confirm(merge=False)
+        # Prepare other moves in draft and cancel states, just to create some noise
+        cls._create_stock_moves([("2021-12-01 16:30:00", 9)])
+        cls._create_stock_moves([("2021-12-01 16:30:00", 2)])._action_cancel()
+
+    def test_stock_forecast_disabled(self):
+        self.shopinvader_backend.product_stock_forecast = False
+        self.shopinvader_product.invalidate_cache()
+        self.shopinvader_product.recompute_json()
+        self.assertNotIn("forecast", self.shopinvader_product.data["stock"]["global"])
+
+    def test_stock_forecast_simple(self):
+        self.shopinvader_product.invalidate_cache()
+        self.shopinvader_product.recompute_json()
+        forecast = self.shopinvader_product.data["stock"]["global"]["forecast"]
+        self.assertEqual(self._to_moves_data(forecast), self.moves_data)
+
+    def test_stock_forecast_horizon_1_days(self):
+        self.shopinvader_backend.product_stock_forecast_horizon = 1  # days
+        self.shopinvader_product.invalidate_cache()
+        self.shopinvader_product.recompute_json()
+        forecast = self.shopinvader_product.data["stock"]["global"]["forecast"]
+        expected = [
+            ("2021-12-01 06:00:00", 10),
+            ("2021-12-01 07:30:00", -5),
+            ("2021-12-01 08:00:00", 10),
+        ]
+        self.assertEqual(self._to_moves_data(forecast), expected)
+
+    def test_stock_forecast_horizon_2_days(self):
+        self.shopinvader_backend.product_stock_forecast_horizon = 2  # days
+        self.shopinvader_product.invalidate_cache()
+        self.shopinvader_product.recompute_json()
+        forecast = self.shopinvader_product.data["stock"]["global"]["forecast"]
+        expected = [
+            ("2021-12-01 06:00:00", 10),
+            ("2021-12-01 07:30:00", -5),
+            ("2021-12-01 08:00:00", 10),
+            ("2021-12-02 06:00:00", 20),
+            ("2021-12-02 10:30:00", -5),
+        ]
+        self.assertEqual(self._to_moves_data(forecast), expected)
+
+    def test_stock_forecast_order(self):
+        """Forecast should always be sorted"""
+        self._create_stock_moves([("2021-12-01 10:00:00", 10)])._action_confirm(
+            merge=False
+        )
+        self.shopinvader_product.invalidate_cache()
+        self.shopinvader_product.recompute_json()
+        forecast = self.shopinvader_product.data["stock"]["global"]["forecast"]
+        expected = [
+            ("2021-12-01 06:00:00", 10),
+            ("2021-12-01 07:30:00", -5),
+            ("2021-12-01 08:00:00", 10),
+            ("2021-12-01 10:00:00", 10),  # ⬅ new move
+            ("2021-12-02 06:00:00", 20),
+            ("2021-12-02 10:30:00", -5),
+            ("2021-12-03 06:00:00", 20),
+            ("2021-12-04 10:30:00", -5),
+            ("2021-12-05 07:30:00", -10),
+        ]
+        self.assertEqual(self._to_moves_data(forecast), expected)

--- a/shopinvader_product_stock_forecast/views/shopinvader_backend.xml
+++ b/shopinvader_product_stock_forecast/views/shopinvader_backend.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record model="ir.ui.view" id="se_backend_form_view">
+        <field name="model">shopinvader.backend</field>
+        <field name="inherit_id" ref="shopinvader_product_stock.se_backend_form_view" />
+        <field name="arch" type="xml">
+            <group name="stock" position="inside">
+                <field name="product_stock_forecast" />
+                <field name="product_stock_field_name" invisible="1" />
+                <div
+                    class="alert alert-danger"
+                    role="alert"
+                    colspan="4"
+                    attrs="{'invisible': ['|', ('product_stock_forecast', '=', False), ('product_stock_field_name', '=', 'qty_available')]}"
+                >
+                    <strong>Warning</strong>:
+                    The stock forecast is prepared to work best with <code
+                    >qty_available</code> as <strong>Product stock field</strong>.
+                    <br
+                    />The forecast data may not make sense otherwise. Use at your own risk.
+                </div>
+                <label
+                    for="product_stock_forecast_horizon"
+                    string="Forecast Horizon"
+                    attrs="{'invisible': [('product_stock_forecast', '=', False)]}"
+                />
+                <div
+                    name="product_stock_forecast_horizon"
+                    attrs="{'invisible': [('product_stock_forecast', '=', False)]}"
+                >
+                    <field name="product_stock_forecast_horizon" class="oe_inline" />
+                    <span class="ml-1">days</span>
+                </div>
+            </group>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module exports the forecasted stock quantities for each product.
This data can be used by the frontend to compute virtual stocks at any given date.

The stock forecast data is a list of planned stock variations, like so:

```py
    [
        {"date": "2021-12-01 08:00:00", "qty": 10},
        {"date": "2021-12-02 10:00:00", "qty": -1},
        {"date": "2021-12-03 15:00:00", "qty": -4},
        {"date": "2021-12-04 11:00:00", "qty": 5},
    ]
```

This data can be used by aggregated and used by the frontend to compute the virtual stock of a product at any given date.

For example, assuming the initial `qty_available` is `10` and that today is `2021-12-01 00:00:00`, we can infer the following:

* After `2021-12-01 08:00:00`, stock will be `20`
* After `2021-12-02 10:00:00`, stock will be `19`
* After `2021-12-03 15:00:00`, stock will be `15`
* After `2021-12-04 11:00:00`, stock will be `20`

