### PR TITLE
[FIX] shopinvader: adding products to a confirmed cart

### DIFF
--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -406,6 +406,8 @@ class ConnectedCartCase(CommonConnectedCartCase, CartClearTest):
         cart_bis = self.service._get()
         self.assertEqual(cart, cart_bis)
         cart.write({"state": "sale"})
+        cart_bis = self.service._get(create_if_not_found=False)
+        self.assertFalse(cart_bis)
         cart_bis = self.service._get()
         self.assertNotEqual(cart, cart_bis)
         self.assertEqual(cart_bis.typology, "cart")


### PR DESCRIPTION
**Steps to reproduce:**

1. Create a new cart and add items
2. Confirm the SO
3. Add items again using the same cart_id

**Result:**
- Items are added to a confirmed SO (not a cart anymore)

**Expected:**
- New cart should've been created

---

This happened because [add_item is calling `_get` with `create_if_not_found=False`, and then explicitly creating a new cart if it wasn't found](https://github.com/shopinvader/odoo-shopinvader/blob/2b572c65e2323a986fa2172b41c4d9a38d1fecbd/shopinvader/services/cart.py#L48-L51).

However [a bug in `_get`](https://github.com/shopinvader/odoo-shopinvader/blob/2b572c65e2323a986fa2172b41c4d9a38d1fecbd/shopinvader/services/cart.py#L450) skipped the cart robustness checks when create_if_not_found is False.