### PR TITLE
[14.0][FIX] shopinvader: fix active=True on shopinvader_product

### DIFF
--- a/shopinvader/models/shopinvader_variant.py
+++ b/shopinvader/models/shopinvader_variant.py
@@ -76,11 +76,7 @@ class ShopinvaderVariant(models.Model):
     def _compute_active(self):
         """Deactivate bindings if related records are archived"""
         for rec in self:
-            rec.active = (
-                rec.active
-                and rec.shopinvader_product_id.active
-                and rec.record_id.active
-            )
+            rec.active = rec.shopinvader_product_id.active and rec.record_id.active
 
     @api.depends("product_template_attribute_value_ids")
     def _compute_attribute_value_ids(self):

--- a/shopinvader/tests/test_product.py
+++ b/shopinvader/tests/test_product.py
@@ -895,6 +895,30 @@ class ProductCase(ProductCommonCase):
         with self._check_correct_unbind_active(self.shopinvader_variants):
             fields.first(self.shopinvader_variants).write({"active": False})
 
+    def test_toggle_active(self):
+        """
+        Ensure toggle active of the shopinvader.variant is propagated
+        If active=False is set on shopinvader.product,
+            then all variants should be active=False
+        If active=True is set on shopinvader.product,
+            then all variant should be active=True
+        :return:
+        """
+        shopinv_product = self.shopinvader_variants.mapped("shopinvader_product_id")
+        self.assertEqual(len(shopinv_product), 1)
+        self.assertGreaterEqual(len(self.shopinvader_variants), 1)
+        # Init: every variants and shopinv product are active True
+        self.shopinvader_variants.write({"active": True})
+        shopinv_product.write({"active": True})
+
+        # Disable the product
+        shopinv_product.write({"active": False})
+        self.assertFalse(all([a.active for a in self.shopinvader_variants]))
+
+        # Re-enable the product
+        shopinv_product.write({"active": True})
+        self.assertTrue(all([a.active for a in self.shopinvader_variants]))
+
     def test_get_invader_variant(self):
         lang = self._install_lang("base.lang_fr")
         self.backend.lang_ids |= lang

--- a/shopinvader/views/shopinvader_product_view.xml
+++ b/shopinvader/views/shopinvader_product_view.xml
@@ -164,6 +164,7 @@
                                             name="shopinvader_backend_ids"
                                             widget="many2many_tags"
                                         />
+                                        <field name="active" widget="boolean_toggle" />
                                     </tree>
                                 </field>
                             </group>


### PR DESCRIPTION
Propagate active=True to variants
(before only active=False was propagated)
And add the active field on shopinvader_product_view