### PR TITLE
[14.0] Simplify usage w/out Locomotive

### DIFF
--- a/shopinvader/demo/backend_demo.xml
+++ b/shopinvader/demo/backend_demo.xml
@@ -3,7 +3,6 @@
 
     <record id="backend_1" model="shopinvader.backend">
         <field name="name">Demo Shopinvader Website</field>
-        <field name="location">http://locomotive:3000</field>
         <field name="lang_ids" eval="[(6, 0, [ref('base.lang_en')])]" />
         <field name="pricelist_id" ref="product.list0" />
         <field name="account_analytic_id" ref="account_analytic_0" />
@@ -16,7 +15,6 @@
 
     <record id="backend_2" model="shopinvader.backend">
         <field name="name">Demo Shopinvader Website 2</field>
-        <field name="location">http://locomotive:3000</field>
         <field name="lang_ids" eval="[(6, 0, [ref('base.lang_en')])]" />
         <field name="pricelist_id" ref="product.list0" />
         <field name="account_analytic_id" ref="account_analytic_0" />

--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -31,7 +31,6 @@ class ShopinvaderBackend(models.Model):
         required=True,
         default=lambda s: s._default_company_id(),
     )
-    location = fields.Char()
     notification_ids = fields.One2many(
         "shopinvader.notification",
         "backend_id",
@@ -236,10 +235,6 @@ class ShopinvaderBackend(models.Model):
             _("This website unique key already exists in database"),
         )
     ]
-
-    @property
-    def _server_env_fields(self):
-        return {"location": {}}
 
     @api.model
     def _default_company_id(self):

--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -221,6 +221,14 @@ class ShopinvaderBackend(models.Model):
     )
     currency_ids = fields.Many2many(comodel_name="res.currency", string="Currency")
 
+    frontend_data_source = fields.Selection(
+        # TODO @simahawk: this value it's here because the form in core module
+        # already adds a "search engine" page.
+        # I'm not sure it should stay here, it should probalby go to `s_search_engine`.
+        selection=[("search_engine", "Search engine")],
+        help="Technical field to control form fields appeareance",
+        default="search_engine",
+    )
     _sql_constraints = [
         (
             "unique_website_unique_key",

--- a/shopinvader/models/shopinvader_variant.py
+++ b/shopinvader/models/shopinvader_variant.py
@@ -347,5 +347,8 @@ class ShopinvaderVariant(models.Model):
 
     def _get_shop_data(self):
         """Compute shop data base_jsonify parser."""
-        exporter = self.env.ref("shopinvader.ir_exp_shopinvader_variant").sudo()
+        exporter = self._jsonify_get_exporter()
         return self.jsonify(exporter.get_json_parser(), one=True)
+
+    def _jsonify_get_exporter(self):
+        return self.env.ref("shopinvader.ir_exp_shopinvader_variant").sudo()

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -241,7 +241,6 @@
             <tree>
                 <field name="name" />
                 <field name="tech_name" />
-                <field name="location" />
                 <field
                     name="company_id"
                     widget="selection"

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -72,17 +72,22 @@
                         <field name="name" class="oe_inline" />
                     </h1>
                     <notebook>
-                        <page name="config" string="Front-end">
-                            <group name="config" colspan="4" col="4">
-                                <field name="tech_name" />
-                                <field
-                                    name="location"
-                                    placeholder="e.g. https://ecommerce.shopinvader.com"
-                                />
-                                <field name="website_unique_key" />
+                        <page name="config" string="Main">
+                            <group name="config_main" colspan="4" col="4">
+                                <group name="config" colspan="2" col="2">
+                                    <field name="tech_name" />
+                                    <field name="website_unique_key" />
+                                    <field name="frontend_data_source" required="1" />
+                                </group>
+                                <group name="auth" colspan="2" col="2">
+                                </group>
                             </group>
                         </page>
-                        <page name="search_eng" string="Search engine">
+                        <page
+                            name="search_eng"
+                            string="Search engine"
+                            attrs="{'invisible': [('frontend_data_source', '!=', 'search_engine')]}"
+                        >
                             <group name="website_name">
                                 <field name="website_public_name" />
                             </group>

--- a/shopinvader_auth_api_key/views/shopinvader_backend_view.xml
+++ b/shopinvader_auth_api_key/views/shopinvader_backend_view.xml
@@ -11,9 +11,9 @@
         <field name="inherit_id" ref="shopinvader.shopinvader_backend_view_form" />
         <field name="model">shopinvader.backend</field>
         <field name="arch" type="xml">
-            <field name="location" position="after">
+            <group name="auth" position="inside">
                 <field name="auth_api_key_id" />
-            </field>
+            </group>
         </field>
     </record>
 

--- a/shopinvader_auth_jwt/views/shopinvader_backend.xml
+++ b/shopinvader_auth_jwt/views/shopinvader_backend.xml
@@ -7,9 +7,9 @@
         <field name="model">shopinvader.backend</field>
         <field name="inherit_id" ref="shopinvader.shopinvader_backend_view_form" />
         <field name="arch" type="xml">
-            <field name="location" position="after">
+            <group name="auth" position="inside">
                 <field name="jwt_aud" />
-            </field>
+            </group>
         </field>
     </record>
 </odoo>

--- a/shopinvader_locomotive/models/shopinvader_backend.py
+++ b/shopinvader_locomotive/models/shopinvader_backend.py
@@ -38,7 +38,9 @@ class ShopinvaderBackend(models.Model):
     @property
     def _server_env_fields(self):
         env_fields = super()._server_env_fields
-        env_fields.update({"username": {}, "password": {}, "handle": {}})
+        env_fields.update(
+            {"location": {}, "username": {}, "password": {}, "handle": {}}
+        )
         return env_fields
 
     def synchronize_metadata(self):

--- a/shopinvader_locomotive/views/shopinvader_backend_view.xml
+++ b/shopinvader_locomotive/views/shopinvader_backend_view.xml
@@ -7,43 +7,54 @@
         <field name="model">shopinvader.backend</field>
         <field name="inherit_id" ref="shopinvader.shopinvader_backend_view_form" />
         <field name="arch" type="xml">
-            <page name="developer" position="inside">
-                <group name="locomotive" string="LocomotiveCMS">
-                    <span
-                    >Synchronize metadata push data managed by odoo and used into locomotive.
-                        For ex: countries, currencies. If some required metadata
-                        (erp url and credentials, search indexes configuration, ...) are not set into locomotive,
-                        The process will also push default values for these fields. Nevertheless, these specific
-                        metadatas are not updated by the script if a value is already set into locomotive.
-                    </span>
-                    <button
-                        name="synchronize_metadata"
-                        type="object"
-                        string="Synchronize Metadata"
-                        class="oe_highlight"
-                        groups="shopinvader.group_shopinvader_manager"
-                    />
-                    <span>
-                        Reset all the required metadata even those normally not updated by the Synchonize Metadata process.</span>
-                    <button
-                        name="reset_site_settings"
-                        type="object"
-                        string="Reset site settings"
-                        class="oe_highlight"
-                        groups="shopinvader.group_shopinvader_manager"
-                    />
-                </group>
+            <page name="config" position="after">
+                <page name="locomotive" string="LocomotiveCMS">
+                    <group name="locomotive_credentials" string="Credentials">
+                        <field
+                            name="location"
+                            placeholder="e.g. https://ecommerce.shopinvader.com"
+                        />
+                        <field
+                            name="username"
+                            required="1"
+                            string="Email"
+                            colspan="2"
+                        />
+                        <field
+                            name="password"
+                            required="1"
+                            password="True"
+                            colspan="2"
+                        />
+                        <field name="handle" required="1" colspan="2" />
+                    </group>
+                    <group name="locomotive_sync" string="Sync">
+                        <span
+                        >Synchronize metadata push data managed by odoo and used into locomotive.
+                            For ex: countries, currencies. If some required metadata
+                            (erp url and credentials, search indexes configuration, ...) are not set into locomotive,
+                            The process will also push default values for these fields. Nevertheless, these specific
+                            metadatas are not updated by the script if a value is already set into locomotive.
+                        </span>
+                        <button
+                            name="synchronize_metadata"
+                            type="object"
+                            string="Synchronize Metadata"
+                            class="oe_highlight"
+                            groups="shopinvader.group_shopinvader_manager"
+                        />
+                        <span>
+                            Reset all the required metadata even those normally not updated by the Synchonize Metadata process.</span>
+                        <button
+                            name="reset_site_settings"
+                            type="object"
+                            string="Reset site settings"
+                            class="oe_highlight"
+                            groups="shopinvader.group_shopinvader_manager"
+                        />
+                    </group>
+                </page>
             </page>
-            <group name="config" position="after">
-                <group name="locomotive_credentials" string="Locomotive Credentials">
-                    <field name="username" required="1" string="Email" colspan="2" />
-                    <field name="password" required="1" password="True" colspan="2" />
-                    <field name="handle" required="1" colspan="2" />
-                </group>
-            </group>
-            <field name="location" position="attributes">
-                <attribute name="required" eval="True" />
-            </field>
             <field name="pricelist_id" position="after">
                 <field
                     name="currency_ids"

--- a/shopinvader_locomotive_reset_password/views/shopinvader_backend.xml
+++ b/shopinvader_locomotive_reset_password/views/shopinvader_backend.xml
@@ -13,7 +13,10 @@
             ref="shopinvader_locomotive.shopinvader_backend_view_form"
         />
         <field name="arch" type="xml">
-            <xpath expr="//page[@name='config']/group[@name='config']" position="after">
+            <xpath
+                expr="//page[@name='locomotive']/group[@name='locomotive_credentials']"
+                position="after"
+            >
                 <group name="password" colspan="4" col="4">
                     <field name="password_validity" />
                     <field


### PR DESCRIPTION
Doing mostly 3 things here:

1. ease customization of the exporter used for variants
2. add a "frontend data source" selection to ease display of fields based on how you expose the catalog to the frontend
3. move `location` to Locomotive module because this field is useless if you don't use Locomotive (and move its fields to a specific page)

