### PR TITLE
[14.0] shopinvader_search_engine: add filter for to_be_checked state

### DIFF
--- a/shopinvader_search_engine/views/shopinvader_variant_view.xml
+++ b/shopinvader_search_engine/views/shopinvader_variant_view.xml
@@ -43,10 +43,15 @@
             <field name="index_id" />
             <field name="sync_state" />
             <separator />
-           <filter
+            <filter
                     string="To Update"
                     name="to_update"
                     domain="[('sync_state','=','to_update')]"
+                />
+            <filter
+                    string="To Check"
+                    name="to_be_checked"
+                    domain="[('sync_state','=','to_be_checked')]"
                 />
             <filter
                     string="Scheduled"


### PR DESCRIPTION
The filter was missing and the state has been added a while ago in
connector_search_engine.