### PR TITLE
[14.0] shopinvader: improve _convert_one_line method in abstract_sale service

### DIFF
--- a/shopinvader/services/abstract_sale.py
+++ b/shopinvader/services/abstract_sale.py
@@ -55,7 +55,9 @@ class AbstractSaleService(AbstractComponent):
             # this likely should never happen if the request from client
             # is forwarded properly
             variant = line.product_id._get_invader_variant(
-                self.shopinvader_backend, line.order_id.partner_id.lang
+                self.shopinvader_backend,
+                line.order_id.partner_id.lang,
+                safe_default=True,
             )
         product = self._convert_one_line_product(variant)
         return {


### PR DESCRIPTION
This method now has another default in case no variants match the language of the partner_id.
It now uses the language of the backend as a last resort.