### PR TITLE
[14.0] shopinvader: expose commitment_date in orders service

### DIFF
--- a/shopinvader/services/abstract_sale.py
+++ b/shopinvader/services/abstract_sale.py
@@ -24,6 +24,7 @@ class AbstractSaleService(AbstractComponent):
             "state_label": state_label,
             "name": sale.name,
             "date": sale.date_order,
+            "date_delivery": sale.commitment_date,
             "client_order_ref": sale.client_order_ref,
             "step": self._convert_step(sale),
             "lines": self._convert_lines(sale),


### PR DESCRIPTION
Until now, only date_order was exposed when requesting a sale.order record. 
This change adds commitment_date to the list of values exposed.