### PR TITLE
[13.0][FIX] shopinvader_product_stock: Syncronize stock only on active bindings

### DIFF
--- a/shopinvader_product_stock/models/product_product.py
+++ b/shopinvader_product_stock/models/product_product.py
@@ -24,7 +24,7 @@ class ProductProduct(models.Model):
         backends = all_bindinds.mapped("backend_id")
         for backend in backends:
             bindings = all_bindinds.filtered(
-                lambda r, b=backend: r.backend_id == b
+                lambda r, b=backend: r.backend_id == b and r.active
             )
             # To avoid access rights issues, execute the job with the user
             # related to the backend


### PR DESCRIPTION
Restrict synchronize stock level to active shopinvader variants

CC @ForgeFlow  