### PR TITLE
[16.0] Add merge policy on test dependencies to avoid conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test-requirements.txt merge=union


### PR DESCRIPTION
When merging some pending PR locally we get unecessary conflict on this file.