### PR TITLE
[ADD] shopinvader_assortment : wizard to remove product from backend

### DIFF
--- a/shopinvader_assortment/__init__.py
+++ b/shopinvader_assortment/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizards

--- a/shopinvader_assortment/__manifest__.py
+++ b/shopinvader_assortment/__manifest__.py
@@ -12,7 +12,12 @@
         "shopinvader",
         "shopinvader_search_engine",
     ],
-    "data": ["data/ir_cron.xml", "views/shopinvader_backend.xml"],
+    "data": [
+        "security/ir.model.access.csv",
+        "data/ir_cron.xml",
+        "views/shopinvader_backend.xml",
+        "wizards/wizard_online_availability.xml",
+    ],
     "demo": ["demo/shopinvader_assortment_demo.xml"],
     "installable": True,
 }

--- a/shopinvader_assortment/security/ir.model.access.csv
+++ b/shopinvader_assortment/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_wizard_online_availability,access_wizard_online_availability,model_wizard_online_availability,base.group_user,1,1,1,0

--- a/shopinvader_assortment/tests/__init__.py
+++ b/shopinvader_assortment/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_product_auto_bind
+from . import test_wizard_online_availability

--- a/shopinvader_assortment/tests/test_wizard_online_availability.py
+++ b/shopinvader_assortment/tests/test_wizard_online_availability.py
@@ -1,0 +1,141 @@
+# © 2022 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from odoo.exceptions import UserError
+from odoo.tests.common import SavepointCase
+
+
+class TestWizardOnlineAvailable(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.product1 = cls.env.ref("product.product_product_8")
+        cls.product2 = cls.env.ref("product.product_product_7")
+        cls.product3 = cls.env.ref("product.product_product_9")
+        cls.product4 = cls.env.ref("product.product_product_24")
+        cls.product5 = cls.env.ref("product.product_product_10")
+        cls.product6 = cls.env.ref("product.product_product_11")
+        cls.product7 = cls.env.ref("product.product_product_5")
+        cls.backend = cls.env.ref("shopinvader.backend_1").with_context(
+            bind_products_immediately=True
+        )
+        cls.backend2 = cls.env.ref("shopinvader.backend_2").with_context(
+            bind_products_immediately=True
+        )
+        filter2 = cls.backend.product_assortment_id.copy()
+        cls.backend2.product_assortment_id = filter2.id
+
+    def test_all_backend(self):
+        wizard = self.env["wizard.online_availability"].create(
+            {"action_type": "exclude"}
+        )
+        with self.assertRaises(UserError) as ve:
+            wizard.manage_availability()
+            self.assertIn(
+                "You need to select a backend or check the 'all backends' option",
+                ve.exception.name,
+            )
+        backends = self.env["shopinvader.backend"].search(
+            [("product_assortment_id", "<>", False)]
+        )
+        for backend in backends:
+            backend.product_assortment_id.write(
+                {
+                    "blacklist_product_ids": [(5, False, False)],
+                }
+            )
+            self.assertEqual(
+                len(backend.product_assortment_id.blacklist_product_ids.ids), 0
+            )
+
+        wizard = (
+            self.env["wizard.online_availability"]
+            .with_context(active_ids=[self.product1.id, self.product2.id])
+            .create({"action_type": "exclude", "all_backend": True})
+        )
+        wizard.manage_availability()
+
+        for backend in backends:
+            self.assertEqual(
+                len(backend.product_assortment_id.blacklist_product_ids.ids), 2
+            )
+            self.assertListEqual(
+                sorted(backend.product_assortment_id.blacklist_product_ids.ids),
+                sorted([self.product1.id, self.product2.id]),
+            )
+
+        wizard = (
+            self.env["wizard.online_availability"]
+            .with_context(active_ids=[self.product3.id])
+            .create({"action_type": "exclude", "all_backend": True})
+        )
+        wizard.manage_availability()
+
+        for backend in backends:
+            self.assertEqual(
+                len(backend.product_assortment_id.blacklist_product_ids.ids), 3
+            )
+            self.assertListEqual(
+                sorted(backend.product_assortment_id.blacklist_product_ids.ids),
+                sorted([self.product1.id, self.product2.id, self.product3.id]),
+            )
+
+        wizard = (
+            self.env["wizard.online_availability"]
+            .with_context(active_ids=[self.product3.id])
+            .create({"action_type": "include", "all_backend": True})
+        )
+        wizard.manage_availability()
+
+        for backend in backends:
+            self.assertEqual(
+                len(backend.product_assortment_id.blacklist_product_ids.ids), 2
+            )
+            self.assertListEqual(
+                sorted(backend.product_assortment_id.blacklist_product_ids.ids),
+                sorted([self.product1.id, self.product2.id]),
+            )
+
+        wizard = (
+            self.env["wizard.online_availability"]
+            .with_context(active_ids=[self.product1.id, self.product2.id])
+            .create({"action_type": "include", "all_backend": True})
+        )
+        wizard.manage_availability()
+
+        for backend in backends:
+            self.assertEqual(
+                len(backend.product_assortment_id.blacklist_product_ids.ids), 0
+            )
+
+    def test_one_backend(self):
+
+        backends = self.env["shopinvader.backend"].search(
+            [("product_assortment_id", "<>", False)]
+        )
+        for backend in backends:
+            backend.product_assortment_id.write(
+                {
+                    "blacklist_product_ids": [(5, False, False)],
+                }
+            )
+            self.assertEqual(
+                len(backend.product_assortment_id.blacklist_product_ids.ids), 0
+            )
+
+        wizard = (
+            self.env["wizard.online_availability"]
+            .with_context(active_ids=[self.product1.id, self.product2.id])
+            .create(
+                {"action_type": "exclude", "backend_ids": [(6, 0, [self.backend.id])]}
+            )
+        )
+
+        wizard.manage_availability()
+
+        self.assertEqual(
+            len(self.backend.product_assortment_id.blacklist_product_ids.ids), 2
+        )
+        self.assertEqual(
+            len(self.backend2.product_assortment_id.blacklist_product_ids.ids), 0
+        )

--- a/shopinvader_assortment/wizards/__init__.py
+++ b/shopinvader_assortment/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard_online_availability

--- a/shopinvader_assortment/wizards/wizard_online_availability.py
+++ b/shopinvader_assortment/wizards/wizard_online_availability.py
@@ -1,0 +1,70 @@
+# Copyright 2022 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class WizardOnlineAvailability(models.TransientModel):
+    """
+    Wizard used to exclude products from a backend
+    Product Assortment -> to_exclude
+    """
+
+    _name = "wizard.online_availability"
+    _description = "Wizard Online Availability"
+
+    backend_ids = fields.Many2many(
+        "shopinvader.backend",
+        string="Backend(s)",
+        help="The backend(s) you want to exclude product from.",
+        required=False,
+        ondelete="cascade",
+        domain=[("product_assortment_id", "<>", False)],
+    )
+    all_backend = fields.Boolean(
+        string="Exclude in all backends",
+        help="If checked, the product(s) will be excluded from all backend",
+        default=False,
+    )
+    action_type = fields.Selection(
+        selection=[
+            ("exclude", "Exclude"),
+            ("include", "Include"),
+        ],
+        required=True,
+        help="""Include does not mean add to the product assortment
+                it means, remove from exclusion.
+                if product was not excluded -> no changes""",
+    )
+
+    def manage_availability(self):
+        if not self.all_backend and len(self.backend_ids) == 0:
+            raise UserError(
+                _("You need to select a backend or check the 'all backends' option")
+            )
+        tmpl_ids = self.env.context.get("active_ids", False)
+        if self.all_backend:
+            backend_ids = self.env["shopinvader.backend"].search([])
+        else:
+            backend_ids = self.backend_ids
+
+        for backend in backend_ids:
+
+            if not backend.product_assortment_id.blacklist_product_ids.ids:
+                new_blacklist = tmpl_ids
+            else:
+                old = set(backend.product_assortment_id.blacklist_product_ids.ids)
+                new = set(tmpl_ids)
+
+                if self.action_type == "include":
+                    new_blacklist = list(old - new)
+
+                else:
+                    old.update(new)
+                    new_blacklist = list(old)
+
+            backend.product_assortment_id.write(
+                {
+                    "blacklist_product_ids": [(6, 0, new_blacklist)],
+                }
+            )

--- a/shopinvader_assortment/wizards/wizard_online_availability.xml
+++ b/shopinvader_assortment/wizards/wizard_online_availability.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="wizard_online_availability_view" model="ir.ui.view">
+        <field name="name">wizard.online_availability.view</field>
+        <field name="model">wizard.online_availability</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="action_type" />
+                    <field name="backend_ids" options="{'no_create': True}" />
+                    <field name='all_backend' />
+                </group>
+
+                <footer>
+                    <button
+                        string="Manage Online Availability"
+                        name="manage_availability"
+                        type="object"
+                        class="oe_highlight"
+                    />
+                    or
+                    <button string="Cancel" class="oe_link" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="wizard_online_availability_action_menu" model="ir.actions.act_window">
+        <field name="name">Manage Online Availability</field>
+        <field name="res_model">wizard.online_availability</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="product.model_product_template" />
+        <field name="view_id" ref="wizard_online_availability_view" />
+    </record>
+</odoo>


### PR DESCRIPTION
the goal is to add a wizard to facilitate the end-user experience
if he wants to exclude x product from y backend he has to open every ir_filter and exclude those
with this wizard he can do it in one step
just pay attention to action_type include
as explained in the help, it can't be used to add a product to a filter
just to enable again a product that has been removed in the past

@Cedric-Pigeon 