### PR TITLE
[IMP] shopinvader: Handle many2one scope lookup by id

### DIFF
--- a/shopinvader/services/service.py
+++ b/shopinvader/services/service.py
@@ -87,6 +87,9 @@ class BaseShopinvaderService(AbstractComponent):
                     op = self._scope_to_domain_operators[op]
                 else:
                     op = "="
+                # If the key is a many2one field, we need to convert the value to an int
+                if key.endswith("_id") and isinstance(value, str) and value.isdigit():
+                    value = int(value)
                 domain.append((key, op, value))
             return domain
         except Exception as e:

--- a/shopinvader/tests/test_search.py
+++ b/shopinvader/tests/test_search.py
@@ -69,3 +69,20 @@ class SearchCase(CommonSearchCase):
         msg = "Invalid scope"
         with self.assertRaisesRegex(UserError, msg):
             self.address_service.dispatch("search", params={"scope": scope})
+
+    def test_search_many2one(self):
+        scope = {"country_id": self.env.ref("base.us").id}
+        res = self.address_service.dispatch("search", params={"scope": scope})["data"]
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["id"], self.address_2.id)
+
+    def test_search_many2one_from_url(self):
+        # See https://github.com/OCA/rest-framework/blob/bbc8a1f26d59eef75507da1a0ce4ca31a261c70d/base_rest/http.py#L148-L152 # noqa
+        import pyquerystring  # base_rest dependency
+
+        params = pyquerystring.parse(
+            "scope[country_id]=%d" % self.env.ref("base.us").id
+        )
+        res = self.address_service.dispatch("search", params=params)["data"]
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["id"], self.address_2.id)


### PR DESCRIPTION
Without this it seems to be impossible to filter many2one by scope like `/shopinvader/address/search?scope[country_id]=42`