### PR TITLE
[14.0][FIX] shopinvader_auth_jwt: default_auth for jwt

### DIFF
--- a/shopinvader_auth_jwt/controllers/main.py
+++ b/shopinvader_auth_jwt/controllers/main.py
@@ -8,7 +8,7 @@ class InvaderController(main.RestController):
 
     _root_path = "/shopinvader_jwt/"
     _collection_name = "shopinvader.backend"
-    _default_auth = "jwt_shopinvader"
+    _default_auth = "jwt"
     _default_save_session = False
     _default_cors = True
     _component_context_provider = "shopinvader_auth_jwt_context_provider"


### PR DESCRIPTION
default_auth should be jwt otherwise it do not work out of the box.

If default_auth is called, it should end to :    `def _auth_method_jwt(cls, validator_name=None):`
https://github.com/OCA/server-auth/blob/14.0/auth_jwt/models/ir_http.py#L57

BTW, align with shopinvader_auth_api_key (default_auth=api_key)
https://github.com/shopinvader/odoo-shopinvader/blob/14.0/shopinvader_auth_api_key/controllers/main.py#L11

