### PR TITLE
[14.0] shopinvader_invoice: add state in schema

### DIFF
--- a/shopinvader_invoice/services/invoice.py
+++ b/shopinvader_invoice/services/invoice.py
@@ -95,6 +95,7 @@ class InvoiceService(Component):
                     "not_paid",
                     "paid",
                     "partial",
+                    "in_payment",
                     "reversed",
                     "invoicing_legacy",
                 ],


### PR DESCRIPTION
it's already allowed in the service

```py
   def _get_allowed_payment_states(self):
        """Get invoice payment states.

        :return: list of str
        """
        states = ["paid", "reversed"]
        if self.shopinvader_backend.invoice_access_open:
            states += ["not_paid", "in_payment", "partial"]
        return states

```
https://github.com/shopinvader/odoo-shopinvader/blob/14.0/shopinvader/services/invoice.py#L39

FYI @acsonefho 