### PR TITLE
[14.0] [FIX] shopinvader: Force partner load in work ctx at customer creation

### DIFF
--- a/shopinvader/services/customer.py
+++ b/shopinvader/services/customer.py
@@ -34,7 +34,7 @@ class CustomerService(Component):
     def create(self, **params):
         vals = self._prepare_params(params)
         binding = self.env["shopinvader.partner"].create(vals)
-        self._load_partner_work_context(binding)
+        self._load_partner_work_context(binding, True)
         self._post_create(self.work.partner)
         return self._prepare_create_response(binding)
 


### PR DESCRIPTION
Using `auth_jwt`, the connected partner when creating a customer is not the customer itself (but exists).

Without `force` welcome mails for example are not sent to the new customer but to the one connected.