### PR TITLE
[14.0][ADD] Notification priority for notification job

### DIFF
--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -538,7 +538,13 @@ class ShopinvaderBackend(models.Model):
             record.id,
         )
         for notif in notifs:
-            notif.with_delay(description=description).send(record.id)
+            job_priority = notif.queue_job_priority
+            if job_priority < 0:
+                notif.send(record.id)
+            else:
+                notif.with_delay(description=description, priority=job_priority).send(
+                    record.id
+                )
         return True
 
     def _extract_configuration(self):

--- a/shopinvader/tests/common.py
+++ b/shopinvader/tests/common.py
@@ -349,3 +349,25 @@ class NotificationCaseMixin(object):
         for k, v in leafs.items():
             domain.append((k, "=", v))
         return self.env["queue.job"].search(domain, limit=1)
+
+    def _check_job_priority(self, job, notif_type=False, force_priority=False):
+        """
+        Ensure the job priority is correct
+        :param job: queue.job recordset
+        :param notif_type: str
+        :param force_priority: int
+        :return: bool
+        """
+        if isinstance(force_priority, bool):
+            notification = self.env["shopinvader.notification"].search(
+                [
+                    ("backend_id", "=", self.backend.id),
+                    ("notification_type", "=", notif_type),
+                ],
+                limit=1,
+            )
+            priority = notification.queue_job_priority
+        else:
+            priority = force_priority
+        self.assertEquals(priority, job.priority)
+        return True

--- a/shopinvader/tests/test_notification.py
+++ b/shopinvader/tests/test_notification.py
@@ -18,14 +18,22 @@ class NotificationCartCase(CommonCase, NotificationCaseMixin):
         self._init_job_counter()
         self.cart.action_confirm_cart()
         self._check_nbr_job_created(1)
+        self._check_job_priority(self.created_jobs, "cart_confirmation")
         self._perform_created_job()
         self._check_notification("cart_confirmation", self.cart)
 
     def test_sale_notification(self):
+        priority = 30
+        self.env["shopinvader.notification"].search([]).write(
+            {"queue_job_priority": priority}
+        )
         self.cart.action_confirm_cart()
         self._init_job_counter()
         self.cart.action_confirm()
         self._check_nbr_job_created(1)
+        self._check_job_priority(
+            self.created_jobs, "sale_confirmation", force_priority=priority
+        )
         self._perform_created_job()
         self._check_notification("sale_confirmation", self.cart)
 
@@ -38,6 +46,7 @@ class NotificationCartCase(CommonCase, NotificationCaseMixin):
         self._init_job_counter()
         self.cart.invoice_ids._post()
         self._check_nbr_job_created(1)
+        self._check_job_priority(self.created_jobs, "invoice_open")
         self._perform_created_job()
         self._check_notification("invoice_open", self.cart.invoice_ids[0])
 

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -154,6 +154,7 @@
                                             name="template_id"
                                             domain="[('model_id', '=', model_id)]"
                                         />
+                                        <field name="queue_job_priority" />
                                     </tree>
                                 </field>
                             </group>


### PR DESCRIPTION
Let the user define the priority on the notification for more flexibility.
This priority is applied on the job.
The user can also define a negative priority to disable the job and execute now the notification.

Code was partially into this PR: https://github.com/shopinvader/odoo-shopinvader/pull/843