### PR TITLE
[16.0][FIX] shopinvader_base_url: No assign value if not changed

### DIFF
--- a/shopinvader_base_url/models/abstract_url.py
+++ b/shopinvader_base_url/models/abstract_url.py
@@ -173,7 +173,8 @@ class AbstractUrl(models.AbstractModel):
                     if current_url.key != url_key:
                         current_url.redirect = True
                         record._add_url(referential, lang, url_key)
-            record.url_need_refresh = False
+            if record.url_need_refresh:
+                record.url_need_refresh = False
 
     def _add_url(self, referential, lang, url_key):
         self.ensure_one()

--- a/shopinvader_search_engine_product_stock/tests/common.py
+++ b/shopinvader_search_engine_product_stock/tests/common.py
@@ -17,7 +17,7 @@ class StockCommonCase(TestBindingIndexBase, JobMixin):
             context=dict(
                 cls.env.context,
                 tracking_disable=True,  # speed up tests
-                test_queue_job_no_delay=False,  # we want the jobs
+                queue_job__no_delay=False,  # we want the jobs
             )
         )
         ref = cls.env.ref


### PR DESCRIPTION
In a compute method, we must assign a value to the computed field only if it's different from the original one. Otherwise, the write method will be called every time.