### PR TITLE
[FIX] shopinvader -> notifications (refactor account.invoice -> account.move)

### DIFF
--- a/shopinvader/models/shopinvader_notification.py
+++ b/shopinvader/models/shopinvader_notification.py
@@ -43,11 +43,11 @@ class ShopinvaderNotification(models.Model):
             },
             "invoice_open": {
                 "name": _("Invoice Validated"),
-                "model": "account.invoice",
+                "model": "account.move",
             },
             "invoice_send_email": {
                 "name": _("Invoice send email"),
-                "model": "account.invoice",
+                "model": "account.move",
             },
             "new_customer_welcome": {
                 "name": _("New customer Welcome"),


### PR DESCRIPTION
old model account.invoice still referenced in _get_all_notification() <br/>
changed to account.move <br/>

@Cedric-Pigeon 