### PR TITLE
[13.0][IMP] shopinvader_sale_profile: Do not use fiscal position on sale profile computation when fpos are not configured

### DIFF
--- a/shopinvader_sale_profile/models/shopinvader_partner.py
+++ b/shopinvader_sale_profile/models/shopinvader_partner.py
@@ -63,9 +63,12 @@ class ShopinvaderPartner(models.Model):
         default_sale_profiles = self._get_default_profiles(backend_ids)
         # company_id field is mandatory so we don't have manage empty value
         for company in self.mapped("backend_id.company_id"):
-            fposition_by_partner = self._get_fiscal_position_by_partner(
-                partners, company_id=company.id
-            )
+            fposition_by_partner = {}
+            # Don't trust on fiscal position if are not configured on sale profile
+            if self.mapped("backend_id.sale_profile_ids.fiscal_position_ids"):
+                fposition_by_partner = self._get_fiscal_position_by_partner(
+                    partners, company_id=company.id
+                )
             # Get every fiscal position ids (without duplicates)
             fposition_ids = list(set(fposition_by_partner.values()))
             sale_profiles = self._get_sale_profiles(


### PR DESCRIPTION
For my use case it is not preferable to use fiscal positions. Fix it is proposed just look if sale profiles are using fiscal position, then it has the same behavior as previously, if no fiscal position are set, we don't get it from partners trusting on Pricelist set on partner level.

CC @ForgeFlow 