### PR TITLE
[14.0] [IMP] `shopinvader_customer_multi_user_company_group`: Split records and address policies

### DIFF
--- a/shopinvader_customer_multi_user_company_group/__manifest__.py
+++ b/shopinvader_customer_multi_user_company_group/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Shopinvader Customer Multi User Company Group",
     "summary": "Share shopinvader records within the Company Group",
-    "version": "14.0.1.0.0",
+    "version": "14.0.2.0.0",
     "license": "AGPL-3",
     "author": "Camptocamp SA",
     "website": "https://github.com/shopinvader/odoo-shopinvader",

--- a/shopinvader_customer_multi_user_company_group/migrations/14.0.2.0.0/post-migrate.py
+++ b/shopinvader_customer_multi_user_company_group/migrations/14.0.2.0.0/post-migrate.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    cr.execute(
+        """
+        UPDATE shopinvader_backend
+        SET multi_user_company_group_address_policy =
+            multi_user_company_group_records_policy
+        """
+    )

--- a/shopinvader_customer_multi_user_company_group/models/shopinvader_backend.py
+++ b/shopinvader_customer_multi_user_company_group/models/shopinvader_backend.py
@@ -25,3 +25,20 @@ class ShopinvaderBackend(models.Model):
         default="hierarchy",
         required=True,
     )
+    multi_user_company_group_address_policy = fields.Selection(
+        selection=[
+            ("hierarchy", "View addresses down the company group hierarchy"),
+            ("shared", "Share addresses across companies in the group"),
+        ],
+        help=(
+            "This affects the behavior of every endpoint which lists partner related "
+            "records, directy or indirectly.\n\n"
+            "* `View addresses down the company group hierarchy`: Users that are part "
+            "of the company group will see addresses from the companies that belong to "
+            "it, but those companies users will only see their own company addresses.\n"
+            "* `Share addresses across companies in the group`: Addresses will be "
+            "shared among companies belonging to the same company group.\n"
+        ),
+        default="hierarchy",
+        required=True,
+    )

--- a/shopinvader_customer_multi_user_company_group/models/shopinvader_partner.py
+++ b/shopinvader_customer_multi_user_company_group/models/shopinvader_partner.py
@@ -80,8 +80,8 @@ class ShopinvaderPartner(models.Model):
             )
         # Regular company group users can see public shared addresses down the hierarchy.
         # This is also the case with the "shared" policy for non company group users.
-        group_records_policy = self.backend_id.multi_user_company_group_records_policy
-        if self.is_company_group_user or group_records_policy == "shared":
+        group_address_policy = self.backend_id.multi_user_company_group_address_policy
+        if self.is_company_group_user or group_address_policy == "shared":
             return expression.OR(
                 [
                     res,

--- a/shopinvader_customer_multi_user_company_group/tests/test_multi_user_service_partner_domain.py
+++ b/shopinvader_customer_multi_user_company_group/tests/test_multi_user_service_partner_domain.py
@@ -11,6 +11,7 @@ class TestMultiUserRecordsHierarchy(TestMultiUserCompanyGroupCommon):
         super().setUpClass()
         cls.backend.multi_user_records_policy = "main_partner_id"
         cls.backend.multi_user_company_group_records_policy = "hierarchy"
+        cls.backend.multi_user_company_group_address_policy = "hierarchy"
 
     def test_hierarchy_company_group__company(self):
         """The company group sees everything"""
@@ -102,6 +103,7 @@ class TestMultiUserRecordsShared(TestMultiUserCompanyGroupCommon):
         super().setUpClass()
         cls.backend.multi_user_records_policy = "main_partner_id"
         cls.backend.multi_user_company_group_records_policy = "shared"
+        cls.backend.multi_user_company_group_address_policy = "shared"
 
     def test_shared_company_group__company(self):
         """The company group sees everything"""
@@ -182,4 +184,70 @@ class TestMultiUserRecordsShared(TestMultiUserCompanyGroupCommon):
                 | self.all_public_addresses
             ),
             orders=orders,
+        )
+
+
+class TestMultiUserRecordsMixed(TestMultiUserCompanyGroupCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.backend.multi_user_records_policy = "main_partner_id"
+        cls.backend.multi_user_company_group_records_policy = "hierarchy"
+        cls.backend.multi_user_company_group_address_policy = "shared"
+
+    def test_mixed_company_group__company(self):
+        """The company group sees everything"""
+        self._test_partner_records(
+            self.company_group,
+            addresses=self.all_partners + self.all_addresses,
+            orders=self.all_orders,
+        )
+
+    def test_mixed_company_group__user(self):
+        """The company group users sees everything that's public"""
+        order_partner_ids = [
+            self.company_group.id,
+            self.company.id,
+            self.company2.id,
+            self.user6.id,
+        ]
+        orders = self.all_orders.filtered(
+            lambda o: o.partner_id.id in order_partner_ids
+        )
+        self._test_partner_records(
+            self.user6,
+            addresses=(
+                self.user6
+                | self.company_group
+                | self.all_public_addresses
+                | self._get_addresses(self.user6, policy="private")
+            ),
+            orders=orders,
+        )
+
+    def test_mixed_company__company(self):
+        """The company sees only its own records, but all public addresses"""
+        self._test_partner_records(
+            self.company,
+            addresses=(
+                self.company
+                | self.company_users
+                | self.all_public_addresses
+                | self._get_addresses(self.company)
+                | self._get_addresses(self.company_users)
+            ),
+            orders=self.company_orders,
+        )
+
+    def test_mixed_company__user(self):
+        """The company users sees its company records and public addresses"""
+        self._test_user_direct_child_of_company__parent_id(
+            self.user,
+            self.company,
+            expected_addresses=(
+                self.user
+                | self.company
+                | self._get_addresses(self.user)
+                | self.all_public_addresses
+            ),
         )

--- a/shopinvader_customer_multi_user_company_group/views/shopinvader_backend.xml
+++ b/shopinvader_customer_multi_user_company_group/views/shopinvader_backend.xml
@@ -15,6 +15,7 @@
         <field name="arch" type="xml">
             <field name="multi_user_records_policy" position="after">
                 <field name="multi_user_company_group_records_policy" />
+                <field name="multi_user_company_group_address_policy" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
This makes it possible to configure two different policies for partner related records and addresses.