### PR TITLE
[14.0][IMP] Set partner on lead if user is logged

### DIFF
--- a/shopinvader_lead/services/lead.py
+++ b/shopinvader_lead/services/lead.py
@@ -79,4 +79,8 @@ class LeadService(Component):
             if human_key in params:
                 params[key] = params.pop(human_key)
         params["shopinvader_backend_id"] = self.shopinvader_backend.id
+        if self.partner:
+            params["partner_id"] = self.partner.id
+            # Remove email_from key as this will update the email on the logged partner
+            params.pop("email_from", None)
         return params


### PR DESCRIPTION
When creating a lead, if the user is logged, the partner should be filled on the lead created