### PR TITLE
[13.0][FIX] shopinvader: _inverse_active sudo on product.template

### DIFF
--- a/shopinvader/models/product_template.py
+++ b/shopinvader/models/product_template.py
@@ -33,7 +33,7 @@ class ProductTemplate(models.Model):
 
     def _inverse_active(self):
         inactive = self.filtered(lambda p: not p.active)
-        inactive.mapped("shopinvader_bind_ids").write({"active": False})
+        inactive.mapped("shopinvader_bind_ids").sudo().write({"active": False})
 
     def _compute_shopinvader_backend_ids(self):
         for rec in self:


### PR DESCRIPTION
Allows users without shopinvader related security groups to archive product templates. 

cc @JordiMForgeFlow @HviorForgeFlow 