### PR TITLE
[16?0][FIX] shopinvader_search_engine: Dump pydantic model in json

### DIFF
--- a/shopinvader_search_engine/tools/category_serializer.py
+++ b/shopinvader_search_engine/tools/category_serializer.py
@@ -12,4 +12,6 @@ class ProductCategoryShopinvaderSerializer(PydanticModelSerializer):
         return ProductCategory
 
     def serialize(self, record):
-        return self.get_model_class().from_product_category(record).model_dump()
+        return (
+            self.get_model_class().from_product_category(record).model_dump(mode="json")
+        )

--- a/shopinvader_search_engine/tools/product_serializer.py
+++ b/shopinvader_search_engine/tools/product_serializer.py
@@ -11,4 +11,6 @@ class ProductProductShopinvaderSerializer(PydanticModelSerializer):
         return ProductProduct
 
     def serialize(self, record):
-        return self.get_model_class().from_product_product(record).model_dump()
+        return (
+            self.get_model_class().from_product_product(record).model_dump(mode="json")
+        )

--- a/shopinvader_search_engine_product_brand/tools/brand_serializer.py
+++ b/shopinvader_search_engine_product_brand/tools/brand_serializer.py
@@ -11,4 +11,4 @@ class ProductBrandShopinvaderSerializer(PydanticModelSerializer):
         return ProductBrand
 
     def serialize(self, record):
-        return self.get_model_class().from_product_brand(record).model_dump()
+        return self.get_model_class().from_product_brand(record).model_dump(mode="json")


### PR DESCRIPTION
When we serialize a product or a category with a pydantic serializer, we must dump the mode in json mode.  If mode is 'json', the dictionary will only contain JSON serializable types. If mode is 'python' (the default), the dictionary may contain any Python objects and will therefore not be serializable in json