### PR TITLE
[13.0][FIX] shopinvader: Allow product event listener to create shopinvader variants without access rights

### DIFF
--- a/shopinvader/components/product_product_event_listener.py
+++ b/shopinvader/components/product_product_event_listener.py
@@ -36,7 +36,7 @@ class ProductProductEventListener(Component):
         )
         # If at least 1 is True, force False
         if any(shopinv_variants.mapped("active")):
-            shopinv_variants.write({"active": False})
+            shopinv_variants.sudo().write({"active": False})
 
     def _launch_shopinvader_variant_creation(self, shopinvader_products):
         """

--- a/shopinvader/models/product_product.py
+++ b/shopinvader/models/product_product.py
@@ -53,7 +53,7 @@ class ProductProduct(models.Model):
     def _inverse_active(self):
         self.filtered(lambda p: not p.active).mapped(
             "shopinvader_bind_ids"
-        ).write({"active": False})
+        ).sudo().write({"active": False})
 
     def _compute_shopinvader_backend_ids(self):
         for rec in self:

--- a/shopinvader/models/shopinvader_product.py
+++ b/shopinvader/models/shopinvader_product.py
@@ -130,7 +130,7 @@ class ShopinvaderProduct(models.Model):
                 ]
             ):
                 vals = self_ctx._prepare_shopinvader_variant(variant)
-                shopinv_variants |= shopinv_variant_obj.create(vals)
+                shopinv_variants |= shopinv_variant_obj.sudo().create(vals)
         return shopinv_variants
 
     @api.model


### PR DESCRIPTION
Avoid that when a variant is created on  a product by a non shopinvader manager rights user, we sudo this process, as shopinvader variant will be automatically archived.

CC @ForgeFlow 