### PR TITLE
shopinvader.variant._get_shop_data: bypass permission check

### DIFF
--- a/shopinvader/models/shopinvader_variant.py
+++ b/shopinvader/models/shopinvader_variant.py
@@ -323,5 +323,5 @@ class ShopinvaderVariant(models.Model):
 
     def _get_shop_data(self):
         """Compute shop data base_jsonify parser."""
-        exporter = self.env.ref("shopinvader.ir_exp_shopinvader_variant")
+        exporter = self.env.ref("shopinvader.ir_exp_shopinvader_variant").sudo()
         return self.jsonify(exporter.get_json_parser(), one=True)


### PR DESCRIPTION
Is not relevant to check permissions on the parser.
No matter which users ask for product data
we should always be able to load the parser.