### PR TITLE
[14.0][FIX] shopinvader: return of dispatch should be something else than dict

### DIFF
--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -238,7 +238,7 @@ class BaseShopinvaderService(AbstractComponent):
     def dispatch(self, method_name, *args, params=None):
         res = super().dispatch(method_name, *args, params=params)
         store_cache = self.shopinvader_response.store_cache
-        if store_cache:
+        if store_cache and isinstance(res, dict):
             values = res.get("store_cache", {})
             values.update(store_cache)
             res["store_cache"] = values


### PR DESCRIPTION
In some case (using `shopinvader/payment/adyen/webhook` for example), the return value is a `str` (`dict` is expected). That raise an exception.

The question is:
- Adyen expect this value? If yes, so this PR should be merged;
- If no, we have to fix into `invader_payment_adyen` and return a `dict`.

https://github.com/shopinvader/odoo-shopinvader-payment/blob/14.0/invader_payment_adyen/services/payment_adyen.py#L575
