### PR TITLE
[13.0][IMP]shopinvader: restrict duplicate partner emails per backend

### DIFF
--- a/shopinvader/models/res_partner.py
+++ b/shopinvader/models/res_partner.py
@@ -189,6 +189,7 @@ class ResPartner(models.Model):
                 JOIN
                     shopinvader_partner sp ON sp.record_id = rp.id
                 WHERE email IS NOT NULL
+                    AND sp.active = TRUE
                     AND rp.active = TRUE
                     AND rp.has_shopinvader_user_active = TRUE
             ) dups

--- a/shopinvader/models/res_partner.py
+++ b/shopinvader/models/res_partner.py
@@ -211,7 +211,7 @@ class ResPartner(models.Model):
         """ % (select_query, from_query, where_query)
         self.env.cr.execute(query)
         duplicate_emails_dict = dict()
-        for backend_id, email in self.env.cr.fetchall():
+        for email, backend_id in self.env.cr.fetchall():
             if not duplicate_emails_dict.get(backend_id):
                 duplicate_emails_dict.setdefault(backend_id, [email])
             else:


### PR DESCRIPTION
Only restrict the duplicated Partner Emails per Backend. Meaning that we can have we can have two Shopinvader Partners belonging to different Websites but still having the same e-mail.

cc @ForgeFlow