### PR TITLE
[14.0][IMP] shopinvader_assortment: Don't activate cron by default

### DIFF
--- a/shopinvader_assortment/data/ir_cron.xml
+++ b/shopinvader_assortment/data/ir_cron.xml
@@ -21,7 +21,7 @@
             <field name="interval_number">1</field>
             <field name="interval_type">hours</field>
             <field name="numbercall">-1</field>
-            <field name="active" eval="True" />
+            <field name="active" eval="False" />
             <field name="doall" eval="False" />
         </record>
     </data>


### PR DESCRIPTION
People need often to adjust some parameters before activating this cron.
So, don't activate it at install