### PR TITLE
[14.0] [FIX] shopinvader_customer_price: Should not alter default behavior

### DIFF
--- a/shopinvader_customer_price/models/shopinvader_backend.py
+++ b/shopinvader_customer_price/models/shopinvader_backend.py
@@ -40,7 +40,7 @@ class ShopinvaderBackend(models.Model):
 
     def _get_partner_pricelist(self, partner):
         pricelist = super()._get_partner_pricelist(partner)
-        if pricelist is None:
+        if pricelist is None and self.cart_pricelist_partner_field_id:
             pricelist = partner.property_product_pricelist
         return pricelist
 

--- a/shopinvader_customer_price/tests/test_cart.py
+++ b/shopinvader_customer_price/tests/test_cart.py
@@ -11,6 +11,7 @@ class ConnectedItemCase(ItemCaseMixin, CommonCase):
     def setUpClass(cls):
         super().setUpClass()
         cls._setup_products()
+        cls.cart = cls.env.ref("shopinvader.sale_order_2")
         cls.partner = cls.env.ref("shopinvader.partner_1")
         cls.custom_pricelist = cls.env["product.pricelist"].create(
             {"name": "Test Pricelist"}
@@ -26,11 +27,13 @@ class ConnectedItemCase(ItemCaseMixin, CommonCase):
             self.service = work.component(usage="cart")
 
     def test_default_pricelist(self):
+        self.cart.unlink()
         self.assertFalse(self.backend.cart_pricelist_partner_field_id)
         cart = self.service._get()
-        self.assertEqual(cart.pricelist_id, self.partner.property_product_pricelist)
+        self.assertEqual(cart.pricelist_id, self.backend.pricelist_id)
 
     def test_custom_pricelist(self):
+        self.cart.unlink()
         self.backend.cart_pricelist_partner_field_id = self.pricelist_field
         cart = self.service._get()
         self.assertEqual(cart.pricelist_id, self.custom_pricelist)


### PR DESCRIPTION
I may be wrong here but it seems that installing this module changes the pricelist behavior for all backends even if `cart_pricelist_partner_field_id` has not been configured on the backend.

I think we should add a check to return the original partner pricelist (presumably `None`) in `_get_partner_pricelist` if `cart_pricelist_partner_field_id` has no value instead of returning `partner.property_product_pricelist`.
