### PR TITLE
[14.0][FIX] duplicate labels

### DIFF
--- a/shopinvader/models/shopinvader_variant.py
+++ b/shopinvader/models/shopinvader_variant.py
@@ -37,7 +37,7 @@ class ShopinvaderVariant(models.Model):
         check_company=True,
     )
     record_id = fields.Many2one(
-        string="Product",
+        string="Related Product",
         comodel_name="product.product",
         required=True,
         ondelete="cascade",


### PR DESCRIPTION
Rename label because of duplicate labels in shopinvader.variant (product_variant_id and record_id) to avoid warning and duplicate filters in search view.
