### PR TITLE
[14.0][ADD] shopinvader_contact_address_default

### DIFF
--- a/setup/shopinvader_contact_address_default/odoo/addons/shopinvader_contact_address_default
+++ b/setup/shopinvader_contact_address_default/odoo/addons/shopinvader_contact_address_default
@@ -1,0 +1,1 @@
+../../../../shopinvader_contact_address_default

--- a/setup/shopinvader_contact_address_default/setup.py
+++ b/setup/shopinvader_contact_address_default/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopinvader_contact_address_default/__init__.py
+++ b/shopinvader_contact_address_default/__init__.py
@@ -1,0 +1,1 @@
+from . import services

--- a/shopinvader_contact_address_default/__manifest__.py
+++ b/shopinvader_contact_address_default/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Shopinvader Partner Contact Address Default",
+    "summary": "Integrates `partner_contact_address_default` with Shopinvader",
+    "version": "14.0.1.0.0",
+    "author": "Camptocamp SA",
+    "maintainers": ["ivantodorovich"],
+    "website": "https://github.com/shopinvader/odoo-shopinvader",
+    "license": "AGPL-3",
+    "category": "Others",
+    "depends": ["shopinvader", "partner_contact_address_default"],
+}

--- a/shopinvader_contact_address_default/readme/CONTRIBUTORS.rst
+++ b/shopinvader_contact_address_default/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+  * Iván Todorovich <ivan.todorovich@gmail.com>

--- a/shopinvader_contact_address_default/readme/DESCRIPTION.rst
+++ b/shopinvader_contact_address_default/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+Integrates OCA module `partner_contact_address_default` into shopinvader, to allow
+shopinvader users to set their preferred delivery and invoice addresses.

--- a/shopinvader_contact_address_default/services/__init__.py
+++ b/shopinvader_contact_address_default/services/__init__.py
@@ -1,0 +1,1 @@
+from . import address

--- a/shopinvader_contact_address_default/services/address.py
+++ b/shopinvader_contact_address_default/services/address.py
@@ -1,0 +1,39 @@
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from odoo.addons.base_rest.components.service import to_int
+from odoo.addons.component.core import Component
+
+
+class AddressService(Component):
+    _inherit = "shopinvader.address.service"
+
+    def _validator_create(self):
+        res = super()._validator_create()
+        res.update(
+            {
+                "partner_invoice_id": {
+                    "type": "integer",
+                    "required": False,
+                    "nullable": True,
+                    "coerce": to_int,
+                },
+                "partner_delivery_id": {
+                    "type": "integer",
+                    "required": False,
+                    "nullable": True,
+                    "coerce": to_int,
+                },
+            }
+        )
+        return res
+
+    def _json_parser(self):
+        res = super()._json_parser()
+        res += [
+            ("partner_invoice_id", ["id", "display_name"]),
+            ("partner_delivery_id", ["id", "display_name"]),
+        ]
+        return res

--- a/shopinvader_contact_address_default/tests/__init__.py
+++ b/shopinvader_contact_address_default/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_address

--- a/shopinvader_contact_address_default/tests/test_address.py
+++ b/shopinvader_contact_address_default/tests/test_address.py
@@ -1,0 +1,47 @@
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.addons.shopinvader.tests.test_address import CommonAddressCase
+
+
+class TestAddress(CommonAddressCase):
+    def test_address_create(self):
+        params = self.address_params.copy()
+        params.update(
+            {
+                "partner_invoice_id": self.address.id,
+                "partner_delivery_id": self.address_2.id,
+            }
+        )
+        self.address_service.dispatch("create", params=params)["data"]
+        partner = self.env["res.partner"].search([("name", "=", params["name"])])
+        self.assertEqual(partner.partner_invoice_id, self.address)
+        self.assertEqual(partner.partner_delivery_id, self.address_2)
+
+    def test_address_update(self):
+        params = {
+            "partner_invoice_id": self.address.id,
+            "partner_delivery_id": self.address_2.id,
+        }
+        self.address_service.dispatch("update", self.partner.id, params=params)["data"]
+        self.assertEqual(self.partner.partner_invoice_id, self.address)
+        self.assertEqual(self.partner.partner_delivery_id, self.address_2)
+
+    def test_address_update_clear(self):
+        self.partner.partner_invoice_id = self.address
+        self.partner.partner_delivery_id = self.address_2
+        params = {
+            "partner_invoice_id": False,
+            "partner_delivery_id": False,
+        }
+        self.address_service.dispatch("update", self.partner.id, params=params)["data"]
+        self.assertFalse(self.partner.partner_invoice_id)
+        self.assertFalse(self.partner.partner_delivery_id)
+
+    def test_address_read(self):
+        self.partner.partner_invoice_id = self.address
+        self.partner.partner_delivery_id = self.address_2
+        data = self.address_service.dispatch("get", self.partner.id)[0]
+        self.assertEqual(data["partner_invoice_id"]["id"], self.address.id)
+        self.assertEqual(data["partner_delivery_id"]["id"], self.address_2.id)


### PR DESCRIPTION
Integrates OCA module [partner_contact_address_default](https://github.com/OCA/partner-contact/tree/14.0/partner_contact_address_default) into shopinvader, to allow shopinvader users to set their preferred delivery and invoice addresses.
