### PR TITLE
[FIX] shopinvader: fix default notifications

### DIFF
--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -36,7 +36,6 @@ class ShopinvaderBackend(models.Model):
         "shopinvader.notification",
         "backend_id",
         "Notification",
-        default=lambda self: self.env["shopinvader.notification"].search([]),
     )
     nbr_product = fields.Integer(
         compute="_compute_nbr_content", string="Number of bound products"


### PR DESCRIPTION
a wrong default value on shopinvader.backend -> notification_ids
when creating a new backend, all existing one are emptied of nofitication and all notification ends on the new one