### PR TITLE
shopinvader: fix default notifications

### DIFF
--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -35,7 +35,6 @@ class ShopinvaderBackend(models.Model):
         "shopinvader.notification",
         "backend_id",
         "Notification",
-        default=lambda self: self.env["shopinvader.notification"].search([]),
     )
     nbr_product = fields.Integer(
         compute="_compute_nbr_content", string="Number of bound products"


### PR DESCRIPTION
When creating a new backend,
all existing backends' notifications are 'stolen' by the new one.

Replaces https://github.com/shopinvader/odoo-shopinvader/pull/1255 to fix the commit msg