### PR TITLE
[13.0][IMP]shopinvader: one active partner per email and backend

### DIFF
--- a/shopinvader/models/shopinvader_partner.py
+++ b/shopinvader/models/shopinvader_partner.py
@@ -6,6 +6,7 @@
 
 
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 STATE_ACTIVE = "active"
 STATE_INACTIVE = "inactive"
@@ -57,12 +58,26 @@ class ShopinvaderPartner(models.Model):
             "unique(backend_id, record_id, partner_email)",
             "A partner can only have one binding by backend.",
         ),
-        (
-            "email_uniq",
-            "unique(backend_id, partner_email)",
-            "An email must be uniq per backend.",
-        ),
     ]
+
+    @api.constrains("backend_id", "partner_email", "state")
+    def _check_unique_active_partner(self):
+        for partner in self:
+            if partner.state == STATE_ACTIVE:
+                domain = [
+                    ("backend_id", "=", partner.backend_id.id),
+                    ("partner_email", "=", partner.partner_email),
+                    ("state", "=", STATE_ACTIVE),
+                    ("id", "!=", partner.id),
+                ]
+                active_partners = self.search_count(domain)
+                if active_partners:
+                    raise ValidationError(
+                        _(
+                            "There cannot be two active partners having the same "
+                            "email within the same backend."
+                        )
+                    )
 
     def _compute_role_depends(self):
         return ("backend_id", "backend_id.customer_default_role")

--- a/shopinvader/tests/test_shopinvader_partner.py
+++ b/shopinvader/tests/test_shopinvader_partner.py
@@ -3,8 +3,7 @@
 
 from datetime import datetime
 
-from psycopg2 import IntegrityError
-
+from odoo.exceptions import ValidationError
 from odoo.tools import mute_logger
 
 from odoo.addons.component.tests.common import SavepointComponentCase
@@ -27,7 +26,7 @@ class TestShopinvaderPartner(SavepointComponentCase):
                 "backend_id": self.backend.id,
             }
         )
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(ValidationError):
             self.env["shopinvader.partner"].create(
                 {
                     "email": self.unique_email,


### PR DESCRIPTION
Removed _sql_constraints checking that there were not two partners having the same email within the same backend. Changed it for an api.constrains that will only check it for active users.
cc @ForgeFlow