### PR TITLE
[14.0] Add shopinvader_data_stored

### DIFF
--- a/setup/shopinvader_data_stored/odoo/addons/shopinvader_data_stored
+++ b/setup/shopinvader_data_stored/odoo/addons/shopinvader_data_stored
@@ -1,0 +1,1 @@
+../../../../shopinvader_data_stored

--- a/setup/shopinvader_data_stored/setup.py
+++ b/setup/shopinvader_data_stored/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopinvader_data_stored/README.rst
+++ b/shopinvader_data_stored/README.rst
@@ -1,0 +1,1 @@
+wait 4 the bot

--- a/shopinvader_data_stored/__init__.py
+++ b/shopinvader_data_stored/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/shopinvader_data_stored/__init__.py
+++ b/shopinvader_data_stored/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import pre_init_hook

--- a/shopinvader_data_stored/__manifest__.py
+++ b/shopinvader_data_stored/__manifest__.py
@@ -18,5 +18,6 @@
     "data": [
         "views/shopinvader_variant_view.xml",
     ],
+    "pre_init_hook": "pre_init_hook",
     "installable": True,
 }

--- a/shopinvader_data_stored/__manifest__.py
+++ b/shopinvader_data_stored/__manifest__.py
@@ -13,9 +13,12 @@
     "category": "Shopinvader",
     "depends": [
         "shopinvader",
-        "jsonify_stored",
+        "jsonifier_stored",
     ],
     "data": [
+        "data/queue_job.xml",
+        "views/shopinvader_backend_view.xml",
+        "views/shopinvader_category_view.xml",
         "views/shopinvader_variant_view.xml",
     ],
     "pre_init_hook": "pre_init_hook",

--- a/shopinvader_data_stored/__manifest__.py
+++ b/shopinvader_data_stored/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2022 Camptocamp SA (http://www.camptocamp.com).
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# @author Matthieu Méquignon <matthieu.mequignon@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+{
+    "name": "Shopinvader Data Stored",
+    "version": "14.0.1.0.0",
+    "author": "Camptocamp",
+    "website": "https://github.com/shopinvader/odoo-shopinvader",
+    "license": "AGPL-3",
+    "category": "Shopinvader",
+    "depends": [
+        "shopinvader",
+        "jsonify_stored",
+    ],
+    "data": [
+        "views/shopinvader_variant_view.xml",
+    ],
+    "installable": True,
+}

--- a/shopinvader_data_stored/data/queue_job.xml
+++ b/shopinvader_data_stored/data/queue_job.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="channel_jsonify_stored_root" model="queue.job.channel">
+        <field name="name">json_data</field>
+        <field name="parent_id" ref="shopinvader.channel_shopinvader" />
+        <field name="removal_interval">15</field>
+    </record>
+    <record id="channel_jsonify_stored_variant" model="queue.job.channel">
+        <field name="name">shopinvader_variant</field>
+        <field name="parent_id" ref="channel_jsonify_stored_root" />
+        <field name="removal_interval">15</field>
+    </record>
+    <record id="channel_jsonify_stored_category" model="queue.job.channel">
+        <field name="name">shopinvader_category</field>
+        <field name="parent_id" ref="channel_jsonify_stored_root" />
+        <field name="removal_interval">15</field>
+    </record>
+
+</odoo>

--- a/shopinvader_data_stored/hooks.py
+++ b/shopinvader_data_stored/hooks.py
@@ -1,0 +1,9 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.addons.jsonifier_stored.hooks import add_jsonifier_column
+
+
+def pre_init_hook(cr):
+    table_name = "shopinvader_variant"
+    add_jsonifier_column(cr, table_name)

--- a/shopinvader_data_stored/models/__init__.py
+++ b/shopinvader_data_stored/models/__init__.py
@@ -1,0 +1,1 @@
+from . import shopinvader_variant

--- a/shopinvader_data_stored/models/__init__.py
+++ b/shopinvader_data_stored/models/__init__.py
@@ -1,1 +1,3 @@
+from . import shopinvader_backend
+from . import shopinvader_category
 from . import shopinvader_variant

--- a/shopinvader_data_stored/models/shopinvader_backend.py
+++ b/shopinvader_data_stored/models/shopinvader_backend.py
@@ -1,0 +1,78 @@
+# Copyright 2022 Camptocamp SA (http://www.camptocamp.com).
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+def _default_m2o_from_xid(env, xid):
+    rec = env.ref(xid, False)
+    return rec.id if rec else None
+
+
+class ShopinvaderBackend(models.Model):
+    _inherit = "shopinvader.backend"
+
+    frontend_data_source = fields.Selection(selection_add=[("odoo", "Odoo")])
+    variant_exporter_id = fields.Many2one(
+        comodel_name="ir.exports",
+        domain=[("resource", "=", "shopinvader.variant")],
+        default=lambda self: self._default_variant_exporter_id(),
+    )
+    variant_data_compute_channel_id = fields.Many2one(
+        comodel_name="queue.job.channel",
+        default=lambda self: self._default_variant_channel_id(),
+    )
+    category_exporter_id = fields.Many2one(
+        comodel_name="ir.exports",
+        domain=[("resource", "=", "shopinvader.category")],
+        default=lambda self: self._default_category_exporter_id(),
+    )
+    category_data_compute_channel_id = fields.Many2one(
+        comodel_name="queue.job.channel",
+        default=lambda self: self._default_category_channel_id(),
+    )
+
+    def _default_variant_exporter_id(self):
+        xid = "shopinvader.ir_exp_shopinvader_variant"
+        return _default_m2o_from_xid(self.env, xid)
+
+    def _default_category_exporter_id(self):
+        xid = "shopinvader.ir_exp_shopinvader_category"
+        return _default_m2o_from_xid(self.env, xid)
+
+    def _default_variant_channel_id(self):
+        xid = "shopinvader_data_stored.channel_jsonify_stored_variant"
+        return _default_m2o_from_xid(self.env, xid)
+
+    def _default_category_channel_id(self):
+        xid = "shopinvader_data_stored.channel_jsonify_stored_category"
+        return _default_m2o_from_xid(self.env, xid)
+
+    def force_recompute_all(self):
+        self.ensure_one()
+        json_mixin = self.env["jsonifier.stored.mixin"]
+        domain = [("backend_id", "=", self.id)]
+        for model_name in self._force_recompute_all_models():
+            job_params = {
+                "channel": self._channel_for_model(model_name),
+            }
+            json_mixin.cron_update_json_data_for(
+                model_name,
+                domain=domain,
+                job_params=job_params,
+            )
+        return True
+
+    def _force_recompute_all_models(self):
+        return (
+            x
+            for x in self.env["jsonifier.stored.mixin"]._inherit_children
+            if x.startswith("shopinvader.")
+        )
+
+    def _channel_for_model(self, model):
+        return {
+            "shopinvader.variant": self.variant_data_compute_channel_id.complete_name,
+            "shopinvader.category": self.category_data_compute_channel_id.complete_name,
+        }.get(model)

--- a/shopinvader_data_stored/models/shopinvader_category.py
+++ b/shopinvader_data_stored/models/shopinvader_category.py
@@ -1,0 +1,22 @@
+# Copyright 2022 Camptocamp SA (http://www.camptocamp.com).
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class ShopinvaderCategory(models.Model):
+    _inherit = ["shopinvader.category", "jsonifier.stored.mixin"]
+    _name = "shopinvader.category"
+
+    def get_shop_data(self):
+        # Use pre-computed index data
+        return self.jsonified_data
+
+    def _jsonify_get_exporter(self):
+        return self.backend_id.category_exporter_id
+
+    def _jobify_json_data_compute_default_channel(self):
+        if self.backend_id.category_data_compute_channel_id:
+            return self.backend_id.category_data_compute_channel_id.complete_name
+        return super()._jobify_json_data_compute_default_channel()

--- a/shopinvader_data_stored/models/shopinvader_variant.py
+++ b/shopinvader_data_stored/models/shopinvader_variant.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Camptocamp SA (http://www.camptocamp.com).
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# @author Matthieu Méquignon <matthieu.mequignon@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class ShopinvaderVariant(models.Model):
+    _inherit = ["shopinvader.variant", "jsonify.stored.mixin"]
+    _name = "shopinvader.variant"
+    _description = "Shopinvader Variant"
+
+    def get_shop_data(self):
+        # Use pre-computed index data
+        return self.jsonified_data

--- a/shopinvader_data_stored/models/shopinvader_variant.py
+++ b/shopinvader_data_stored/models/shopinvader_variant.py
@@ -7,10 +7,21 @@ from odoo import models
 
 
 class ShopinvaderVariant(models.Model):
-    _inherit = ["shopinvader.variant", "jsonify.stored.mixin"]
+    _inherit = ["shopinvader.variant", "jsonifier.stored.mixin"]
     _name = "shopinvader.variant"
-    _description = "Shopinvader Variant"
 
     def get_shop_data(self):
         # Use pre-computed index data
         return self.jsonified_data
+
+    def _jsonify_get_exporter(self):
+        return self.backend_id.variant_exporter_id
+
+    def _jobify_json_data_compute_default_channel(self):
+        if self.backend_id.variant_data_compute_channel_id:
+            return self.backend_id.variant_data_compute_channel_id.complete_namme
+        return super()._jobify_json_data_compute_default_channel()
+
+    def _json_data_compute_get_all_langs(self, table=None):
+        # the lang field comes from s.product which in turn gets it from abstract.url
+        return super()._json_data_compute_get_all_langs(table="shopinvader_product")

--- a/shopinvader_data_stored/readme/CONTRIBUTORS.rst
+++ b/shopinvader_data_stored/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Matthieu Méquignon <matthieu.mequignon@camptocamp.com>
+* Simone Orsi <simone.orsi@camptocamp.com>

--- a/shopinvader_data_stored/readme/DESCRIPTION.rst
+++ b/shopinvader_data_stored/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+With this module installed, shopinvader will fetch already computed data,
+instead of computing it on demand.

--- a/shopinvader_data_stored/readme/ROADMAP.rst
+++ b/shopinvader_data_stored/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+* Add tests
+* cleanup `shopinvader_search_engine` when `connector_search_engine` will be refactored

--- a/shopinvader_data_stored/views/shopinvader_backend_view.xml
+++ b/shopinvader_data_stored/views/shopinvader_backend_view.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="shopinvader_backend_view_form" model="ir.ui.view">
+        <field name="model">shopinvader.backend</field>
+        <field name="inherit_id" ref="shopinvader.shopinvader_backend_view_form" />
+        <field name="arch" type="xml">
+            <page name="developer" position="before">
+                <page
+                    name="data"
+                    string="Binding data"
+                    attrs="{'invisible': [('frontend_data_source', '!=', 'odoo')]}"
+                >
+                    <group name="one">
+                        <group name="json_data" string="Data">
+                            <field
+                                name="category_exporter_id"
+                                attrs="{'required': [('frontend_data_source', '=', 'odoo')]}"
+                            />
+                            <field
+                                name="variant_exporter_id"
+                                attrs="{'required': [('frontend_data_source', '=', 'odoo')]}"
+                            />
+                        </group>
+                        <group name="channel_data" string="Job channels">
+                            <field
+                                name="variant_data_compute_channel_id"
+                                attrs="{'required': [('frontend_data_source', '=', 'odoo')]}"
+                            />
+                            <field
+                                name="category_data_compute_channel_id"
+                                attrs="{'required': [('frontend_data_source', '=', 'odoo')]}"
+                            />
+                        </group>
+                    </group>
+                    <group name="actions" col="10" colspan="4">
+                        <button
+                            name="force_recompute_all"
+                            string="Recompute all"
+                            type="object"
+                        />
+                    </group>
+                </page>
+            </page>
+        </field>
+    </record>
+
+</odoo>

--- a/shopinvader_data_stored/views/shopinvader_category_view.xml
+++ b/shopinvader_data_stored/views/shopinvader_category_view.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
 
-<record id="shopinvader_variant_form_view" model="ir.ui.view">
-    <field name="model">shopinvader.variant</field>
-    <field name="inherit_id" ref="shopinvader.shopinvader_variant_form_view" />
+<record id="view_shopinvader_category_form" model="ir.ui.view">
+    <field name="model">shopinvader.category</field>
+    <field name="inherit_id" ref="shopinvader.view_shopinvader_category_form" />
     <field name="arch" type="xml">
-        <page name="main" position="after">
+        <page name="seo" position="after">
             <page name="json_data" string="Data">
                 <group name="jsonified_data" string="JSON-ified Data">
                     <field name="ir_export_id" />
@@ -17,21 +17,24 @@
 </record>
 
 <!-- TODO: remove from s_search_engine when rebased on this work -->
-<record model="ir.actions.server" id="action_recompute_shopinvader_product_on_template">
+<record
+        model="ir.actions.server"
+        id="action_recompute_shopinvader_category_on_category"
+    >
     <field name="name">Recompute JSON data</field>
     <field name="model_id" ref="product.model_product_template" />
     <field name="binding_model_id" ref="product.model_product_template" />
     <field name="state">code</field>
     <field name="code">
-bindings = records.mapped("product_variant_ids.shopinvader_bind_ids")
+bindings = records.mapped("shopinvader_bind_ids")
 env["jsonifier.stored.mixin"].jobify_json_data_compute_for(bindings.browse(), ids=bindings.ids)
     </field>
 </record>
 
-<record model="ir.actions.server" id="action_recompute_shopinvader_product_on_binding">
+<record model="ir.actions.server" id="action_recompute_shopinvader_category_on_binding">
     <field name="name">Recompute JSON data</field>
-    <field name="model_id" ref="shopinvader.model_shopinvader_variant" />
-    <field name="binding_model_id" ref="shopinvader.model_shopinvader_variant" />
+    <field name="model_id" ref="shopinvader.model_shopinvader_category" />
+    <field name="binding_model_id" ref="shopinvader.model_shopinvader_category" />
     <field name="state">code</field>
     <field name="code">
 env["jsonifier.stored.mixin"].jobify_json_data_compute_for(records.browse(), ids=records.ids)

--- a/shopinvader_data_stored/views/shopinvader_variant_view.xml
+++ b/shopinvader_data_stored/views/shopinvader_variant_view.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+<record id="shopinvader_variant_form_view" model="ir.ui.view">
+    <field name="model">shopinvader.variant</field>
+    <field name="inherit_id" ref="shopinvader.shopinvader_variant_form_view" />
+    <field name="arch" type="xml">
+        <page name="main" position="after">
+            <page name="json_data" string="Data">
+                <group name="jsonified_data" string="JSON-ified Data">
+                    <field name="ir_export_id" />
+                </group>
+                <field name="jsonified_display" widget="ace" readonly="1" />
+            </page>
+        </page>
+    </field>
+</record>
+
+<!-- TODO: remove from s_search_engine -->
+<!-- FIXME:  _compute_jsonified_data runs w/out jobs -->
+<record model="ir.actions.server" id="action_recompute_shopinvader_product_on_template">
+    <field name="name">Recompute shopinvader product</field>
+    <field name="model_id" ref="product.model_product_template" />
+    <field name="binding_model_id" ref="product.model_product_template" />
+    <field name="state">code</field>
+    <field name="code">
+        records.mapped("product_variant_ids.shopinvader_bind_ids")._compute_jsonified_data()
+    </field>
+</record>
+
+<record model="ir.actions.server" id="action_recompute_shopinvader_product_on_binding">
+    <field name="name">Recompute shopinvader product</field>
+    <field name="model_id" ref="shopinvader.model_shopinvader_variant" />
+    <field name="binding_model_id" ref="shopinvader.model_shopinvader_variant" />
+    <field name="state">code</field>
+    <field name="code">
+        records._compute_jsonified_data()
+    </field>
+</record>
+
+</odoo>

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,5 @@ vcrpy
 vcrpy-unittest
 unittest2 # For shopinvader test_controller, which inherits component
 odoo-test-helper
+
+odoo14-addon-jsonifier_stored @ git+https://github.com/OCA/server-tools.git@refs/pull/2324/head#subdirectory=setup/jsonifier_stored


### PR DESCRIPTION
Replaces #1237 
Depends on 

- [x] https://github.com/shopinvader/odoo-shopinvader/pull/1277
- [x] https://github.com/OCA/server-tools/pull/2324

Moves out of the search engine the capabilities to pre-compute data to expose via API.
In the long term, it would be ideal to refactor search engine on https://github.com/OCA/server-tools/pull/2324

**TODO**
- [ ] add tests
- [ ] update s_search_engine roadmap