### PR TITLE
[FIX] 14.0 _add_item: consistent return value

### DIFF
--- a/shopinvader/services/cart.py
+++ b/shopinvader/services/cart.py
@@ -303,7 +303,7 @@ class CartService(Component):
             self._upgrade_cart_item_quantity(cart, item, params, action="sum")
         else:
             with self.env.norecompute():
-                self._create_cart_line(cart, params)
+                item = self._create_cart_line(cart, params)
             cart.recompute()
         return item
 


### PR DESCRIPTION
before:
cart.py `_add_item` function does not have a consistent return value:

If the item already exists it is returned
If the item is created, None is returned

after:
`_add_item` always returns the item