### PR TITLE
[14.0][FIX] `shopinvader_image` 🖼️ hash : recompute hash if related data changes

### DIFF
--- a/shopinvader_image/models/shopinvader_image_mixin.py
+++ b/shopinvader_image/models/shopinvader_image_mixin.py
@@ -96,14 +96,14 @@ class ShopinvaderImageMixin(models.AbstractModel):
         return res
 
     def _prepare_data_resize(self, thumbnail, image_relation):
-        """
-        Prepare data to fill images serialized field
-        :param thumbnail: storage.thumbnail recordset
-        :param image_relation: product.image.relation recordset
+        """Prepare data to fill images serialized field
+
+        :param thumbnail: ``storage.thumbnail`` recordset
+        :param image_relation: ``image.relation.abstract`` recordset
         :return: dict
         """
         self.ensure_one()
-        tag = ""
-        if image_relation.tag_id:
-            tag = image_relation.tag_id.name
-        return {"src": thumbnail.url, "alt": self.name, "tag": tag}
+        res = {"src": thumbnail.url, "alt": self.name}
+        if "tag_id" in image_relation._fields:
+            res["tag"] = image_relation.tag_id.name or ""
+        return res

--- a/shopinvader_image/models/shopinvader_image_mixin.py
+++ b/shopinvader_image/models/shopinvader_image_mixin.py
@@ -51,6 +51,8 @@ class ShopinvaderImageMixin(models.AbstractModel):
 
     def _get_images_store_hash(self):
         self.ensure_one()
+        if not self[self._image_field]:
+            return False
         return str(hash(self._get_images_store_hash_tuple()))
 
     def _get_images_store_hash_timestamp(self):


### PR DESCRIPTION
Previous to this PR, the hash was only recomputed when the related `storage.image` record changed.
But that's not the only place exported data comes from, we also get it from tags and potentially the relation itself.

Rather than hashing all the images write dates, we compute the latest single write_date for all related records and hash it instead.

This PR includes two other small changes, each in its own commit.