### PR TITLE
[14.0] shopinvader_image: allow skipping CDN URL 

### DIFF
--- a/shopinvader_image/models/shopinvader_backend.py
+++ b/shopinvader_image/models/shopinvader_backend.py
@@ -1,8 +1,28 @@
 # Copyright 2017 Akretion (http://www.akretion.com).
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
+# Copyright 2022 Camptocamp SA (http://www.camptocamp.com)
+# @author Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
+
+CDN_HELP_TEXT = """
+Enable this flag to control
+whether the CDN URL must be included or not
+in the URL stored in images' JSON data.
+
+OFF: the URL will NOT include the CDN URL (eg: only the relative path);
+ON: the URL will include the CDN URL;
+
+Excluding the URL can be useful to:
+
+1. reduce payload size w/o duplicating data
+2. allow using the same storage w/ different CDN
+
+If you use this option,
+take care of adding the CDN URL on your frontend
+to all images' relative path.
+"""
 
 
 class ShopinvaderBackend(models.Model):
@@ -17,4 +37,10 @@ class ShopinvaderBackend(models.Model):
         comodel_name="shopinvader.image.resize",
         relation="category_image_resize",
         string="Category Image Size",
+    )
+    # TODO: set default False in v > 15.
+    image_data_include_cdn_url = fields.Boolean(
+        string="Image URLs w/ CDN",
+        help=CDN_HELP_TEXT,
+        default=True,
     )

--- a/shopinvader_image/models/shopinvader_image_mixin.py
+++ b/shopinvader_image/models/shopinvader_image_mixin.py
@@ -81,7 +81,7 @@ class ShopinvaderImageMixin(models.AbstractModel):
         # NOTE: this is not perfect in terms of perf because it will cause
         # calls to `get_or_create_thumbnail` when no image data has changed
         # but it's better than having broken URLs.
-        public_urls = tuple(images.mapped("url"))
+        public_urls = tuple([self._get_image_url(x) for x in images])
         resize_scales = tuple(
             self._resize_scales().mapped(lambda r: (r.key, r.size_x, r.size_y))
         )
@@ -122,7 +122,11 @@ class ShopinvaderImageMixin(models.AbstractModel):
         :return: dict
         """
         self.ensure_one()
-        res = {"src": thumbnail.url, "alt": self.name}
+        res = {"src": self._get_image_url(thumbnail), "alt": self.name}
         if "tag_id" in image_relation._fields:
             res["tag"] = image_relation.tag_id.name or ""
         return res
+
+    def _get_image_url(self, image):
+        fname = "url" if self.backend_id.image_data_include_cdn_url else "url_path"
+        return image[fname]

--- a/shopinvader_image/tests/test_images.py
+++ b/shopinvader_image/tests/test_images.py
@@ -17,15 +17,47 @@ class TestShopinvaderImage(TestShopinvaderImageCase):
     # TODO: test permission explicitely if needed
 
     def test_basic_images_compute(self):
+        storage_backend = self.shopinvader_variant.image_ids.image_id.backend_id
+        storage_backend.write(
+            {
+                "served_by": "external",
+                "base_url": "https://foo.com",
+            }
+        )
         images = self.shopinvader_variant.images
         self.assertEqual(len(images), 2)
         for image in images:
             for scale in self.backend.shopinvader_variant_resize_ids:
                 img = image[scale.key]
                 self.assertEqual(img["alt"], self.shopinvader_variant.name)
-                self.assertIn(
-                    "customizable-desk-config_{0.size_x}_{0.size_y}".format(scale),
-                    img["src"],
+                self.assertTrue(
+                    img["src"].startswith(
+                        "https://foo.com/customizable-desk-config_{0.size_x}_{0.size_y}".format(
+                            scale
+                        )
+                    )
+                )
+                self.assertIn("tag", img)
+
+    def test_basic_images_compute_no_cdn_url(self):
+        storage_backend = self.shopinvader_variant.image_ids.image_id.backend_id
+        storage_backend.write(
+            {
+                "served_by": "external",
+                "base_url": "https://foo.com",
+            }
+        )
+        self.backend.image_data_include_cdn_url = False
+        images = self.shopinvader_variant.images
+        self.assertEqual(len(images), 2)
+        for image in images:
+            for scale in self.backend.shopinvader_variant_resize_ids:
+                img = image[scale.key]
+                self.assertEqual(img["alt"], self.shopinvader_variant.name)
+                self.assertTrue(
+                    img["src"].startswith(
+                        "/customizable-desk-config_{0.size_x}_{0.size_y}".format(scale)
+                    )
                 )
                 self.assertIn("tag", img)
 

--- a/shopinvader_image/views/shopinvader_backend_view.xml
+++ b/shopinvader_image/views/shopinvader_backend_view.xml
@@ -15,6 +15,7 @@
                         name="shopinvader_category_resize_ids"
                         widget="many2many_tags"
                     />
+                    <field name="image_data_include_cdn_url" />
                 </group>
             </page>
         </field>


### PR DESCRIPTION
Excluding the URL can be useful to:

1. reduce payload size w/o duplicating dat
2. allow using the same storage w/ different CDN

If you use this option,
take care of adding the CDN url on your frontend.

Depends on:
- [x] https://github.com/OCA/storage/pull/186