### PR TITLE
s_image: ensure images' URL recompute

### DIFF
--- a/shopinvader_image/tests/test_images.py
+++ b/shopinvader_image/tests/test_images.py
@@ -61,3 +61,13 @@ class TestShopinvaderImage(TestShopinvaderImageCase):
             # recomputed
             self.assertEqual(variant.images, [{"c": 3, "d": 4}])
             mocked.assert_called()
+
+        # Simulate base URL change
+        self.assertFalse(variant._images_must_recompute())
+        random_image = variant.variant_image_ids[0].image_id
+        # test backend serves images via odoo base url
+        self.env["ir.config_parameter"].sudo().set_param(
+            "web.base.url", "https://foo.com"
+        )
+        random_image.invalidate_cache()
+        self.assertTrue(variant._images_must_recompute())

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
+openupgradelib
 # TODO these should be on PyPI
-openupgradelib @ git+https://github.com/OCA/openupgradelib.git
 locomotivecms @ git+https://github.com/akretion/locomotivecms-python-client.git
 # test requirements
 requests_mock


### PR DESCRIPTION
Images' data are stored on s.variant.
If the backend URL changes they should be recomputed
otherwise you might have broken URLs client side.

Additionally, this solves the problem of the url_key
which might be generated in different ways and not only w/ display_name.