### PR TITLE
Shopinvader_delivery_carrier: improve view UX

### DIFF
--- a/shopinvader_delivery_carrier/models/shopinvader_backend.py
+++ b/shopinvader_delivery_carrier/models/shopinvader_backend.py
@@ -17,6 +17,11 @@ class ShopinvaderBackend(models.Model):
             ("assigned|done", "Ready and done"),
         ],
         default="assigned|done",
+        help="""Allows to filter out pickings based on state
+            All: publish all pickings
+            All but draft: filter out only draft and cancels pickings
+            Ready and done: publish only assigned and done pickings
+        """,
     )
 
     def _get_visible_delivery_order_states(self):

--- a/shopinvader_delivery_carrier/views/backend_view.xml
+++ b/shopinvader_delivery_carrier/views/backend_view.xml
@@ -8,7 +8,7 @@
             <page name="delivery" position="inside">
                 <group name="carrier" string="Carrier">
                     <field name="delivery_order_states" />
-                    <field name="carrier_ids" nolabel="1" />
+                    <field name="carrier_ids" />
                 </group>
             </page>
         </field>


### PR DESCRIPTION
- Remove no-label on delivery methods.
- add help message en delivery_order_states