### PR TITLE
[14.0][IMP] shopinvader_sale_profile: Do not use fiscal position on sale profile computation when fpos are not configured

### DIFF
--- a/shopinvader_sale_profile/models/shopinvader_partner.py
+++ b/shopinvader_sale_profile/models/shopinvader_partner.py
@@ -63,9 +63,12 @@ class ShopinvaderPartner(models.Model):
         default_sale_profiles = self._get_default_profiles(backend_ids)
         # company_id field is mandatory so we don't have manage empty value
         for company in self.mapped("backend_id.company_id"):
-            fposition_by_partner = self._get_fiscal_position_by_partner(
-                partners, company=company
-            )
+            fposition_by_partner = {}
+            # Don't trust on fiscal position if are not configured on sale profile
+            if self.mapped("backend_id.sale_profile_ids.fiscal_position_ids"):
+                fposition_by_partner = self._get_fiscal_position_by_partner(
+                    partners, company=company
+                )
             # Get every fiscal position ids (without duplicates)
             fposition_ids = list(set(fposition_by_partner.values()))
             sale_profiles = self._get_sale_profiles(

--- a/shopinvader_sale_profile/tests/test_shopinvader_backend_sale_profile.py
+++ b/shopinvader_sale_profile/tests/test_shopinvader_backend_sale_profile.py
@@ -86,3 +86,29 @@ class TestShopinvaderBackendSaleProfile(CommonCase):
                 self.backend._get_cart_pricelist(partner),
                 expected,
             )
+
+    def test_get_pricelist_partner_no_fpos_configured(self):
+        self.backend.write({"use_sale_profile": True})
+        profile1 = self.env.ref("shopinvader_sale_profile.shopinvader_sale_profile_1")
+        profile2 = self.env.ref("shopinvader_sale_profile.shopinvader_sale_profile_2")
+        profile3 = self.env.ref("shopinvader_sale_profile.shopinvader_sale_profile_3")
+        profile1.default = True
+        profile2.default = False
+        profile3.default = False
+        # Partner from France
+        partner = self.env.ref("shopinvader.partner_1")
+        invader_partner = partner._get_invader_partner(self.backend)
+        # Set USD Pricelist
+        partner_pricelist = self.env.ref("shopinvader.pricelist_1")
+        partner.property_product_pricelist = partner_pricelist.id
+        fpos_pricelist = profile1.pricelist_id
+        # Recompute sale profile from invader partner
+        invader_partner._compute_sale_profile_id()
+        self.assertEqual(self.backend._get_cart_pricelist(partner), fpos_pricelist)
+        # Drop fpos from demo profiles
+        profile1.fiscal_position_ids = False
+        profile2.fiscal_position_ids = False
+        profile3.fiscal_position_ids = False
+        # Recompute sale profile from invader partner
+        invader_partner._compute_sale_profile_id()
+        self.assertEqual(self.backend._get_cart_pricelist(partner), partner_pricelist)


### PR DESCRIPTION
Port https://github.com/shopinvader/odoo-shopinvader/pull/1204

CC @simahawk @ForgeFlow 