### PR TITLE
[14.0][IMP] shopinvader_elasticsearch: Don't replace the search engine backend

### DIFF
--- a/shopinvader_elasticsearch/demo/backend_demo.xml
+++ b/shopinvader_elasticsearch/demo/backend_demo.xml
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
 
-    <record id="shopinvader.backend_1" model="shopinvader.backend">
+    <record id="backend_elasticsearch_demo" model="shopinvader.backend">
+        <field name="name">Demo Shopinvader with Elasticsearch</field>
+        <field name="lang_ids" eval="[(6, 0, [ref('base.lang_en')])]" />
+        <field name="pricelist_id" ref="product.list0" />
+        <field name="account_analytic_id" ref="shopinvader.account_analytic_0" />
+        <field
+            name="allowed_country_ids"
+            eval="[(6, 0, [ref('base.fr'),ref('base.lu'),ref('base.be'),ref('base.it'),ref('base.es')])]"
+        />
+        <field name="currency_ids" eval="[(6, 0, [ref('base.USD'),ref('base.EUR')])]" />
         <field
             name="se_backend_id"
             ref="connector_elasticsearch.backend_1_se_backend"

--- a/shopinvader_elasticsearch/tests/test_settings.py
+++ b/shopinvader_elasticsearch/tests/test_settings.py
@@ -18,6 +18,9 @@ ES_CONFIG_US = {
 class TestSettingsService(CommonCase):
     def setUp(self, *args, **kwargs):
         super().setUp(*args, **kwargs)
+        self.backend = self.env.ref(
+            "shopinvader_elasticsearch.backend_elasticsearch_demo"
+        )
         with self.work_on_services(
             partner=self.env.ref("shopinvader.partner_1")
         ) as work:

--- a/shopinvader_elasticsearch/tests/test_shopinvader_elasticsearch.py
+++ b/shopinvader_elasticsearch/tests/test_shopinvader_elasticsearch.py
@@ -19,7 +19,9 @@ class TestElasticsearchBackend(VCRMixin, TestBindingIndexBase):
         ElasticsearchAdapter._build_component(cls._components_registry)
         cls.backend_specific = cls.env.ref("connector_elasticsearch.backend_1")
         cls.backend = cls.backend_specific.se_backend_id
-        cls.shopinvader_backend = cls.env.ref("shopinvader.backend_1")
+        cls.shopinvader_backend = cls.env.ref(
+            "shopinvader_elasticsearch.backend_elasticsearch_demo"
+        )
         cls.shopinvader_backend.bind_all_product()
         cls.shopinvader_backend.bind_all_category()
         cls.index_product = cls.env.ref("shopinvader_elasticsearch.index_1")


### PR DESCRIPTION
When loading demo data, don't replace the search engine backend on shopinvader backend
as a complex install could have several from different types.