### PR TITLE
[14.0][IMP] shopinvader_customer_multi_user(_company_group)

### DIFF
--- a/shopinvader_customer_multi_user/tests/common.py
+++ b/shopinvader_customer_multi_user/tests/common.py
@@ -2,7 +2,9 @@
 # @author Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from functools import partial
 from os import urandom
+from textwrap import dedent
 
 from odoo.addons.shopinvader.tests.test_customer import TestCustomerCommon
 
@@ -11,59 +13,62 @@ class TestMultiUserCommon(TestCustomerCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.company_binding = cls._create_partner(
-            cls.env, invader_user_token="ABCDEF", is_company=True
+        cls.company, cls.company_binding = cls._create_partner_and_binding(
+            name="ACME Ltd", invader_user_token="ABCDEF", is_company=True
         )
-        cls.company = cls.company_binding.record_id
-        cls.user_binding = cls._create_partner(
-            cls.env,
+        cls.user, cls.user_binding = cls._create_partner_and_binding(
             name="Simple user",
             parent_id=cls.company.id,
-            external_id="simple-user",
-            email="simpleuser@test.com",
         )
-        # Create 2 more users so that we have
-        # 1 company user with 3 simple users
-        # and user 3 is a child of user 2.
-        cls.user_binding2 = cls._create_partner(
-            cls.env,
+        # Create 2 more users so that we have 1 company user with 3 simple
+        # users and user 3 is a child of user 2.
+        #
+        #      ┌─ Company ─┐
+        #      │           │
+        #      ▼           ▼
+        #    User        User2
+        #                  │
+        #                  ▼
+        #                User3
+        #
+        cls.user2, cls.user2_binding = cls._create_partner_and_binding(
             name="Simple user 2",
             parent_id=cls.company.id,
-            external_id="simple-user-2",
-            email="simpleuser2@test.com",
         )
-        cls.user_binding3 = cls._create_partner(
-            cls.env,
+        cls.user3, cls.user3_binding = cls._create_partner_and_binding(
             name="Simple user 3",
-            parent_id=cls.user_binding2.record_id.id,
-            main_partner_id=cls.user_binding2.record_id.id,
-            external_id="simple-user-3",
-            email="simpleuser3@test.com",
+            parent_id=cls.user2.id,
+            main_partner_id=cls.user2.id,
         )
+        # Configure backend
         cls.backend.multi_user_records_policy = "record_id"
         cls.backend.customer_multi_user = True
 
-    @staticmethod
-    def _get_random_hash():
-        """
-        returns a positive integer from hashing 4 random bytes
-        """
-        return abs(hash(urandom(4)))
+    @classmethod
+    def _create_partner_binding(cls, **vals):
+        """Creates a shopinvader.partner"""
+        assert "name" in vals, "name is required"
+        if "backend_id" not in vals:
+            vals["backend_id"] = cls.backend.id
+        if "external_id" not in vals:
+            vals["external_id"] = vals["name"].lower().replace(" ", "-")
+            vals["external_id"] += str(abs(hash(urandom(4))))
+        if "ref" not in vals:
+            vals["ref"] = "#%s" % vals["external_id"].upper()
+        if "email" not in vals:
+            vals["email"] = "%s@example.com" % vals["external_id"]
+        return cls.env["shopinvader.partner"].create(vals)
 
-    @staticmethod
-    def _create_partner(env, **kw):
-        values = {
-            "backend_id": env.ref("shopinvader.backend_1").id,
-            "name": "ACME ltd",
-            "external_id": "acme",
-            "email": "company@test.com",
-            "ref": "#ACME",
-        }
-        values.update(kw)
-        values["external_id"] = values["external_id"] + str(
-            TestMultiUserCommon._get_random_hash()
-        )
-        return env["shopinvader.partner"].create(values)
+    @classmethod
+    def _create_partner(cls, **vals):
+        """Creates a shopinvader.partner, returns the related res.partner"""
+        return cls._create_partner_binding(**vals).record_id
+
+    @classmethod
+    def _create_partner_and_binding(cls, **vals):
+        """Creates a shopinvader.partner, returns both binding and res.partner"""
+        binding = cls._create_partner_binding(**vals)
+        return binding.record_id, binding
 
     def _get_service(self, partner, usage="users"):
         with self.work_on_services(
@@ -95,8 +100,8 @@ class TestUserManagementCommmon(TestMultiUserCommon):
             ],
         )
 
-    def _test_create(self, service, params, expected_parent=None):
-        partner = expected_parent or service.partner_user
+    def _test_create(self, service, params, parent=None):
+        partner = parent or service.partner_user
         count_before = len(partner.child_ids)
         res = service.dispatch("create", params=params)["data"]
         self.assertEqual(len(partner.child_ids), count_before + 1)
@@ -112,3 +117,212 @@ class TestUserManagementCommmon(TestMultiUserCommon):
         )
         self.assertEqual(res, expected)
         return invader_partner
+
+
+class TestMultiUserPartnerDomainCommon(TestMultiUserCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Quick shortcuts
+        cls.all_companies = cls.company
+        cls.all_users = cls.user + cls.user2 + cls.user3
+        cls.all_partners = cls.all_companies + cls.all_users
+        # Create Sale Orders and Invoices for each partner
+        cls.all_orders = cls._create_sales_and_invoices(cls.all_partners)
+        cls.all_invoices = cls.all_orders.invoice_ids
+        # Create Private and Public addresses for each partner
+        cls.all_public_addresses, cls.all_private_addresses = cls._create_addresses(
+            cls.all_partners
+        )
+        cls.all_addresses = cls.all_public_addresses + cls.all_private_addresses
+
+    @classmethod
+    def _create_sales_and_invoices(cls, partners, invoice=True):
+        base_sale_order = cls.env.ref("shopinvader.sale_order_2")
+        sales = cls.env["sale.order"]
+        for partner in partners:
+            sale = base_sale_order.copy({"partner_id": partner.id})
+            sale.action_confirm()
+            if invoice:
+                for line in sale.order_line:
+                    line.write({"qty_delivered": line.product_uom_qty})
+                sale._create_invoices()
+            sales += sale
+        return sales
+
+    @classmethod
+    def _create_addresses(cls, partners, public=True, private=True):
+        """Creates both public and private addresses for partners
+
+        :param public: if True, create public addresses
+        :param private: if True, create private addresses
+        :return: a tuple of public and private addresses
+        """
+        res_public = cls.env["res.partner"]
+        res_private = cls.env["res.partner"]
+        for partner in partners:
+            if public:
+                res_public += cls.env["res.partner"].create(
+                    {
+                        "name": f"{partner.name} (Public Address)",
+                        "parent_id": partner.id,
+                        "type": "delivery",
+                        "invader_address_share_policy": "public",
+                    }
+                )
+            if private:
+                res_private += cls.env["res.partner"].create(
+                    {
+                        "name": f"{partner.name} (Private Address)",
+                        "parent_id": partner.id,
+                        "type": "delivery",
+                        "invader_address_share_policy": "private",
+                    }
+                )
+        return res_public, res_private
+
+    @classmethod
+    def _get_addresses(cls, partners, policy=None):
+        """Return partner direct children addresses
+
+        :param policy: Optional. Either 'public' or 'private' or None
+        """
+        addresses = partners.child_ids.filtered(
+            lambda rec: not rec.shopinvader_bind_ids
+        )
+        if policy:
+            addresses = addresses.filtered(
+                lambda rec: rec.invader_address_share_policy == policy
+            )
+        return addresses
+
+    def _partner_diff_message(self, partner, expected, found, display_format=None):
+        """Build a beautiful human readable recordset diff message
+
+        :param partner: the partner we're testing
+        :param expected: the expected result recordset
+        :param found: the found result recordset
+        :param display_format: the format to use to print each record (optional)
+        """
+
+        def mapper(record, compare=None):
+            mark = " "
+            if compare:
+                mark = " " if record in compare else "✗"
+            if display_format:
+                record_format = display_format
+            else:
+                record_format = "({rec.id}) {rec.display_name}"
+                if record._name != "res.partner" and "partner_id" in record._fields:
+                    record_format += (
+                        " | ({rec.partner_id.id}) {rec.partner_id.display_name}"
+                    )
+            return f"{mark} {record_format.format(rec=record)}"
+
+        def records2str(records, compare=None):
+            return "\n".join(records.mapped(partial(mapper, compare=compare)))
+
+        return dedent(
+            """
+            For partner:
+            > {partner}
+
+            Expected:
+            {expected}
+
+            Found:
+            {found}
+            """
+        ).format(
+            partner=f"({partner.id}) {partner.display_name}",
+            expected=records2str(expected, compare=found),
+            found=records2str(found, compare=expected),
+        )
+
+    def _get_service(self, partner, usage):
+        with self.work_on_services(
+            partner=partner.get_shop_partner(self.backend),
+            partner_user=partner,
+            shopinvader_session=self.shopinvader_session,
+        ) as work:
+            return work.component(usage=usage)
+
+    def _test_address(self, partner, expected):
+        service = self._get_service(partner, "addresses")
+        res = service.search(per_page=100)
+        res_ids = [x["id"] for x in res["data"]]
+        found = self.env[expected._name].browse(res_ids).sorted(key="id")
+        expected = expected.sorted(key="id")
+        self.assertEqual(
+            found.ids,
+            expected.ids,
+            self._partner_diff_message(partner, expected, found),
+        )
+
+    def _test_sale(self, partner, expected):
+        service = self._get_service(partner, "sales")
+        res = service.search(per_page=1000)
+        res_ids = [x["id"] for x in res["data"]]
+        found = self.env[expected._name].browse(res_ids).sorted(key="id")
+        expected = expected.sorted(key="id")
+        self.assertEqual(
+            found.ids,
+            expected.ids,
+            self._partner_diff_message(partner, expected, found),
+        )
+
+    def _test_invoice(self, partner, expected):
+        service = self._get_service(partner, "invoice")
+        found = service._get_available_invoices().sorted(key="id")
+        expected = expected.sorted(key="id")
+        self.assertEqual(
+            found.ids,
+            expected.ids,
+            self._partner_diff_message(partner, expected, found),
+        )
+
+    def _test_partner_records(
+        self, partner, addresses=None, orders=None, invoices=None
+    ):
+        """Test everything for a partner
+
+        :param partner: res.partner to test
+        :param addresses: expected addresses recordset
+        :param orders: expected sales orders recordset
+        :param invoices: expected invoices recordset
+        """
+        if addresses is not None:
+            self._test_address(partner, addresses)
+        if orders is not None:
+            self._test_sale(partner, orders)
+        if invoices is not None:
+            self._test_invoice(partner, invoices)
+        elif orders:
+            self._test_invoice(partner, orders.invoice_ids)
+
+    def _test_user_direct_child_of_company__record_id(self, partner):
+        """Helper to check company direct children users (record_id)"""
+        self._test_partner_records(
+            partner,
+            addresses=partner + self._get_addresses(partner),
+            orders=self.all_orders.filtered(lambda x: x.partner_id == partner),
+            invoices=self.all_orders.filtered(
+                lambda x: x.partner_id == partner
+            ).invoice_ids,
+        )
+
+    def _test_user_direct_child_of_company__parent_id(
+        self, partner, parent_partners, expected_addresses=None
+    ):
+        """Helper to check company direct children users (parent_id)"""
+        expected_addresses = expected_addresses or partner + parent_partners
+        expected_sales = self.all_orders.filtered(
+            lambda x: x.partner_id in (partner | parent_partners)
+        )
+        expected_invoices = expected_sales.invoice_ids
+        self._test_partner_records(
+            partner,
+            addresses=expected_addresses,
+            orders=expected_sales,
+            invoices=expected_invoices,
+        )

--- a/shopinvader_customer_multi_user/tests/test_multi_user_management.py
+++ b/shopinvader_customer_multi_user/tests/test_multi_user_management.py
@@ -10,14 +10,14 @@ from .common import TestUserManagementCommmon
 class TestUserManagement(TestUserManagementCommmon):
     def test_search_as_admin(self):
         service = self._get_service(self.company)
-        expected = self.user_binding2 + self.user_binding3 + self.user_binding
+        expected = self.user2_binding + self.user3_binding + self.user_binding
         self._test_search(service, expected)
 
     def test_search_as_simpleuser(self):
         for binding in (
             self.user_binding,
-            self.user_binding2,
-            self.user_binding3,
+            self.user2_binding,
+            self.user3_binding,
         ):
             service = self._get_service(binding.record_id)
             with self.assertRaisesRegex(exceptions.AccessError, "User not allowed"):
@@ -34,8 +34,8 @@ class TestUserManagement(TestUserManagementCommmon):
     def test_create_as_simpleuser(self):
         for binding in (
             self.user_binding,
-            self.user_binding2,
-            self.user_binding3,
+            self.user2_binding,
+            self.user3_binding,
         ):
             service = self._get_service(binding.record_id)
             params = {
@@ -59,8 +59,8 @@ class TestUserManagement(TestUserManagementCommmon):
     def test_update_as_simpleuser(self):
         for binding in (
             self.user_binding,
-            self.user_binding2,
-            self.user_binding3,
+            self.user2_binding,
+            self.user3_binding,
         ):
             service = self._get_service(binding.record_id)
             params = {
@@ -71,29 +71,29 @@ class TestUserManagement(TestUserManagementCommmon):
 
     def test_delete_as_admin(self):
         service = self._get_service(self.company)
-        child_partner2 = self.user_binding2.record_id
+        child_partner2 = self.user2_binding.record_id
         # Delete its user
-        service.dispatch("delete", self.user_binding2.id)
+        service.dispatch("delete", self.user2_binding.id)
         # The binding is gone
-        self.assertFalse(self.user_binding2.exists())
+        self.assertFalse(self.user2_binding.exists())
         # BUT since its partner had another user it won't be touched
         self.assertTrue(child_partner2.active)
         # Let's delete the other user
-        child_partner3 = self.user_binding3.record_id
-        service.dispatch("delete", self.user_binding3.id)
-        self.assertFalse(self.user_binding3.exists())
+        child_partner3 = self.user3_binding.record_id
+        service.dispatch("delete", self.user3_binding.id)
+        self.assertFalse(self.user3_binding.exists())
         # Now its partner is archived
         self.assertFalse(child_partner3.active)
 
     def test_delete_as_simpleuser(self):
         for binding in (
             self.user_binding,
-            self.user_binding2,
-            self.user_binding3,
+            self.user2_binding,
+            self.user3_binding,
         ):
             service = self._get_service(binding.record_id)
             with self.assertRaisesRegex(exceptions.AccessError, "User not allowed"):
-                service.dispatch("delete", self.user_binding2.id)
+                service.dispatch("delete", self.user2_binding.id)
 
 
 class TestUserManagementDelegateManage(TestUserManagementCommmon):
@@ -101,7 +101,7 @@ class TestUserManagementDelegateManage(TestUserManagementCommmon):
     def setUpClass(cls):
         super().setUpClass()
         cls.user_binding.can_manage_users = True
-        cls.user_binding2.can_manage_users = True
+        cls.user2_binding.can_manage_users = True
 
     # Test delegated permission: manage users
 
@@ -109,13 +109,13 @@ class TestUserManagementDelegateManage(TestUserManagementCommmon):
         # This user has no sub users, no result
         binding = self.user_binding
         service = self._get_service(binding.record_id)
-        expected = self.user_binding2.browse()
+        expected = self.user2_binding.browse()
         self._test_search(service, expected)
 
         # This user has a sub user, should find it
-        binding = self.user_binding2
+        binding = self.user2_binding
         service = self._get_service(binding.record_id)
-        expected = self.user_binding3
+        expected = self.user3_binding
         self._test_search(service, expected)
 
     def test_create_as_simpleuser_delegate_manage_users(self):
@@ -133,17 +133,17 @@ class TestUserManagementDelegateManage(TestUserManagementCommmon):
     def test_delete_as_simpleuser_delegate_manage_users(self):
         binding = self.user_binding
         service = self._get_service(binding.record_id)
-        child_partner2 = self.user_binding2.record_id
+        child_partner2 = self.user2_binding.record_id
         # Delete a user that does not belong to him
         with self.assertRaises(exceptions.MissingError):
-            service.dispatch("delete", self.user_binding2.id)
+            service.dispatch("delete", self.user2_binding.id)
 
         # Try to delete its sub user instead
-        binding = self.user_binding2
+        binding = self.user2_binding
         service = self._get_service(binding.record_id)
-        child_partner3 = self.user_binding3.record_id
-        service.dispatch("delete", self.user_binding3.id)
-        self.assertFalse(self.user_binding3.exists())
+        child_partner3 = self.user3_binding.record_id
+        service.dispatch("delete", self.user3_binding.id)
+        self.assertFalse(self.user3_binding.exists())
         # BUT since its partner had another user it won't be touched
         self.assertTrue(child_partner2.active)
         self.assertFalse(child_partner3.active)

--- a/shopinvader_customer_multi_user/tests/test_multi_user_partner.py
+++ b/shopinvader_customer_multi_user/tests/test_multi_user_partner.py
@@ -101,12 +101,9 @@ class TestMultiUserPartner(TestMultiUserCommon):
         self.assertEqual(new_binding.main_partner_id, custom_partner)
 
         # on create
-        new_binding2 = self._create_partner(
-            self.env,
-            parent_id=self.company.id,
+        new_binding2 = self._create_partner_binding(
             name="New Binding 2",
-            email="new2@test.com",
+            parent_id=self.company.id,
             main_partner_id=custom_partner.id,
-            external_id="new-binding-2",
         )
         self.assertEqual(new_binding2.main_partner_id, custom_partner)

--- a/shopinvader_customer_multi_user/tests/test_multi_user_service_partner_domain.py
+++ b/shopinvader_customer_multi_user/tests/test_multi_user_service_partner_domain.py
@@ -2,241 +2,58 @@
 # @author Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from .common import TestMultiUserCommon
+from .common import TestMultiUserPartnerDomainCommon
 
 
-class TestMultiUserServicePartnerDomain(TestMultiUserCommon):
+class TestMultiUserServicePartnerDomain(TestMultiUserPartnerDomainCommon):
     """Test partner domains for services"""
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        # Enable multi-user
-        cls.backend.customer_multi_user = True
-        cls.all_bindings = cls.user_binding + cls.user_binding2 + cls.user_binding3
-        # Create sale orders per each partner
-        cls.sale_company = cls.env.ref("shopinvader.sale_order_2").copy(
-            {"partner_id": cls.company.id}
-        )
-        cls.sale_user1 = cls.sale_company.copy(
-            {"partner_id": cls.user_binding.record_id.id}
-        )
-        cls.sale_user2 = cls.sale_company.copy(
-            {"partner_id": cls.user_binding2.record_id.id}
-        )
-        cls.sale_user3 = cls.sale_company.copy(
-            {"partner_id": cls.user_binding3.record_id.id}
-        )
-        cls.all_orders = (
-            cls.sale_company + cls.sale_user1 + cls.sale_user2 + cls.sale_user3
-        )
-        # Create invoices per each order/partner
-        cls.all_invoices = cls.env["account.move"].browse()
-        for sale in cls.all_orders:
-            sale.action_confirm()
-            for line in sale.order_line:
-                line.write({"qty_delivered": line.product_uom_qty})
-            cls.all_invoices |= sale._create_invoices()
-
-        # Create address per each partner
-        ResPartner = cls.env["res.partner"]
-        cls.address_company = ResPartner.create(
-            {
-                "name": "Delivery Address Company",
-                "parent_id": cls.company.id,
-                "type": "delivery",
-                "invader_address_share_policy": "public",
-            }
-        )
-        cls.address_user1_public = ResPartner.create(
-            {
-                "name": "Delivery Address User 1 (public)",
-                "parent_id": cls.user_binding.record_id.id,
-                "type": "delivery",
-                "invader_address_share_policy": "public",
-            }
-        )
-        cls.address_user1_private = ResPartner.create(
-            {
-                "name": "Delivery Address User 1 (private)",
-                "parent_id": cls.user_binding.record_id.id,
-                "type": "delivery",
-                "invader_address_share_policy": "private",
-            }
-        )
-        cls.address_user2_public = ResPartner.create(
-            {
-                "name": "Delivery Address User 2 (public)",
-                "parent_id": cls.user_binding2.record_id.id,
-                "type": "delivery",
-                "invader_address_share_policy": "public",
-            }
-        )
-        cls.address_user2_private = ResPartner.create(
-            {
-                "name": "Delivery Address User 2 (private)",
-                "parent_id": cls.user_binding2.record_id.id,
-                "type": "delivery",
-                "invader_address_share_policy": "private",
-            }
-        )
-        cls.address_user3_public = ResPartner.create(
-            {
-                "name": "Delivery Address User 3 (public)",
-                "parent_id": cls.user_binding3.record_id.id,
-                "type": "delivery",
-                "invader_address_share_policy": "public",
-            }
-        )
-        cls.address_user3_private = ResPartner.create(
-            {
-                "name": "Delivery Address User 3 (private)",
-                "parent_id": cls.user_binding3.record_id.id,
-                "type": "delivery",
-                "invader_address_share_policy": "private",
-            }
-        )
-        cls.all_addresses = (
-            cls.address_company
-            + cls.address_user1_public
-            + cls.address_user1_private
-            + cls.address_user2_public
-            + cls.address_user2_private
-            + cls.address_user3_public
-            + cls.address_user3_private
-        )
-        cls.all_public_addresses = cls.all_addresses.filtered(
-            lambda r: r.invader_address_share_policy == "public"
-        )
-        cls.all_private_addresses = cls.all_addresses - cls.all_public_addresses
-
-    def _get_service(self, partner, usage):
-        with self.work_on_services(
-            partner=partner.get_shop_partner(self.backend),
-            partner_user=partner,
-            shopinvader_session=self.shopinvader_session,
-        ) as work:
-            return work.component(usage=usage)
-
-    def _test_address(self, partner, expected):
-        service = self._get_service(partner, "addresses")
-        res = service.search(per_page=100)
-        expected = expected.sorted(key="id")
-        found = sorted(res["data"], key=lambda x: x["id"])
-        self.assertEqual(
-            [x["id"] for x in found],
-            expected.ids,
-            """
-            For partner:
-                {partner.name}
-            Expected:
-                {expected}
-            Found:
-                {found}
-            """.format(
-                partner=partner,
-                expected=("\n" + " " * 16).join(
-                    ["%s (%d)" % (x.name, x.id) for x in expected]
-                ),
-                found=("\n" + " " * 16).join(
-                    ["%s (%d)" % (x["name"], x["id"]) for x in found]
-                ),
-            ),
-        )
-
-    def _test_sale(self, partner, expected):
-        service = self._get_service(partner, "sales")
-        res = service.search()
-        self.assertEqual(
-            sorted([x["id"] for x in res["data"]]),
-            sorted(expected.ids),
-        )
-
-    def _test_invoice(self, partner, expected):
-        service = self._get_service(partner, "invoice")
-        res = service._get_available_invoices()
-        self.assertEqual(sorted(res.ids), sorted(expected.ids))
 
     # Company can see always everything
     def test_user_company__record_id(self):
-        partner = self.company
-        self._test_address(
-            partner,
-            partner + self.all_addresses + self.all_bindings.mapped("record_id"),
+        self._test_partner_records(
+            self.company,
+            addresses=self.all_partners + self.all_addresses,
+            orders=self.all_orders,
+            invoices=self.all_invoices,
         )
-        self._test_sale(partner, self.all_orders)
-        self._test_invoice(partner, self.all_invoices)
 
     def test_user_company__parent_id(self):
         self.backend.multi_user_records_policy = "parent_id"
-        partner = self.company
-        self._test_address(
-            partner,
-            partner + self.all_addresses + self.all_bindings.mapped("record_id"),
+        self._test_partner_records(
+            self.company,
+            addresses=self.all_partners + self.all_addresses,
+            orders=self.all_orders,
+            invoices=self.all_invoices,
         )
-        self._test_sale(partner, self.all_orders)
-        self._test_invoice(partner, self.all_invoices)
 
     def test_user_company__main_partner_id(self):
         self.backend.multi_user_records_policy = "main_partner_id"
-        partner = self.company
-        self._test_address(
-            partner,
-            partner + self.all_addresses + self.all_bindings.mapped("record_id"),
-        )
-        self._test_sale(partner, self.all_orders)
-        self._test_invoice(partner, self.all_invoices)
-
-    def _test_user_direct_child_of_company__record_id(self, partner):
-        self._test_address(
-            partner,
-            partner + partner.child_ids.filtered(lambda x: not x.shopinvader_bind_ids),
-        )
-        self._test_sale(
-            partner,
-            self.all_orders.filtered(lambda x: x.partner_id == partner),
-        )
-        self._test_invoice(
-            partner,
-            self.all_orders.filtered(lambda x: x.partner_id == partner).mapped(
-                "invoice_ids"
-            ),
+        self._test_partner_records(
+            self.company,
+            addresses=self.all_partners + self.all_addresses,
+            orders=self.all_orders,
+            invoices=self.all_invoices,
         )
 
     def test_user_direct_child_of_company__record_id(self):
         """Direct child sees only its own records."""
         # For this test, consider all addresses as private
         self.all_public_addresses.write({"invader_address_share_policy": "private"})
-        partner = self.user_binding.record_id
-        self._test_user_direct_child_of_company__record_id(partner)
-        partner = self.user_binding2.record_id
-        self._test_user_direct_child_of_company__record_id(partner)
-        partner = self.user_binding3.record_id
-        self._test_user_direct_child_of_company__record_id(partner)
-
-    def _test_user_direct_child_of_company__parent_id(
-        self, partner, parent_partners, expected_addresses=None
-    ):
-        expected_addresses = expected_addresses or partner + parent_partners
-        expected_sales = self.all_orders.filtered(
-            lambda x: x.partner_id in partner + parent_partners
-        )
-        expected_invoices = expected_sales.mapped("invoice_ids")
-        self._test_address(partner, expected_addresses)
-        self._test_sale(partner, expected_sales)
-        self._test_invoice(partner, expected_invoices)
+        self._test_user_direct_child_of_company__record_id(self.user)
+        self._test_user_direct_child_of_company__record_id(self.user2)
+        self._test_user_direct_child_of_company__record_id(self.user3)
 
     def test_user_direct_child_of_company__parent_id(self):
         """Direct child sees only its own records and the ones from direct parent."""
         self.backend.multi_user_records_policy = "parent_id"
         # Case 1: User 1 sees only its own records, the ones from its direct parent,
         # and the publicly shared ones from their sibilings
-        partner = self.user_binding.record_id
+        partner = self.user
         expected_addresses = (
             partner
             | self.company
-            | self.address_company
-            | self.address_user1_private
+            | self._get_addresses(self.company, policy="public")
+            | self._get_addresses(self.user, policy="private")
             | self.all_public_addresses
         )
         self._test_user_direct_child_of_company__parent_id(
@@ -244,12 +61,12 @@ class TestMultiUserServicePartnerDomain(TestMultiUserCommon):
         )
         # Case 2: User 2 sees only its own records, the ones from its direct parent,
         # and the publicly shared ones from their sibilings
-        partner = self.user_binding2.record_id
+        partner = self.user2
         expected_addresses = (
             partner
             | self.company
-            | self.address_company
-            | self.address_user2_private
+            | self._get_addresses(self.company, policy="public")
+            | self._get_addresses(self.user2, policy="private")
             | self.all_public_addresses
         )
         self._test_user_direct_child_of_company__parent_id(
@@ -257,28 +74,29 @@ class TestMultiUserServicePartnerDomain(TestMultiUserCommon):
         )
         # Case 3: User 3 sees only its own records, the ones from its direct parent,
         # and the publicly shared ones from their sibilings
-        partner = self.user_binding3.record_id
+        partner = self.user3
         expected_addresses = (
             partner
-            | self.user_binding2.record_id
-            | self.address_user3_private
-            | self.address_user3_public
-            | self.address_user2_public
+            | self.user2
+            | self._get_addresses(self.user3)
+            | self._get_addresses(self.user2, policy="public")
         )
         self._test_user_direct_child_of_company__parent_id(
             partner,
-            self.user_binding2.record_id,
+            self.user2,
             expected_addresses=expected_addresses,
         )
         # Case 4: main partner is the parent in this case
         # but if we set the company, then they can see records from the company as well
-        self.user_binding3.main_partner_id = self.company
+        self.user3_binding.main_partner_id = self.company
         expected_addresses |= (
-            self.company | self.address_company | self.all_public_addresses
+            self.company
+            | self._get_addresses(self.company, policy="public")
+            | self.all_public_addresses
         )
         self._test_user_direct_child_of_company__parent_id(
             partner,
-            self.company + self.user_binding2.record_id,
+            self.company + self.user2,
             expected_addresses=expected_addresses,
         )
 
@@ -287,12 +105,12 @@ class TestMultiUserServicePartnerDomain(TestMultiUserCommon):
         self.backend.multi_user_records_policy = "main_partner_id"
         # Case 1: User 1 sees only its own records, the ones from its main partner,
         # and the publicly shared ones from their sibilings
-        partner = self.user_binding.record_id
+        partner = self.user
         expected_addresses = (
             partner
             | self.company
-            | self.address_company
-            | self.address_user1_private
+            | self._get_addresses(self.company, policy="public")
+            | self._get_addresses(self.user, policy="private")
             | self.all_public_addresses
         )
         self._test_user_direct_child_of_company__parent_id(
@@ -300,56 +118,52 @@ class TestMultiUserServicePartnerDomain(TestMultiUserCommon):
         )
         # Case 2: User 2 sees only its own records, the ones from its main partner,
         # and the publicly shared ones from their sibilings
-        partner = self.user_binding2.record_id
+        partner = self.user2
         expected_addresses = (
             partner
             | self.company
-            | self.address_company
-            | self.address_user2_private
+            | self._get_addresses(self.company, policy="public")
+            | self._get_addresses(self.user2, policy="private")
             | self.all_public_addresses
         )
         self._test_user_direct_child_of_company__parent_id(
             partner, self.company, expected_addresses=expected_addresses
         )
         # Case 3: Change User 2's main partner to user 1
-        self.user_binding2.main_partner_id = self.user_binding.record_id
+        self.user2_binding.main_partner_id = self.user
         expected_addresses = (
             partner
-            | self.address_user2_private
-            | self.address_user2_public
-            | self.address_user1_public
-            | self.user_binding.record_id
+            | self._get_addresses(self.user2)
+            | self._get_addresses(self.user, policy="public")
+            | self.user
         )
         self._test_user_direct_child_of_company__parent_id(
             partner,
-            self.user_binding.record_id,
+            self.user,
             expected_addresses=expected_addresses,
         )
-        self.assertEqual(
-            self.user_binding3.main_partner_id, self.user_binding2.record_id
-        )
+        self.assertEqual(self.user3_binding.main_partner_id, self.user2)
         # Case 4: User 3 sees only its own records, the ones from its main partner,
         # and the publicly shared ones from their sibilings
-        partner = self.user_binding3.record_id
+        partner = self.user3
         expected_addresses = (
             partner
-            | self.address_user3_private
-            | self.address_user3_public
-            | self.address_user2_public
-            | self.user_binding2.record_id
+            | self._get_addresses(self.user3)
+            | self._get_addresses(self.user2, policy="public")
+            | self.user2
         )
         self._test_user_direct_child_of_company__parent_id(
             partner,
-            self.user_binding2.record_id,
+            self.user2,
             expected_addresses=expected_addresses,
         )
         # Case 5: Change User 3's main partner to company
-        self.user_binding3.main_partner_id = self.company
+        self.user3_binding.main_partner_id = self.company
         expected_addresses = (
             partner
             | self.company
-            | self.address_company
-            | self.address_user3_private
+            | self._get_addresses(self.company, policy="public")
+            | self._get_addresses(self.user3, policy="private")
             | self.all_public_addresses
         )
         self._test_user_direct_child_of_company__parent_id(

--- a/shopinvader_customer_multi_user/tests/test_multi_user_token.py
+++ b/shopinvader_customer_multi_user/tests/test_multi_user_token.py
@@ -15,12 +15,9 @@ class TestMultiUserToken(TestMultiUserCommon):
     def _generate_random_companies(self, count=5):
         tokens = set()
         for x in range(count):
-            comp = self._create_partner(
-                self.env,
+            comp = self._create_partner_binding(
                 name="ACME %s" % x,
-                email="acme%s@test.com" % x,
                 is_company=True,
-                external_id="acme{}-{}".format(x, self._get_random_hash()),
             )
             if comp.invader_user_token:
                 tokens.add(comp.invader_user_token)

--- a/shopinvader_customer_multi_user/tests/test_partner_access_info.py
+++ b/shopinvader_customer_multi_user/tests/test_partner_access_info.py
@@ -23,7 +23,7 @@ class TestPartnerAccessInfo(TestUserManagementCommmon):
         self.assertTrue(info["users"]["manage"])
 
     def test_access_info_simpleuser(self):
-        for binding in self.user_binding + self.user_binding2 + self.user_binding3:
+        for binding in self.user_binding + self.user2_binding + self.user3_binding:
             info = self._get_access_info(
                 partner_user=binding.record_id,
                 invader_partner_user=binding,

--- a/shopinvader_customer_multi_user_company_group/__manifest__.py
+++ b/shopinvader_customer_multi_user_company_group/__manifest__.py
@@ -10,5 +10,8 @@
     "author": "Camptocamp SA",
     "website": "https://github.com/shopinvader/odoo-shopinvader",
     "depends": ["shopinvader_customer_multi_user", "partner_company_group"],
-    "data": ["views/shopinvader_partner.xml"],
+    "data": [
+        "views/shopinvader_backend.xml",
+        "views/shopinvader_partner.xml",
+    ],
 }

--- a/shopinvader_customer_multi_user_company_group/models/__init__.py
+++ b/shopinvader_customer_multi_user_company_group/models/__init__.py
@@ -1,1 +1,2 @@
+from . import shopinvader_backend
 from . import shopinvader_partner

--- a/shopinvader_customer_multi_user_company_group/models/shopinvader_backend.py
+++ b/shopinvader_customer_multi_user_company_group/models/shopinvader_backend.py
@@ -1,0 +1,27 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ShopinvaderBackend(models.Model):
+    _inherit = "shopinvader.backend"
+
+    multi_user_company_group_records_policy = fields.Selection(
+        selection=[
+            ("hierarchy", "View records down the company group hierarchy"),
+            ("shared", "Share records across companies in the group"),
+        ],
+        help=(
+            "This affects the behavior of every endpoint which lists partner related "
+            "records, directy or indirectly.\n\n"
+            "* `View records down the company group hierarchy`: Users that are part of "
+            "the company group will see records from the companies that belong to it, "
+            "but those companies users will only see their own company records.\n"
+            "* `Share records across companies in the group`: Records will be shared "
+            "among companies belonging to the same company group.\n"
+        ),
+        default="hierarchy",
+        required=True,
+    )

--- a/shopinvader_customer_multi_user_company_group/models/shopinvader_partner.py
+++ b/shopinvader_customer_multi_user_company_group/models/shopinvader_partner.py
@@ -23,40 +23,48 @@ class ShopinvaderPartner(models.Model):
 
     def _make_partner_domain(self, partner_field, operator="="):
         res = super()._make_partner_domain(partner_field, operator=operator)
-        if not self.is_company_group_user:
-            return res
         # The hierarchy when dealing with company_groups is trickier as company_group
         # is not really a part of the parent_id / child_ids hierarchy.
         # More often than not, the company group partner won't have a company_group_id
         # set itself. One would expect a circular reference to itself there, so:
         company_group = self.company_group_id or self.commercial_partner_id
-        domain_field = (
+        domain_company_group_field = (
             f"{partner_field}.company_group_id"
             if partner_field != "id"
             else "company_group_id"
         )
-        # Main users can always see everything down their hierarchy and companies
-        # belonging to the group hierarchy.
-        if self.is_admin_account or self.is_main_account:
+        domain_parent_field = (
+            f"{partner_field}.parent_id" if partner_field != "id" else "parent_id"
+        )
+        # Main company group users can always see everything down their hierarchy and
+        # companies belonging to the group hierarchy.
+        if self.is_company_group_user and (
+            self.is_admin_account or self.is_main_account
+        ):
             return expression.OR(
                 [
                     res,
-                    [(domain_field, "child_of", company_group.id)],
+                    [(domain_company_group_field, "child_of", company_group.id)],
                 ]
             )
-        # If we are logged as or in the company group itself, we can see all the
-        # public records down our group member's hierarchies.
-        return expression.OR(
-            [
-                res,
-                [(domain_field, operator, company_group.id)],
-            ]
-        )
+        # Regular company group users can see public records down the hierarchy, that is
+        # records that aren't linked to users but to companies.
+        # This is also the case with the "shared" policy for non company group users.
+        group_records_policy = self.backend_id.multi_user_company_group_records_policy
+        if self.is_company_group_user or group_records_policy == "shared":
+            return expression.OR(
+                [
+                    res,
+                    [
+                        (domain_company_group_field, "child_of", company_group.id),
+                        (domain_parent_field, "=", False),
+                    ],
+                ]
+            )
+        return res
 
     def _make_address_domain(self):
         res = super()._make_address_domain()
-        if not self.is_company_group_user:
-            return res
         # The hierarchy when dealing with company_groups is trickier as company_group
         # is not really a part of the parent_id / child_ids hierarchy.
         # More often than not, the company group partner won't have a company_group_id
@@ -64,19 +72,26 @@ class ShopinvaderPartner(models.Model):
         company_group = self.company_group_id or self.commercial_partner_id
         # Main users can always see everything down their hierarchy and companies
         # belonging to the group hierarchy.
-        if self.is_admin_account or self.is_main_account:
+        if self.is_company_group_user and (
+            self.is_admin_account or self.is_main_account
+        ):
             return expression.OR(
                 [res, [("company_group_id", "child_of", company_group.id)]]
             )
-        # If we are logged as or in the company group itself, we can see all the
-        # public records down our group member's hierarchies.
-        return expression.OR(
-            [
-                res,
+        # Regular company group users can see public shared addresses down the hierarchy.
+        # This is also the case with the "shared" policy for non company group users.
+        group_records_policy = self.backend_id.multi_user_company_group_records_policy
+        if self.is_company_group_user or group_records_policy == "shared":
+            return expression.OR(
                 [
-                    ("company_group_id", "child_of", company_group.id),
-                    ("shopinvader_bind_ids", "=", False),
-                    ("invader_address_share_policy", "=", "public"),
-                ],
-            ]
-        )
+                    res,
+                    [
+                        "|",
+                        ("id", "child_of", company_group.id),
+                        ("company_group_id", "child_of", company_group.id),
+                        ("shopinvader_bind_ids", "=", False),
+                        ("invader_address_share_policy", "=", "public"),
+                    ],
+                ]
+            )
+        return res

--- a/shopinvader_customer_multi_user_company_group/tests/__init__.py
+++ b/shopinvader_customer_multi_user_company_group/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import common
 from . import test_multi_user_service_partner_domain

--- a/shopinvader_customer_multi_user_company_group/tests/common.py
+++ b/shopinvader_customer_multi_user_company_group/tests/common.py
@@ -1,0 +1,90 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.addons.shopinvader_customer_multi_user.tests.common import (
+    TestMultiUserPartnerDomainCommon,
+)
+
+
+class TestMultiUserCompanyGroupCommon(TestMultiUserPartnerDomainCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # `TestMultiUserPartnerDomainCommon` will give us this hierarchy:
+        #
+        #      ┌─ Company ─┐
+        #      │           │
+        #      ▼           ▼
+        #    User        User2
+        #                  │
+        #                  ▼
+        #                User3
+        #
+        # Create a company group, move the existing company to the group
+        # and create a second company also part of the group.
+        #
+        #           ┌─── Company Group ───┐
+        #           │          │          │
+        #           │          │          │
+        #           │          ▼          │
+        #           │        User6        │
+        #           ▼                     ▼
+        #     ┌─ Company ─┐        ┌─ Company 2 ─┐
+        #     │           │        │             │
+        #     ▼           ▼        ▼             ▼
+        #   User        User2    User4         User5
+        #                 │
+        #                 ▼
+        #               User3
+        #
+        cls.company_group, cls.company_group_binding = cls._create_partner_and_binding(
+            name="Company Group Corp", is_company=True
+        )
+        cls.company.company_group_id = cls.company_group
+        cls.company2, cls.company2_binding = cls._create_partner_and_binding(
+            name="Smile Inc",
+            is_company=True,
+            company_group_id=cls.company_group.id,
+        )
+        cls.user4, cls.user4_binding = cls._create_partner_and_binding(
+            name="User 4",
+            parent_id=cls.company2.id,
+        )
+        cls.user5, cls.user5_binding = cls._create_partner_and_binding(
+            name="User 5",
+            parent_id=cls.company2.id,
+        )
+        cls.user6, cls.user6_binding = cls._create_partner_and_binding(
+            name="User 6",
+            parent_id=cls.company_group.id,
+        )
+        # Update shortcuts and create orders and addresses for each
+        new_companies = cls.company_group + cls.company2
+        new_users = cls.user4 + cls.user5 + cls.user6
+        new_partners = new_companies + new_users
+        cls.all_companies += new_companies
+        cls.all_users += new_users
+        cls.all_partners += new_partners
+        # Create Sale Orders and Invoices for each new partner
+        cls.all_orders += cls._create_sales_and_invoices(new_partners)
+        cls.all_invoices = cls.all_orders.invoice_ids
+        # Create Private and Public addresses for each new partner
+        new_public_addresses, new_private_addresses = cls._create_addresses(
+            new_partners
+        )
+        cls.all_public_addresses += new_public_addresses
+        cls.all_private_addresses += new_private_addresses
+        cls.all_addresses = cls.all_public_addresses + cls.all_private_addresses
+        # Shortcuts for company addresses, users, etc
+        cls.company_users = cls.user + cls.user2 + cls.user3
+        cls.company_partners = cls.company + cls.company_users
+        cls.company_orders = cls.all_orders.filtered(
+            lambda x: x.partner_id in cls.company_partners
+        )
+
+        cls.company2_users = cls.user4 + cls.user5
+        cls.company2_partners = cls.company2 + cls.company2_users
+        cls.company2_orders = cls.all_orders.filtered(
+            lambda x: x.partner_id in cls.company2_partners
+        )

--- a/shopinvader_customer_multi_user_company_group/tests/test_multi_user_service_partner_domain.py
+++ b/shopinvader_customer_multi_user_company_group/tests/test_multi_user_service_partner_domain.py
@@ -2,308 +2,184 @@
 # @author Iván Todorovich <ivan.todorovich@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.addons.shopinvader.tests.test_customer import TestCustomerCommon
+from .common import TestMultiUserCompanyGroupCommon
 
 
-class TestMultiUserServicePartnerDomain(TestCustomerCommon):
+class TestMultiUserRecordsHierarchy(TestMultiUserCompanyGroupCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # Enable multi-user
-        cls.backend.customer_multi_user = True
-        # Create companies
-        cls.company_group_binding = cls._create_partner(
-            cls.env,
-            name="Company Group",
-            external_id="company-group",
-            email="info@company-group.org",
-            is_company=True,
-        )
-        cls.company_a_binding = cls._create_partner(
-            cls.env,
-            name="Company A",
-            external_id="company-a",
-            email="info@company-a.org",
-            invader_user_token="COMPANY_A_TOKEN",
-            company_group_id=cls.company_group_binding.record_id.id,
-            is_company=True,
-        )
-        cls.company_b_binding = cls._create_partner(
-            cls.env,
-            name="Company B",
-            external_id="company-b",
-            email="info@company-b.org",
-            invader_user_token="COMPANY_B_TOKEN",
-            company_group_id=cls.company_group_binding.record_id.id,
-            is_company=True,
-        )
-        # Create users
-        cls.user_g_binding = cls._create_partner(
-            cls.env,
-            name="User G",
-            external_id="user-g",
-            email="user-g@company-group.org",
-            parent_id=cls.company_group_binding.record_id.id,
-        )
-        cls.user_a_binding = cls._create_partner(
-            cls.env,
-            name="User A",
-            external_id="user-a",
-            email="user-a@company-a.org",
-            parent_id=cls.company_a_binding.record_id.id,
-        )
-        cls.user_b_binding = cls._create_partner(
-            cls.env,
-            name="User B",
-            external_id="user-b",
-            email="user-b@company-b.org",
-            parent_id=cls.company_b_binding.record_id.id,
-        )
-        cls.company_group = cls.company_group_binding.record_id
-        cls.company_a = cls.company_a_binding.record_id
-        cls.company_b = cls.company_b_binding.record_id
-        cls.user_g = cls.user_g_binding.record_id
-        cls.user_a = cls.user_a_binding.record_id
-        cls.user_b = cls.user_b_binding.record_id
-        # Some quick recordset accessors
-        cls.all_companies = cls.company_group + cls.company_a + cls.company_b
-        cls.all_users = cls.user_g + cls.user_a + cls.user_b
-        cls.all_partners = cls.all_companies + cls.all_users
-        # Create Sale Orders per each user
-        # For maintenance reasons, loop and setattr on the fly
-        cls.all_sales = cls.env["sale.order"]
-        base_sale_order = cls.env.ref("shopinvader.sale_order_2")
-        for partner in cls.all_users:
-            partner_key = partner.name.lower().replace(" ", "_")
-            sale = base_sale_order.copy({"partner_id": partner.id})
-            setattr(cls, f"sale_{partner_key}", sale)
-            cls.all_sales |= sale
-        # Create invoices per each order
-        cls.all_invoices = cls.env["account.move"]
-        for sale in cls.all_sales:
-            sale.action_confirm()
-            for line in sale.order_line:
-                line.write({"qty_delivered": line.product_uom_qty})
-            cls.all_invoices |= sale._create_invoices()
-        # Create public and private addresses for each user
-        # For maintenance reasons, loop and setattr on the fly
-        ResPartner = cls.env["res.partner"]
-        cls.all_public_addresses = cls.env["res.partner"]
-        cls.all_private_addresses = cls.env["res.partner"]
-        for partner in cls.all_partners:
-            partner_key = partner.name.lower().replace(" ", "_")
-            public_address = ResPartner.create(
-                {
-                    "name": f"Delivery Address {partner.name} (Public)",
-                    "parent_id": partner.id,
-                    "type": "delivery",
-                    "invader_address_share_policy": "public",
-                }
-            )
-            private_address = ResPartner.create(
-                {
-                    "name": f"Delivery Address {partner.name} (Private)",
-                    "parent_id": partner.id,
-                    "type": "delivery",
-                    "invader_address_share_policy": "private",
-                }
-            )
-            setattr(cls, f"address_{partner_key}_public", public_address)
-            setattr(cls, f"address_{partner_key}_private", private_address)
-            cls.all_public_addresses |= public_address
-            cls.all_private_addresses |= private_address
-        cls.all_addresses = cls.all_public_addresses + cls.all_private_addresses
+        cls.backend.multi_user_records_policy = "main_partner_id"
+        cls.backend.multi_user_company_group_records_policy = "hierarchy"
 
-    @staticmethod
-    def _create_partner(env, **kw):
-        values = {
-            "backend_id": env.ref("shopinvader.backend_1").id,
-            "name": "ACME ltd",
-            "external_id": "acme",
-            "email": "company@test.com",
-            "ref": "#ACME",
-        }
-        values.update(kw)
-        return env["shopinvader.partner"].create(values)
-
-    @staticmethod
-    def _get_partner_expected_versus_found_message(
-        partner, expected, found, mapper=None
-    ):
-        if mapper is None:
-
-            def mapper(x):
-                return "%s (%d)" % (x.name, x.id)
-
-        return """
-            For partner:
-                {partner}
-            Expected:
-                {expected}
-            Found:
-                {found}
-            """.format(
-            partner=partner.name,
-            expected=("\n" + " " * 16).join(expected.mapped(mapper)),
-            found=("\n" + " " * 16).join(found.mapped(mapper)),
+    def test_hierarchy_company_group__company(self):
+        """The company group sees everything"""
+        self._test_partner_records(
+            self.company_group,
+            addresses=self.all_partners + self.all_addresses,
+            orders=self.all_orders,
         )
 
-    def _get_service(self, partner, usage):
-        with self.work_on_services(
-            partner=partner.get_shop_partner(self.backend),
-            partner_user=partner,
-            shopinvader_session=self.shopinvader_session,
-        ) as work:
-            return work.component(usage=usage)
-
-    # Test Helpers
-
-    def _test_address(self, partner, expected):
-        service = self._get_service(partner, "addresses")
-        res = service.search(per_page=100)
-        res_ids = [x["id"] for x in res["data"]]
-        found = self.env[expected._name].browse(res_ids).sorted(key="id")
-        expected = expected.sorted(key="id")
-        self.assertEqual(
-            found.ids,
-            expected.ids,
-            self._get_partner_expected_versus_found_message(partner, expected, found),
+    def test_hierarchy_company_group__user(self):
+        """The company group users sees everything that's public"""
+        order_partner_ids = [
+            self.company_group.id,
+            self.company.id,
+            self.company2.id,
+            self.user6.id,
+        ]
+        orders = self.all_orders.filtered(
+            lambda o: o.partner_id.id in order_partner_ids
         )
-
-    def _test_sale(self, partner, expected):
-        service = self._get_service(partner, "sales")
-        res = service.search()
-        res_ids = [x["id"] for x in res["data"]]
-        found = self.env[expected._name].browse(res_ids).sorted(key="id")
-        expected = expected.sorted(key="id")
-        self.assertEqual(
-            found.ids,
-            expected.ids,
-            self._get_partner_expected_versus_found_message(
-                partner,
-                expected,
-                found,
-                mapper=lambda x: "%s (%d) :: %s (%d)"
-                % (x.name, x.id, x.partner_id.name, x.partner_id.id),
-            ),
-        )
-
-    def _test_invoice(self, partner, expected):
-        service = self._get_service(partner, "invoice")
-        found = service._get_available_invoices().sorted(key="id")
-        expected = expected.sorted(key="id")
-        self.assertEqual(
-            found.ids,
-            expected.ids,
-            self._get_partner_expected_versus_found_message(
-                partner,
-                expected,
-                found,
-                mapper=lambda x: "%s (%d) :: %s (%d)"
-                % (x.name, x.id, x.partner_id.name, x.partner_id.id),
-            ),
-        )
-
-    # Tests
-
-    def test_company_group_level(self):
-        """The company group sees all"""
-        # Case 1: The company group itself
-        partner = self.company_group
-        self._test_address(partner, self.all_partners + self.all_addresses)
-        self._test_sale(partner, self.all_sales)
-        self._test_invoice(partner, self.all_invoices)
-        # Case 2: The company group user, same but only public addresses
-        partner = self.user_g
-        self._test_address(
-            partner,
-            (
-                self.user_g
+        self._test_partner_records(
+            self.user6,
+            addresses=(
+                self.user6
                 | self.company_group
                 | self.all_public_addresses
-                | self.address_user_g_private
+                | self._get_addresses(self.user6, policy="private")
             ),
+            orders=orders,
         )
-        self._test_sale(partner, self.all_sales)
-        self._test_invoice(partner, self.all_invoices)
 
-    def test_company_level(self):
+    def test_hierarchy_company__company(self):
         """The company sees only its own records"""
-        # Case 1: Company A
-        partner = self.company_a
-        self._test_address(
-            partner,
-            (
-                partner
-                | self.user_a
-                | self.address_user_a_public
-                | self.address_user_a_private
-                | self.address_company_a_public
-                | self.address_company_a_private
+        self._test_partner_records(
+            self.company,
+            addresses=(
+                self.company_partners | self._get_addresses(self.company_partners)
             ),
+            orders=self.company_orders,
         )
-        sales = self.sale_user_a
-        self._test_sale(partner, sales)
-        self._test_invoice(partner, sales.mapped("invoice_ids"))
-        # Case 2: Same but without admin user
-        partner = self.user_a
-        self._test_address(
-            partner,
-            (
-                partner
-                | self.company_a
-                | self.address_user_a_public
-                | self.address_user_a_private
-                | self.address_company_a_public
-            ),
-        )
-        sales = self.sale_user_a
-        self._test_sale(partner, sales)
-        self._test_invoice(partner, sales.mapped("invoice_ids"))
 
-    def test_company_level_with_child(self):
+    def test_hierarchy_company__user(self):
+        """The company users sees its company records and public addresses"""
+        self._test_user_direct_child_of_company__parent_id(
+            self.user,
+            self.company,
+            expected_addresses=(
+                self.user
+                | self.company
+                | self._get_addresses(self.user)
+                | self._get_addresses(self.company, policy="public")
+                | self._get_addresses(self.company_users, policy="public")
+            ),
+        )
+
+    def test_hierarchy_company_with_child__company(self):
         """The company sees only its own records and its childs records"""
-        self.company_b.parent_id = self.company_a
-        # Case 1: Company A
-        partner = self.company_a
-        self._test_address(
-            partner,
-            (
-                # Sees company A
-                self.company_a
-                | self.user_a
-                | self.address_user_a_public
-                | self.address_user_a_private
-                | self.address_company_a_public
-                | self.address_company_a_private
-                # And company B
-                | self.company_b
-                | self.user_b
-                | self.address_user_b_public
-                | self.address_user_b_private
-                | self.address_company_b_public
-                | self.address_company_b_private
+        self.company2.parent_id = self.company
+        self._test_partner_records(
+            self.company,
+            addresses=(
+                self.company_partners
+                | self.company2_partners
+                | self._get_addresses(self.company_partners)
+                | self._get_addresses(self.company2_partners)
+            ),
+            orders=(self.company_orders | self.company2_orders),
+        )
+
+    def test_hierarchy_company_with_child__user(self):
+        """The company user sees only its company records and public addresses"""
+        self.company2.parent_id = self.company
+        self._test_user_direct_child_of_company__parent_id(
+            self.user,
+            self.company,
+            expected_addresses=(
+                self.user
+                | self.company
+                | self._get_addresses(self.user)
+                | self._get_addresses(self.company_partners, policy="public")
+                | self._get_addresses(self.company2_partners, policy="public")
             ),
         )
-        sales = self.sale_user_a | self.sale_user_b
-        self._test_sale(partner, sales)
-        self._test_invoice(partner, sales.mapped("invoice_ids"))
-        # Case 2: Same but without admin user
-        partner = self.user_a
-        self._test_address(
-            partner,
-            (
-                # Sees company A
-                self.company_a
-                | self.user_a
-                | self.address_user_a_public
-                | self.address_user_a_private
-                | self.address_company_a_public
-                # And company B
-                | self.address_user_b_public
-                | self.address_company_b_public
-            ),
+
+
+class TestMultiUserRecordsShared(TestMultiUserCompanyGroupCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.backend.multi_user_records_policy = "main_partner_id"
+        cls.backend.multi_user_company_group_records_policy = "shared"
+
+    def test_shared_company_group__company(self):
+        """The company group sees everything"""
+        # Exactly the same than "hierarchy", as the group users always see everything
+        self._test_partner_records(
+            self.company_group,
+            addresses=self.all_partners + self.all_addresses,
+            orders=self.all_orders,
         )
-        sales = self.sale_user_a
-        self._test_sale(partner, sales)
-        self._test_invoice(partner, sales.mapped("invoice_ids"))
+
+    def test_shared_company_group__user(self):
+        """The company group users sees everything that's public"""
+        # Exactly the same than "hierarchy", as the group users always see everything
+        order_partner_ids = [
+            self.company_group.id,
+            self.company.id,
+            self.company2.id,
+            self.user6.id,
+        ]
+        orders = self.all_orders.filtered(
+            lambda o: o.partner_id.id in order_partner_ids
+        )
+        self._test_partner_records(
+            self.user6,
+            addresses=(
+                self.user6
+                | self.company_group
+                | self.all_public_addresses
+                | self._get_addresses(self.user6, policy="private")
+            ),
+            orders=orders,
+        )
+
+    def test_shared_company__company(self):
+        """The company sees everything that's public in the group"""
+        order_partner_ids = [
+            # orders linked directly to companies
+            self.company_group.id,
+            self.company.id,
+            self.company2.id,
+            # and its own users
+            *self.company_users.ids,
+        ]
+        orders = self.all_orders.filtered(
+            lambda o: o.partner_id.id in order_partner_ids
+        )
+        self._test_partner_records(
+            self.company,
+            addresses=(
+                self.company
+                | self.company_users
+                | self.all_public_addresses
+                | self._get_addresses(self.company)
+                | self._get_addresses(self.company_users)
+            ),
+            orders=orders,
+        )
+
+    def test_shared_company__user(self):
+        """The company users sees everything that's public in the group"""
+        order_partner_ids = [
+            # orders linked directly to companies
+            self.company_group.id,
+            self.company.id,
+            self.company2.id,
+            # and his own orders
+            self.user.id,
+        ]
+        orders = self.all_orders.filtered(
+            lambda o: o.partner_id.id in order_partner_ids
+        )
+        self._test_partner_records(
+            self.user,
+            addresses=(
+                self.user
+                | self.company
+                | self._get_addresses(self.user)
+                | self.all_public_addresses
+            ),
+            orders=orders,
+        )

--- a/shopinvader_customer_multi_user_company_group/views/shopinvader_backend.xml
+++ b/shopinvader_customer_multi_user_company_group/views/shopinvader_backend.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="shopinvader_backend_form_view" model="ir.ui.view">
+        <field name="model">shopinvader.backend</field>
+        <field
+            name="inherit_id"
+            ref="shopinvader_customer_multi_user.shopinvader_backend_form_view"
+        />
+        <field name="arch" type="xml">
+            <field name="multi_user_records_policy" position="after">
+                <field name="multi_user_company_group_records_policy" />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
**shopinvader_customer_multi_user**:
- Moved most helpers to `TestMultiUserPartnerDomainCommon`
- Added new helpers to simply writing tests
- Renamed `user_bindingN` to `userN_binding` (for readability and consistency with the new `userN` properties)

**shopinvader_customer_multi_user_company_group**:
- Reuse the added helpers and base tests on top of `shopinvader_customer_multi_user`
- Implement a shared company group record policy:

```
For example, in this scenario:

           ┌─── Company Group ───┐
           │          │          │
           │          │          │
           │          ▼          │
           │        User6        │
           ▼                     ▼
     ┌─ Company ─┐        ┌─ Company 2 ─┐
     │           │        │             │
     ▼           ▼        ▼             ▼
   User        User2    User4         User5

With "hierarchy" policy:
- User6 sees all public records of all companies
- User2 sees public records of Company
- User4 sees public records of Company 2

With "shared" policy:
- All users see all public records of all companies
```