### PR TITLE
[FIX] Do not send standard sale confirmation email

### DIFF
--- a/shopinvader/models/sale.py
+++ b/shopinvader/models/sale.py
@@ -110,6 +110,15 @@ class SaleOrder(models.Model):
             self.reset_price_tax()
         return True
 
+    def _send_order_confirmation_mail(self):
+        non_shopinvader_orders = self.env["sale.order"].browse()
+        for order in self:
+            # Only send emails through shopinvader notifications
+            # When order are done from website
+            if not order.shopinvader_backend_id:
+                non_shopinvader_orders |= order
+        return super(SaleOrder, non_shopinvader_orders)._send_order_confirmation_mail()
+
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"


### PR DESCRIPTION
Without this PR, shopinvader orders with sale_confirmation notification set were sending 2 emails when confirming an order