### PR TITLE
[14.0] [IMP] `_prepare_cart`: prioritize values in `cart_params` over the ones in the backend settings

### DIFF
--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -456,16 +456,18 @@ class CartService(Component):
                 "shopinvader_backend_id": self.shopinvader_backend.id,
             }
         )
+        # Play onchanges
         vals.update(self.env["sale.order"].play_onchanges(vals, vals.keys()))
-        if self.shopinvader_backend.account_analytic_id.id:
-            vals[
-                "analytic_account_id"
-            ] = self.shopinvader_backend.account_analytic_id.id
-        pricelist = self._get_pricelist(partner)
-        if pricelist:
-            vals["pricelist_id"] = pricelist.id
-        if self.shopinvader_backend.sequence_id:
-            vals["name"] = self.shopinvader_backend.sequence_id._next()
+        # Set optional default values from backend configuration
+        backend = self.shopinvader_backend
+        if "analytic_account_id" not in cart_params and backend.account_analytic_id:
+            vals["analytic_account_id"] = backend.account_analytic_id.id
+        if "pricelist_id" not in cart_params:
+            pricelist = self._get_pricelist(partner)
+            if pricelist:
+                vals["pricelist_id"] = pricelist.id
+        if "name" not in cart_params and backend.sequence_id:
+            vals["name"] = backend.sequence_id._next()
         return vals
 
     def _get_pricelist(self, partner):

--- a/shopinvader_sale_automatic_workflow/services/cart.py
+++ b/shopinvader_sale_automatic_workflow/services/cart.py
@@ -10,6 +10,7 @@ class CartService(Component):
 
     def _prepare_cart(self, **cart_params):
         res = super()._prepare_cart(**cart_params)
-        if self.shopinvader_backend.workflow_process_id:
-            res["workflow_process_id"] = self.shopinvader_backend.workflow_process_id.id
+        backend = self.shopinvader_backend
+        if "workflow_process_id" not in cart_params and backend.workflow_process_id:
+            res["workflow_process_id"] = backend.workflow_process_id.id
         return res


### PR DESCRIPTION
This allows to do this, for example:

```py
# assuming shopinvader_backend.sequence_id is set..
cart = self.component(usage="cart")._create_empty_cart(name="Test")
```

Otherwise, the sequence set in the backend would be consumed, and the "Test" name would be ignored.

As a workaround, if we'd need to do this, we could override `_create_empty_cart` to set the name to what we want after it's created, but it's not ideal: it requires a `write` after a created, and the sequence number is consumed.


ping @simahawk 