### PR TITLE
[14.0] [FIX] shopinvader_product_order:  sequence on shopinvader.variant

### DIFF
--- a/shopinvader_product_order/models/__init__.py
+++ b/shopinvader_product_order/models/__init__.py
@@ -1,1 +1,2 @@
 from . import shopinvader_product
+from . import shopinvader_variant

--- a/shopinvader_product_order/models/shopinvader_variant.py
+++ b/shopinvader_product_order/models/shopinvader_variant.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ShopinvaderVariant(models.Model):
+    _inherit = "shopinvader.variant"
+    _order = "sequence, name"
+
+    sequence = fields.Integer(
+        related="shopinvader_product_id.sequence",
+        store=True,
+    )


### PR DESCRIPTION
The `shopinvader.variant` model inherits from both `shopinvader.product` and `product.product`, which also inherits from `product.template`.

Both `shopinvader.product` and `product.template` have a sequence field, so we need to explicitly state which one to use.