### PR TITLE
[14.0][FIX] shopinvader: address type switched to contact during update

### DIFF
--- a/shopinvader/services/address.py
+++ b/shopinvader/services/address.py
@@ -156,6 +156,8 @@ class AddressService(Component):
         for key in res:
             if "required" in res[key]:
                 del res[key]["required"]
+            if "default" in res[key]:
+                del res[key]["default"]
         return res
 
     def _validator_delete(self):


### PR DESCRIPTION
Steps to reproduce:

1. Create an address of type "other".
2. Update any address field but the type.
3. Address type changed to "contact".

The reason is the default validator value applies for updates, and it shouldn't. In fact any default value should apply for any update operation (same that we do with required).

This issue wasn't caught by tests because, self.address_params was being modified in some tests, and since it's set on setUpClass, these modifications were transfered to other tests.

While fixing this, I take the opportunity to:

  * Move helper methods to CommonAddressCase.
  * Add more helper methods to simplify code.