### PR TITLE
[14.0][ADD] `shopinvader_sale_automatic_workflow` : Use sale automatic workflows for Shopinvader orders 🤖

### DIFF
--- a/setup/shopinvader_sale_automatic_workflow/odoo/addons/shopinvader_sale_automatic_workflow
+++ b/setup/shopinvader_sale_automatic_workflow/odoo/addons/shopinvader_sale_automatic_workflow
@@ -1,0 +1,1 @@
+../../../../shopinvader_sale_automatic_workflow

--- a/setup/shopinvader_sale_automatic_workflow/setup.py
+++ b/setup/shopinvader_sale_automatic_workflow/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopinvader_sale_automatic_workflow/__init__.py
+++ b/shopinvader_sale_automatic_workflow/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import services

--- a/shopinvader_sale_automatic_workflow/__manifest__.py
+++ b/shopinvader_sale_automatic_workflow/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Shopinvader Sale Automatic Workflow",
+    "summary": "Use sale automatic workflows for Shopinvader orders",
+    "version": "14.0.1.0.0",
+    "author": "Camptocamp SA",
+    "maintainers": ["ivantodorovich"],
+    "website": "https://github.com/shopinvader/odoo-shopinvader",
+    "license": "AGPL-3",
+    "category": "Shopinvader",
+    "depends": ["shopinvader", "sale_automatic_workflow"],
+    "data": ["views/shopinvader_backend.xml"],
+    "auto_install": True,
+}

--- a/shopinvader_sale_automatic_workflow/models/__init__.py
+++ b/shopinvader_sale_automatic_workflow/models/__init__.py
@@ -1,0 +1,1 @@
+from . import shopinvader_backend

--- a/shopinvader_sale_automatic_workflow/models/shopinvader_backend.py
+++ b/shopinvader_sale_automatic_workflow/models/shopinvader_backend.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ShopinvaderBackend(models.Model):
+    _inherit = "shopinvader.backend"
+
+    workflow_process_id = fields.Many2one(
+        comodel_name="sale.workflow.process",
+        string="Automatic Workflow",
+        help="Sales Orders created by this backend will use this workflow",
+        ondelete="restrict",
+    )

--- a/shopinvader_sale_automatic_workflow/readme/CONTRIBUTORS.rst
+++ b/shopinvader_sale_automatic_workflow/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+  * Iván Todorovich <ivan.todorovich@gmail.com>

--- a/shopinvader_sale_automatic_workflow/readme/DESCRIPTION.rst
+++ b/shopinvader_sale_automatic_workflow/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module allows to configure an Automatic Workflow for orders created
+from a Shopinvader Backend.

--- a/shopinvader_sale_automatic_workflow/services/__init__.py
+++ b/shopinvader_sale_automatic_workflow/services/__init__.py
@@ -1,0 +1,1 @@
+from . import cart

--- a/shopinvader_sale_automatic_workflow/services/cart.py
+++ b/shopinvader_sale_automatic_workflow/services/cart.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.addons.component.core import Component
+
+
+class CartService(Component):
+    _inherit = "shopinvader.cart.service"
+
+    def _prepare_cart(self, **cart_params):
+        res = super()._prepare_cart(**cart_params)
+        if self.shopinvader_backend.workflow_process_id:
+            res["workflow_process_id"] = self.shopinvader_backend.workflow_process_id.id
+        return res

--- a/shopinvader_sale_automatic_workflow/tests/__init__.py
+++ b/shopinvader_sale_automatic_workflow/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_automatic_workflow

--- a/shopinvader_sale_automatic_workflow/tests/test_automatic_workflow.py
+++ b/shopinvader_sale_automatic_workflow/tests/test_automatic_workflow.py
@@ -1,0 +1,29 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tools import mute_logger
+
+from odoo.addons.shopinvader.tests.test_cart import CommonConnectedCartCase
+
+
+class TestShopinvaderOrderSaleWorkflow(CommonConnectedCartCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.backend.workflow_process_id = cls.env["sale.workflow.process"].create(
+            {"name": "Test Workflow"}
+        )
+
+    @mute_logger("odoo.models.unlink")
+    def test_cart_create(self):
+        self.cart.unlink()
+        cart = self.service._get()
+        self.assertRecordValues(
+            cart,
+            [
+                {
+                    "workflow_process_id": self.backend.workflow_process_id.id,
+                }
+            ],
+        )

--- a/shopinvader_sale_automatic_workflow/views/shopinvader_backend.xml
+++ b/shopinvader_sale_automatic_workflow/views/shopinvader_backend.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="shopinvader_backend_view_form" model="ir.ui.view">
+        <field name="model">shopinvader.backend</field>
+        <field name="inherit_id" ref="shopinvader.shopinvader_backend_view_form" />
+        <field name="arch" type="xml">
+            <group name="sale_conf" position="inside">
+                <field name="workflow_process_id" />
+            </group>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Simple module that allows to set an [Automatic Workflow](https://github.com/OCA/sale-workflow/tree/14.0/sale_automatic_workflow) on created Shopinvader orders.