### PR TITLE
[FIX] 14.0: export_selected_products: 1 at a time

### DIFF
--- a/shopinvader/models/shopinvader_backend.py
+++ b/shopinvader/models/shopinvader_backend.py
@@ -448,11 +448,11 @@ class ShopinvaderBackend(models.Model):
             grouped_by_template = defaultdict(self.env["product.product"].browse)
             for rec in products:
                 grouped_by_template[rec.product_tmpl_id] |= rec
-            method = backend.with_delay().bind_single_product
-            if run_immediately:
-                method = backend.bind_single_product
             for tmpl, variants in grouped_by_template.items():
-                method(langs, tmpl, variants)
+                if run_immediately:
+                    backend.bind_single_product(langs, tmpl, variants)
+                else:
+                    backend.with_delay().bind_single_product(langs, tmpl, variants)
 
     def bind_single_product(self, langs, product_tmpl, variants):
         """Bind given product variants for given template and languages.


### PR DESCRIPTION
before:

Wen using `with_delay`, when the function is called with several products, it creates one job instead of 1 per product

after:

It creates 1 job per product



This is due to `with_delay` being called only once. And `with_delay` only creates one job and not 1 per function call.
I don't know if this should be changed in `queue_job` or if this is wanted.