### PR TITLE
[FIX] shopinvader: easy expose model // swagger

### DIFF
--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -115,7 +115,7 @@ class BaseShopinvaderService(AbstractComponent):
 
     @property
     def _exposed_model(self):
-        return self.env[self._expose_model]
+        return self.env.get(self._expose_model)
 
     def _paginate_search(
         self, default_page=1, default_per_page=5, order=None, **params


### PR DESCRIPTION
This is related to https://github.com/shopinvader/odoo-shopinvader/pull/1181
The swagger ui fails with this:

![captura](https://user-images.githubusercontent.com/1914185/143904144-5d5fb15f-59a2-493b-98d8-1d692eda58a9.png)

<details>
<summary>Traceback</summary>

```python-traceback
Traceback (most recent call last):
  File "/odoo/src/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/odoo/src/odoo/http.py", line 807, in dispatch
    r = self._call_function(**self.params)
  File "/odoo/src/odoo/http.py", line 360, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/odoo/src/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/odoo/src/odoo/http.py", line 348, in checked_call
    result = self.endpoint(*a, **kw)
  File "/odoo/src/odoo/http.py", line 913, in __call__
    return self.method(*args, **kw)
  File "/odoo/src/odoo/http.py", line 532, in response_wrap
    response = f(*args, **kw)
  File "/odoo/external-src/rest-framework/base_rest/controllers/api_docs.py", line 42, in api
    default_auth=controller_class._default_auth
  File "/odoo/external-src/rest-framework/base_rest/components/service.py", line 187, in to_openapi
    api_spec.generate_paths()
  File "/odoo/external-src/rest-framework/base_rest/apispec/base_rest_service_apispec.py", line 72, in generate_paths
    for _name, method in inspect.getmembers(self._service, inspect.ismethod):
  File "/usr/lib/python3.7/inspect.py", line 341, in getmembers
    value = getattr(object, key)
  File "/odoo/external-src/odoo-shopinvader/shopinvader/services/service.py", line 118, in _exposed_model
    return self.env[self._expose_model]
  File "/odoo/src/odoo/api.py", line 473, in __getitem__
    return self.registry[model_name]._browse(self, (), ())
  File "/odoo/src/odoo/modules/registry.py", line 176, in __getitem__
    return self.models[model_name]
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/werkzeug/serving.py", line 306, in run_wsgi
    execute(self.server.app)
  File "/usr/local/lib/python3.7/dist-packages/werkzeug/serving.py", line 294, in execute
    application_iter = app(environ, start_response)
  File "/odoo/src/odoo/service/server.py", line 441, in app
    return self.app(e, s)
  File "/odoo/src/odoo/service/wsgi_server.py", line 113, in application
    return application_unproxied(environ, start_response)
  File "/odoo/src/odoo/service/wsgi_server.py", line 88, in application_unproxied
    result = odoo.http.root(environ, start_response)
  File "/odoo/src/odoo/http.py", line 1306, in __call__
    return self.dispatch(environ, start_response)
  File "/odoo/src/odoo/http.py", line 1272, in __call__
    return self.app(environ, start_wrapped)
  File "/usr/local/lib/python3.7/dist-packages/werkzeug/middleware/shared_data.py", line 220, in __call__
    return self.app(environ, start_response)
  File "/odoo/src/odoo/http.py", line 1479, in dispatch
    result = ir_http._dispatch()
  File "/odoo/src/addons/auth_signup/models/ir_http.py", line 19, in _dispatch
    return super(Http, cls)._dispatch()
  File "/odoo/external-src/odoo-cloud-platform/monitoring_statsd/models/ir_http.py", line 16, in _dispatch
    return super()._dispatch()
  File "/odoo/src/addons/web_editor/models/ir_http.py", line 21, in _dispatch
    return super(IrHttp, cls)._dispatch()
  File "/odoo/src/addons/utm/models/ir_http.py", line 29, in _dispatch
    response = super(IrHttp, cls)._dispatch()
  File "/odoo/src/addons/http_routing/models/ir_http.py", line 508, in _dispatch
    result = super(IrHttp, cls)._dispatch()
  File "/odoo/src/odoo/addons/base/models/ir_http.py", line 241, in _dispatch
    return cls._handle_exception(e)
  File "/odoo/src/addons/utm/models/ir_http.py", line 34, in _handle_exception
    response = super(IrHttp, cls)._handle_exception(exc)
  File "/odoo/src/addons/http_routing/models/ir_http.py", line 598, in _handle_exception
    return super(IrHttp, cls)._handle_exception(exception)
  File "/odoo/src/odoo/addons/base/models/ir_http.py", line 209, in _handle_exception
    return request._handle_exception(exception)
  File "/odoo/src/odoo/http.py", line 745, in _handle_exception
    return super(HttpRequest, self)._handle_exception(exception)
  File "/odoo/src/odoo/http.py", line 316, in _handle_exception
    raise exception.with_traceback(None) from new_cause
KeyError: None - - -
```
</details>