### PR TITLE
[16.0][IMP] shopinvader_api: Ignore extra in input rqst

### DIFF
--- a/shopinvader_api_address/schemas.py
+++ b/shopinvader_api_address/schemas.py
@@ -4,7 +4,7 @@
 from extendable_pydantic import StrictExtendableBaseModel
 
 
-class AddressCreate(StrictExtendableBaseModel):
+class AddressCreate(StrictExtendableBaseModel, extra="ignore"):
     """
     used to create new address (res.partner)
     state and country can be name or code
@@ -36,7 +36,7 @@ class AddressCreate(StrictExtendableBaseModel):
         return vals
 
 
-class AddressUpdate(StrictExtendableBaseModel):
+class AddressUpdate(StrictExtendableBaseModel, extra="ignore"):
     """
     used to update address (res.partner)
     state and country can be name or code

--- a/shopinvader_api_cart/schemas/cart.py
+++ b/shopinvader_api_cart/schemas/cart.py
@@ -12,19 +12,19 @@ class CartTransaction(StrictExtendableBaseModel):
     product_id: int
 
 
-class CartSyncInput(StrictExtendableBaseModel):
+class CartSyncInput(StrictExtendableBaseModel, extra="ignore"):
     transactions: List[CartTransaction]
 
 
-class DeliveryUpdateInfo(StrictExtendableBaseModel):
+class DeliveryUpdateInfo(StrictExtendableBaseModel, extra="ignore"):
     address_id: int
 
 
-class InvoicingUpdateInfo(StrictExtendableBaseModel):
+class InvoicingUpdateInfo(StrictExtendableBaseModel, extra="ignore"):
     address_id: int
 
 
-class CartUpdateInput(StrictExtendableBaseModel):
+class CartUpdateInput(StrictExtendableBaseModel, extra="ignore"):
     client_order_ref: str | None = None
     delivery: DeliveryUpdateInfo | None = None
     invoicing: InvoicingUpdateInfo | None = None

--- a/shopinvader_schema_sale/schemas/sale.py
+++ b/shopinvader_schema_sale/schemas/sale.py
@@ -48,7 +48,7 @@ class Sale(StrictExtendableBaseModel):
         )
 
 
-class SaleSearch(StrictExtendableBaseModel):
+class SaleSearch(StrictExtendableBaseModel, extra="ignore"):
     name: Annotated[
         str | None,
         Field(


### PR DESCRIPTION
Ignoring extra fields in a JSON input document when implementing a REST server is a good practice for several reasons:

Backward compatibility:
-----------------------

Ignoring extra fields allows for backward compatibility. Clients may evolve over time, adding new fields to the JSON documents they send. If the server strictly enforces a fixed structure, any change on the client side would require a corresponding change on the server side. By ignoring extra fields, the server remains compatible with older clients and can handle requests from clients with additional data.

Flexibility and extensibility:
------------------------------

Ignoring extra fields makes the API more flexible and extensible. It allows clients to include additional information without breaking the existing functionality. This is particularly useful when different clients (e.g., mobile apps, web applications) have varying requirements or when the server is part of a larger ecosystem with diverse clients.

Avoiding breaking changes:
--------------------------

Enforcing a strict schema and rejecting requests with extra fields can lead to breaking changes. If a client adds a new field but the server expects the old format, the server may reject the request. Ignoring extra fields helps prevent unnecessary disruptions and allows for a smoother transition when updating client-server communication.

Reducing friction during development:
-------------------------------------

During development, teams may work on the client and server components independently. Ignoring extra fields can reduce friction between teams, as changes on one side do not necessarily require immediate adjustments on the other side.