### PR TITLE
[14.0][FIX] shopinvader_invoice: Add set_session in get()

### DIFF
--- a/shopinvader_invoice/services/invoice.py
+++ b/shopinvader_invoice/services/invoice.py
@@ -13,7 +13,10 @@ class InvoiceService(Component):
         :return: dict/json
         """
         invoice = self._get(_id)
-        result = {"data": self._to_json(invoice)[0]}
+        result = {
+            "data": self._to_json(invoice)[0],
+            "set_session": {"invoice_id": invoice.id},
+        }
         return result
 
     def search(self, **params):
@@ -43,7 +46,9 @@ class InvoiceService(Component):
         :return: dict
         """
         invoice_schema = self._get_return_invoice_schema()
-        schema = {"data": {"type": "dict", "schema": invoice_schema}}
+        schema = {
+            "set_session": {"type": "dict"},
+            "data": {"type": "dict", "schema": invoice_schema}}
         return schema
 
     def _validator_return_search(self):

--- a/shopinvader_invoice/tests/test_invoice_service.py
+++ b/shopinvader_invoice/tests/test_invoice_service.py
@@ -21,7 +21,9 @@ class TestInvoiceServiceAnonymous(CommonInvoiceCase):
         # Check first without invoice related to the anonymous user
         result = self.service_guest.dispatch("search")
         data = result.get("data", [])
+        invoice_id = result.get("set_session", {}).get("invoice_id")
         self.assertFalse(data)
+        self.assertFalse(invoice_id)
         # Then create a invoice related to the anonymous user
         invoice = self._create_invoice(
             partner=self.backend.anonymous_partner_id, validate=True
@@ -160,6 +162,11 @@ class TestInvoiceService(CommonInvoiceCase):
         self.assertEqual(invoice4.partner_id, self.service.partner)
         result = self.service.dispatch("get", invoice1.id)
         data = result.get("data", [])
+        invoice_id = result.get("set_session", {}).get("invoice_id")
+        self.assertEqual(
+            invoice_id,
+            invoice1.id,
+        )
         self._check_data_content([data], invoice1)
         return
 


### PR DESCRIPTION
In order to get correct header filled in with an entry
HTTP_SESS_INVOICE_ID, add the set_session with the invoice id.