### PR TITLE
[13.0][IMP]shopinvader_product_stock: update stock state when action assign

### DIFF
--- a/shopinvader_product_stock/models/stock_move.py
+++ b/shopinvader_product_stock/models/stock_move.py
@@ -57,9 +57,13 @@ class StockMove(models.Model):
 
     def _action_done(self, cancel_backorder=False):
         """
-
         :return: bool
         """
         result = super()._action_done(cancel_backorder=cancel_backorder)
         result._jobify_product_stock_update()
+        return result
+
+    def _action_assign(self):
+        result = super()._action_assign()
+        self._jobify_product_stock_update()
         return result


### PR DESCRIPTION
We should also trigger the update of the Stock State when the Stock Move is assigned as there may be some updates in the `stock.quant` instances.

cc @ForgeFlow