### PR TITLE
[14.0] [IMP] shopinvader: Make SESS_CART_ID optional when a partner is logged in

### DIFF
--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -219,6 +219,12 @@ class ShopinvaderBackend(models.Model):
         "provides a fallback mechanism in such a case.",
         default=lambda self: self._default_website_unique_key(),
     )
+
+    restrict_cart_to_partner = fields.Boolean(
+        "Restrict access of cart to corresponding logged in partner",
+        default=False,
+    )
+
     currency_ids = fields.Many2many(comodel_name="res.currency", string="Currency")
 
     frontend_data_source = fields.Selection(

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -458,6 +458,32 @@ class ConnectedCartCase(CommonConnectedCartCase, CartClearTest):
         self.assertIn("note", res["data"])
         self.assertEqual("FOO", res["data"]["note"])
 
+    def test_cart_get_from_any_partner(self):
+        anon_cart = self.env.ref("shopinvader.sale_order_1")
+        with self.work_on_services(
+            partner=self.partner,
+            shopinvader_session={"cart_id": anon_cart.id},
+        ) as work:
+            self.service = work.component(usage="cart")
+            cart = self.service.dispatch("search")["data"]
+
+        self.assertEqual(anon_cart.id, cart["id"])
+        self.assertNotEqual(anon_cart.partner_id, self.partner)
+
+    def test_cart_get_restrict_cart_to_partner(self):
+        self.backend.restrict_cart_to_partner = True
+        anon_cart = self.env.ref("shopinvader.sale_order_1")
+        with self.work_on_services(
+            partner=self.partner,
+            shopinvader_session={"cart_id": anon_cart.id},
+        ) as work:
+            self.service = work.component(usage="cart")
+            cart = self.service.dispatch("search")["data"]
+
+        # Is it necessary to create a cart in this case?
+        # This is done for backward compatibility for now
+        self.assertNotEqual(anon_cart.id, cart["id"])
+
 
 class ConnectedCartNoTaxCase(CartCase):
     def setUp(self, *args, **kwargs):

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -104,6 +104,7 @@
                                 <field name="clear_cart_options" />
                                 <field name="cart_checkout_address_policy" />
                                 <field name="pricelist_id" required="1" />
+                                <field name="restrict_cart_to_partner" />
                             </group>
                             <group name="sale_conf" string="Sale configuration">
                                 <field

--- a/shopinvader_customer_price/tests/test_cart.py
+++ b/shopinvader_customer_price/tests/test_cart.py
@@ -27,10 +27,12 @@ class ConnectedItemCase(ItemCaseMixin, CommonCase):
 
     def test_default_pricelist(self):
         self.assertFalse(self.backend.cart_pricelist_partner_field_id)
-        cart = self.service._get()
+        cart = self.service._create_empty_cart()
+
         self.assertEqual(cart.pricelist_id, self.partner.property_product_pricelist)
 
     def test_custom_pricelist(self):
         self.backend.cart_pricelist_partner_field_id = self.pricelist_field
-        cart = self.service._get()
+        cart = self.service._create_empty_cart()
+
         self.assertEqual(cart.pricelist_id, self.custom_pricelist)

--- a/shopinvader_wishlist/tests/test_wishlist.py
+++ b/shopinvader_wishlist/tests/test_wishlist.py
@@ -172,7 +172,7 @@ class WishlistCase(CommonWishlistCase):
 
         with self.work_on_services(partner=self.partner) as work:
             cart_service = work.component(usage="cart")
-        cart = cart_service._get()
+        cart = cart_service._create_empty_cart()
         # no line yet
         self.assertFalse(cart.order_line)
 
@@ -195,6 +195,8 @@ class WishlistCase(CommonWishlistCase):
         self.assertEqual(len(self.prod_set.set_line_ids), 3)
         with self.work_on_services(partner=self.partner) as work:
             cart_service = work.component(usage="cart")
+        # Start with an empty cart
+        cart_service._create_empty_cart()
         cart = cart_service._get()
         # no line yet
         self.assertFalse(cart.order_line)


### PR DESCRIPTION
This PR add a way to get the current "active" partner cart without session cart id.
This PR also add a `restrict_cart_to_partner` option on backend to restrict cart access to its logged in partner owner.