### PR TITLE
[14.0] [FIX] shopinvader: Coerce scope to dict

### DIFF
--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
+import json
 import logging
 
 from odoo import _
@@ -15,6 +16,12 @@ from odoo.addons.component.core import AbstractComponent
 from .. import shopinvader_response, utils
 
 _logger = logging.getLogger(__name__)
+
+
+def to_dict(val):
+    if isinstance(val, dict):
+        return val
+    return json.loads(val)
 
 
 class BaseShopinvaderService(AbstractComponent):
@@ -109,7 +116,7 @@ class BaseShopinvaderService(AbstractComponent):
                 "type": "integer",
             },
             "domain": {"type": "list", "nullable": True},
-            "scope": {"type": "dict", "nullable": True},
+            "scope": {"type": "dict", "coerce": to_dict, "nullable": True},
             "order": {"type": "string", "nullable": True},
         }
 


### PR DESCRIPTION
It is as much a PR as a question. How are we supposed to use the search scope parameter?

It is validated as a dict but there is no coercion so it's always ignored,  am I missing something? 

With this patch I can use an url like: `/shopinvader/sales/search?scope=%7B%22name.like%22%3A%20%22S%25%22%7D` (decoded: `/shopinvader/sales/search?scope={"name.like": "S%"}`)
