### PR TITLE
[16.0][FIX] shopinvader_search_engine_image: no thumbnail sizes

### DIFF
--- a/shopinvader_search_engine_image/tests/test_shopinvader_search_engine_image.py
+++ b/shopinvader_search_engine_image/tests/test_shopinvader_search_engine_image.py
@@ -6,6 +6,12 @@ from .common import TestSeMultiImageThumbnailCase
 
 
 class TestShopinvaderSearchEngineImage(TestSeMultiImageThumbnailCase):
+    def test_index_no_thumbnail_sizes(self):
+        self.backend.image_field_thumbnail_size_ids = None
+        product = self.product_binding._contextualize(self.product_binding)
+        data = self.product_index.model_serializer.serialize(product.record)
+        self.assertEqual(data["images"], [])
+
     def test_product_image(self):
         self.backend.image_data_url_strategy = "odoo"
         product = self.product_binding._contextualize(self.product_binding)


### PR DESCRIPTION
A `UserError` is raised when no thumbnail sizes is defined on the `se.backend`.
That should not prevent the serialization.