### PR TITLE
[14.0][UPD] shopinvader partner binding: dedicated res.groups

### DIFF
--- a/shopinvader/migrations/14.0.5.14.1/post-migrate.py
+++ b/shopinvader/migrations/14.0.5.14.1/post-migrate.py
@@ -1,0 +1,25 @@
+# Copyright 2022 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import SUPERUSER_ID, api
+
+
+def _upgrade_shopinvader_model_access(env):
+    """
+    Upgrade the "shopinvader partner binding edit" access rights
+    (as it's not update)
+    """
+    sec_group = env.ref("shopinvader.group_shopinvader_partner_binding")
+    env.ref("shopinvader.access_shopinvader_partner_edit").write(
+        {
+            "group_id": sec_group.id,
+        }
+    )
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        _upgrade_shopinvader_model_access(env)

--- a/shopinvader/security/ir.model.access.csv
+++ b/shopinvader/security/ir.model.access.csv
@@ -7,7 +7,7 @@ access_shopinvader_product_edit,shopinvader_product edit,model_shopinvader_produ
 access_shopinvader_product_read,shopinvader_product read,model_shopinvader_product,base.group_user,1,0,0,0
 access_shopinvader_variant_edit,shopinvader_variant edit,model_shopinvader_variant,shopinvader.group_shopinvader_manager,1,1,1,1
 access_shopinvader_variant_read,shopinvader_variant read,model_shopinvader_variant,base.group_user,1,0,0,0
-access_shopinvader_partner_edit,shopinvader_partner edit,model_shopinvader_partner,shopinvader.group_shopinvader_manager,1,1,1,1
+access_shopinvader_partner_edit,shopinvader_partner edit,model_shopinvader_partner,shopinvader.group_shopinvader_partner_binding,1,1,1,1
 access_shopinvader_partner_read,shopinvader_partner read,model_shopinvader_partner,base.group_user,1,0,0,0
 access_product_filter_employee,product.filter employee,model_product_filter,base.group_user,1,0,0,0
 access_product_filter_sale_manager,product.filter salemanager,model_product_filter,sales_team.group_sale_manager,1,1,1,1

--- a/shopinvader/security/shopinvader_security.xml
+++ b/shopinvader/security/shopinvader_security.xml
@@ -6,8 +6,12 @@
         <field name="sequence">30</field>
     </record>
 
+    <record id="group_shopinvader_partner_binding" model="res.groups">
+        <field name="name">Shopinvader partner binding</field>
+    </record>
+
     <record id="group_shopinvader_manager" model="res.groups">
-        <field name="name">Shopinvader Manager</field>
+        <field name="name">Manager</field>
         <field name="category_id" ref="module_category_shopinvader" />
         <field
             name="users"
@@ -15,7 +19,7 @@
         />
         <field
             name="implied_ids"
-            eval="[(4, ref('queue_job.group_queue_job_manager'))]"
+            eval="[(4, ref('queue_job.group_queue_job_manager')), (4, ref('shopinvader.group_shopinvader_partner_binding'))]"
         />
     </record>
 

--- a/shopinvader/wizards/shopinvader_partner_binding.xml
+++ b/shopinvader/wizards/shopinvader_partner_binding.xml
@@ -50,7 +50,7 @@
         <field name="view_id" ref="shopinvader_partner_binding_form_view" />
         <field
             name="groups_id"
-            eval="[(4, ref('shopinvader.group_shopinvader_manager'))]"
+            eval="[(4, ref('shopinvader.group_shopinvader_partner_binding'))]"
         />
     </record>
 


### PR DESCRIPTION
Add a new security group only allowed to bind partners. Binders doesn't need full access rights just to bind.

The existing security group implies this new one (so it stills compatible).

And as the `ir.model.access` is `noupdate="1"`, I did a migration script.