### PR TITLE
[14.0][IMP] shopinvader: add possibility to use a specific exporter

### DIFF
--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -227,6 +227,15 @@ class ShopinvaderBackend(models.Model):
         help="Technical field to control form fields appeareance",
         default="search_engine",
     )
+    variant_exporter_id = fields.Many2one(
+        comodel_name="ir.exports",
+        string="Variant exporter for website",
+        help="Specific variants exporter for website call (after add to cart etc).\n"
+        "By default the json generated for Search engine is used."
+        "But this one might contains a lot of data who is not necessary for the front side.\n"
+        "That cost a lot in Database-read/network/json-cast time.",
+        domain=[("resource", "=", "shopinvader.variant")],
+    )
     _sql_constraints = [
         (
             "unique_website_unique_key",

--- a/shopinvader/models/shopinvader_variant.py
+++ b/shopinvader/models/shopinvader_variant.py
@@ -343,6 +343,9 @@ class ShopinvaderVariant(models.Model):
 
     def get_shop_data(self):
         """Return product data for the shop."""
+        if self.backend_id.variant_exporter_id:
+            exporter = self.backend_id.variant_exporter_id
+            return self.jsonify(exporter.get_json_parser(), one=True)
         return self._get_shop_data()
 
     def _get_shop_data(self):

--- a/shopinvader/tests/test_backend.py
+++ b/shopinvader/tests/test_backend.py
@@ -176,3 +176,20 @@ class BackendCase(CommonCase):
             "new_key"
         )
         self.assertEqual(self.backend, backend)
+
+    def test_variant_exporter(self):
+        exporter = self.env["ir.exports"].create(
+            {
+                "name": "Specific variant export 1",
+                "resource": "shopinvader.variant",
+                "export_fields": [
+                    (0, False, {"name": "id"}),
+                    (0, False, {"name": "name"}),
+                ],
+            }
+        )
+        self.backend.write({"variant_exporter_id": exporter.id})
+        variant = self.env["shopinvader.variant"].search([], limit=1)
+        data = variant.get_shop_data()
+        expected_data = variant.jsonify(exporter.get_json_parser(), one=True)
+        self.assertEqual(expected_data, data)

--- a/shopinvader/views/shopinvader_backend_view.xml
+++ b/shopinvader/views/shopinvader_backend_view.xml
@@ -135,7 +135,10 @@
                         </page>
                         <page name="products" string="Products">
                             <group>
-                                <field name="use_shopinvader_product_name" />
+                                <group>
+                                    <field name="use_shopinvader_product_name" />
+                                    <field name="variant_exporter_id" />
+                                </group>
                             </group>
                         </page>
                         <page name="localization" string="Localization">


### PR DESCRIPTION
Add possibility to use a specific exporter for shopinvader.variant json used as response in shopinvader_request case.

By default, the M2O field is empty and keep the previous behaviour.