### PR TITLE
[14.0][FIX] shopinvader: fix '_post' signature

### DIFF
--- a/shopinvader/models/account_move.py
+++ b/shopinvader/models/account_move.py
@@ -11,7 +11,7 @@ class AccountMove(models.Model):
         "shopinvader.backend", "Shopinvader Backend"
     )
 
-    def _post(self, soft=False):
+    def _post(self, soft=True):
         res = super(AccountMove, self)._post(soft=soft)
         for record in self:
             backend = record.shopinvader_backend_id


### PR DESCRIPTION
The expected signature is `_post(soft=True)`: https://github.com/odoo/odoo/blob/612f4917efe98e5cb6f3c184728eb245a1ca0278/addons/account/models/account_move.py#L2583

Ref. 3287