### PR TITLE
[IMP] shopinvader_delivery_carrier: Add update_carrier_shipping_costs

### DIFF
--- a/shopinvader_delivery_carrier/__manifest__.py
+++ b/shopinvader_delivery_carrier/__manifest__.py
@@ -20,6 +20,7 @@
         "sale_shipping_info_helper",
         "delivery_carrier_info",
     ],
+    # odoo_test_helper is needed for the tests
     "data": ["views/backend_view.xml", "data/cart_step.xml"],
     "demo": [
         "demo/backend_demo.xml",

--- a/shopinvader_delivery_carrier/tests/common.py
+++ b/shopinvader_delivery_carrier/tests/common.py
@@ -1,6 +1,7 @@
 # Copyright 2017 Akretion (http://www.akretion.com).
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo_test_helper import FakeModelLoader
 
 from odoo.addons.shopinvader.tests.test_cart import CommonConnectedCartCase
 
@@ -9,14 +10,54 @@ class CommonCarrierCase(CommonConnectedCartCase):
     @classmethod
     def setUpClass(cls):
         super(CommonCarrierCase, cls).setUpClass()
+        cls.loader = FakeModelLoader(cls.env, cls.__module__)
+        cls.loader.backup_registry()
+
+        from .models import OtherCarrier
+
+        cls.loader.update_registry((OtherCarrier,))
+
         cls.free_carrier = cls.env.ref("delivery.free_delivery_carrier")
-        cls.poste_carrier = cls.env.ref("delivery.delivery_carrier")
         cls.free_carrier.code = "FREE"
         cls.free_carrier.description = "delivery in 5 days"
+
+        cls.poste_carrier = cls.env.ref("delivery.delivery_carrier")
         cls.poste_carrier.code = "POSTE"
         cls.poste_carrier.description = "delivery in 2 days"
+
+        cls.other_carrier = cls.env["delivery.carrier"].create(
+            {
+                "name": "Other carrier",
+                "code": "OTHER",
+                "description": "delivery computed by the carrier",
+                "delivery_type": "other",
+                "product_id": cls.env["product.product"]
+                .create(
+                    {
+                        "name": "Other delivery",
+                        "default_code": "OTHER_DELIVERY",
+                        "type": "service",
+                        "categ_id": cls.env.ref(
+                            "delivery.product_category_deliveries"
+                        ).id,
+                        "sale_ok": False,
+                        "purchase_ok": False,
+                        "list_price": "0.0",
+                        "invoice_policy": "order",
+                    }
+                )
+                .id,
+            }
+        )
+        cls.other_carrier.description = "delivery computed by the carrier"
+
         cls.product_1 = cls.env.ref("product.product_product_4b")
         cls.precision = 2
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.loader.restore_registry()
+        super().tearDownClass()
 
     def extract_cart(self, response):
         self.shopinvader_session["cart_id"] = response["set_session"]["cart_id"]
@@ -41,6 +82,9 @@ class CommonCarrierCase(CommonConnectedCartCase):
         return self.extract_cart(
             self.service.dispatch("delete_item", params={"item_id": item_id})
         )
+
+    def update_carrier_shipping_costs(self):
+        return self.extract_cart(self.service.dispatch("update_carrier_shipping_costs"))
 
     def _set_carrier(self, carrier):
         response = self.service.dispatch(

--- a/shopinvader_delivery_carrier/tests/models.py
+++ b/shopinvader_delivery_carrier/tests/models.py
@@ -1,0 +1,30 @@
+from odoo import fields, models
+
+
+class OtherCarrier(models.Model):
+    _inherit = "delivery.carrier"
+
+    delivery_type = fields.Selection(
+        selection_add=[
+            ("other", "Other"),
+        ],
+        ondelete={
+            "other": lambda recs: recs.write(
+                {
+                    "delivery_type": "fixed",
+                    "fixed_price": 0,
+                }
+            )
+        },
+    )
+    per_unit_price = fields.Float("Per Unit Price", default=10)
+
+    def other_rate_shipment(self, order):
+        # Return a test price of per_unit_price per item
+        return {
+            "success": True,
+            "price": self.per_unit_price
+            * sum(order.order_line.mapped("product_uom_qty")),
+            "error_message": False,
+            "warning_message": False,
+        }

--- a/shopinvader_delivery_carrier/tests/test_carrier.py
+++ b/shopinvader_delivery_carrier/tests/test_carrier.py
@@ -73,6 +73,58 @@ class CarrierCase(CommonCarrierCase):
             },
         )
 
+    def test_setting_other_carrier(self):
+        self.backend.carrier_ids |= self.other_carrier
+        cart = self._set_carrier(self.other_carrier)
+        self.assertEqual(cart["shipping"]["amount"]["total"], 60)
+        self.assertEqual(
+            cart["shipping"]["selected_carrier"],
+            {
+                "description": self.other_carrier.description,
+                "id": self.other_carrier.id,
+                "name": self.other_carrier.name,
+                "code": self.other_carrier.code,
+            },
+        )
+
+    def test_setting_other_carrier_add_item(self):
+        self.backend.carrier_ids |= self.other_carrier
+        cart = self._set_carrier(self.other_carrier)
+        self.assertEqual(cart["shipping"]["amount"]["total"], 60)
+        self.assertEqual(
+            cart["shipping"]["selected_carrier"],
+            {
+                "description": self.other_carrier.description,
+                "id": self.other_carrier.id,
+                "name": self.other_carrier.name,
+                "code": self.other_carrier.code,
+            },
+        )
+        cart = self.add_item(self.product_1.id, 2)
+        cart = self._set_carrier(self.other_carrier)
+        self.assertEqual(cart["shipping"]["amount"]["total"], 80)
+
+    def test_setting_other_carrier_update_carrier_shipping_costs(self):
+        self.backend.carrier_ids |= self.other_carrier
+        cart = self._set_carrier(self.other_carrier)
+        self.assertEqual(cart["shipping"]["amount"]["total"], 60)
+        self.assertEqual(
+            cart["shipping"]["selected_carrier"],
+            {
+                "description": self.other_carrier.description,
+                "id": self.other_carrier.id,
+                "name": self.other_carrier.name,
+                "code": self.other_carrier.code,
+            },
+        )
+        self.other_carrier.write({"per_unit_price": 100})
+
+        cart = self.extract_cart(self.service.dispatch("search"))
+        self.assertEqual(cart["shipping"]["amount"]["total"], 60)
+
+        cart = self.update_carrier_shipping_costs()
+        self.assertEqual(cart["shipping"]["amount"]["total"], 600)
+
     def test_reset_carrier_on_add_item(self):
         self._apply_carrier_and_assert_set()
         cart = self.add_item(self.product_1.id, 2)


### PR DESCRIPTION
update_carrier_shipping_costs updates shipping costs for custom carriers that need the rate_shipment method to be called (Get Rate button in odoo UI).

Also automatically recompute carrier shipping costs on set_carrier.