### PR TITLE
[14.0] [FIX] shopinvader: Change address create return value for the created address

### DIFF
--- a/shopinvader/services/address.py
+++ b/shopinvader/services/address.py
@@ -42,7 +42,7 @@ class AddressService(Component):
         params["parent_id"] = self.partner.id
         partner = self.env["res.partner"].create(self._prepare_params(params))
         self._post_create(partner)
-        return self.search()
+        return {"data": self.get(partner.id)}
 
     def update(self, _id, **params):
         address = self._get(_id)

--- a/shopinvader/tests/test_address.py
+++ b/shopinvader/tests/test_address.py
@@ -49,7 +49,7 @@ class CommonAddressCase(CommonCase):
     def _create_address(self, params):
         existing_res = self.address_service.search(per_page=100)["data"]
         existing_ids = {address["id"] for address in existing_res}
-        self.address_service.dispatch("create", params=params)["data"]
+        self.address_service.dispatch("create", params=params)
         after_res = self.address_service.search(per_page=100)["data"]
         after_ids = {address["id"] for address in after_res}
         created_ids = after_ids - existing_ids


### PR DESCRIPTION
**This is a breaking change.**

This changes the address return value for the created address instead of returning a paginated list of address which makes little sense in a create context.