### PR TITLE
[14.0] [IMP] shopinvader_auth_jwt: Handle new email_create partner strategy in shopinvader

### DIFF
--- a/shopinvader_auth_jwt/models/__init__.py
+++ b/shopinvader_auth_jwt/models/__init__.py
@@ -1,1 +1,2 @@
+from . import auth_jwt_validator
 from . import shopinvader_backend

--- a/shopinvader_auth_jwt/models/auth_jwt_validator.py
+++ b/shopinvader_auth_jwt/models/auth_jwt_validator.py
@@ -1,0 +1,63 @@
+import logging
+from collections import namedtuple
+
+from odoo import models
+from odoo.http import request
+
+from odoo.addons.shopinvader.components.service_context_provider import (
+    ShopinvaderServiceContextProvider,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class AuthJwtValidator(models.Model):
+    _inherit = "auth.jwt.validator"
+
+    def _get_shopinvader_backend(self):
+        # Remove this hack when shopinvader.partner is no more
+        backend = ShopinvaderServiceContextProvider._get_backend(
+            namedtuple("DummyWorkContext", ("request", "env"))(
+                request=request, env=self.env
+            )
+        )
+        return backend
+
+    def _create_partner_from_payload(self, payload):
+        partner = super()._create_partner_from_payload(payload)
+        backend = self._get_shopinvader_backend()
+
+        if not backend:
+            _logger.debug("No backend found")
+            return partner
+
+        self.env["shopinvader.partner"].create(
+            {
+                "partner_email": partner.email,
+                "backend_id": backend.id,
+                "record_id": partner.id,
+                "external_id": payload.get("sub"),
+            }
+        )
+
+        return partner
+
+    def _get_partner_from_email(self, email):
+        backend = self._get_shopinvader_backend()
+
+        partner = self.env["res.partner"].search(
+            [
+                ("auth_jwt_email", "=", email),
+                ("shopinvader_bind_ids.backend_id", "=", backend.id),
+            ]
+        )
+        if not len(partner):
+            partner = self.env["res.partner"].search(
+                [
+                    ("email", "=", email),
+                    ("auth_jwt_email", "=", False),
+                    ("shopinvader_bind_ids.backend_id", "=", backend.id),
+                ]
+            )
+
+        return partner


### PR DESCRIPTION
This PR is the shopinvader counter part of https://github.com/OCA/server-auth/pull/346 and is obviously blocked by it.
It also changes the way the shopinvader partner is got by directly using the `jwt_partner_id` set by the validator.