### PR TITLE
[14.0] [FIX] shopinvader: don't create cart on search

### DIFF
--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -34,7 +34,7 @@ class CartService(Component):
         """Retrieve cart from session or existing cart for current customer."""
         if not self.cart_id:
             return {}
-        return self._to_json(self._get())
+        return self._to_json(self._get(create_if_not_found=False))
 
     def update(self, **params):
         cart = self._get()

--- a/shopinvader/tests/test_cart.py
+++ b/shopinvader/tests/test_cart.py
@@ -267,7 +267,14 @@ class AnonymousCartCase(CartCase, CartClearTest):
         # reset cart_id parameter
         self.service.shopinvader_session.update({"cart_id": False})
         search_result = self.service.search()
-        self.assertDictEqual(search_result, {})
+        self.assertEqual(search_result, {})
+        self.service.shopinvader_session.update({"cart_id": self.cart.id})
+        # if cart is no longer a cart, it shouldn't create one neither
+        # and it should clear the session's cart id
+        self.cart.typology = "sale"
+        search_result = self.service.search()
+        self.assertEqual(search_result["store_cache"]["cart"], {})
+        self.assertEqual(search_result["set_session"]["cart_id"], 0)
 
 
 class CommonConnectedCartCase(CartCase):


### PR DESCRIPTION
`search` shouldn't create a cart if missing.

This covers the case where a `cart_id` is present in the session, but it references a cart that's no longer a valid cart for our service.