### PR TITLE
[FIX] shopinvader : shopinvader.variant

### DIFF
--- a/shopinvader/models/shopinvader_variant.py
+++ b/shopinvader/models/shopinvader_variant.py
@@ -296,6 +296,10 @@ class ShopinvaderVariant(models.Model):
     def _compute_main_product(self):
         # Respect same order.
         order_by = [x.strip() for x in self.env["product.product"]._order.split(",")]
+        # Problem : after previous line , list can contain element like 'product_id desc'
+        # Solution : resplit each element and keep only first part
+        # Test made with order_by = [] and [''] -> still works
+        order_by = [r.split(" ")[0] for r in order_by]
         backends = self.mapped("backend_id")
         fields_to_read = ["shopinvader_product_id", "backend_id", "lang_id"] + order_by
         product_ids = self.mapped("shopinvader_product_id").ids


### PR DESCRIPTION
Problem : when using sql keyword on the _order of product model we get this error on the _jsonify_record
'ValueError: Invalid field '[field] desc' on model 'shopinvader.variant'

this commit solve this by removing sql keyword from _order in the _compute_main_product method

@acsonefho 