### PR TITLE
[16.0][FIX] shopinvader_api_cart: Returns 204 if no content

### DIFF
--- a/shopinvader_api_cart/routers/cart.py
+++ b/shopinvader_api_cart/routers/cart.py
@@ -3,7 +3,7 @@
 from collections import OrderedDict
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 
 from odoo import _, api, models
 from odoo.exceptions import MissingError
@@ -34,7 +34,7 @@ def get(
     Return an empty dict if no cart was found
     """
     cart = env["sale.order"]._find_open_cart(partner.id, uuid)
-    return Sale.from_sale_order(cart) if cart else None
+    return Sale.from_sale_order(cart) if cart else Response(status_code=204)
 
 
 @cart_router.post("/sync", status_code=201)
@@ -49,7 +49,7 @@ def sync(
     cart = env["shopinvader_api_cart.cart_router.helper"]._sync_cart(
         partner, cart, uuid, data.transactions
     )
-    return Sale.from_sale_order(cart) if cart else None
+    return Sale.from_sale_order(cart) if cart else Response(status_code=204)
 
 
 @cart_router.post("/update")

--- a/shopinvader_api_cart/tests/test_shopinvader_api_cart.py
+++ b/shopinvader_api_cart/tests/test_shopinvader_api_cart.py
@@ -76,8 +76,7 @@ class TestSaleCart(FastAPITransactionCase):
     def test_get_authenticated_no_cart_no_uuid(self) -> None:
         with self._create_test_client(router=cart_router) as test_client:
             response: Response = test_client.get("/")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), None)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_get_authenticated_no_cart_no_uuid_no_rights(self) -> None:
         with self._create_unauthenticated_user_client() as test_client, self.assertRaises(
@@ -88,8 +87,7 @@ class TestSaleCart(FastAPITransactionCase):
     def test_get_authenticated_no_cart_uuid(self) -> None:
         with self._create_test_client(router=cart_router) as test_client:
             response: Response = test_client.get("/1234")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), None)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_get_authenticated_no_cart_uuid_no_rights(self) -> None:
         with self._create_unauthenticated_user_client() as test_client, self.assertRaises(
@@ -218,6 +216,12 @@ class TestSaleCart(FastAPITransactionCase):
         self.assertEqual(0, len(response_json["lines"]))
         self.assertEqual(so.id, response_json["id"])
         self.assertFalse(so.applied_cart_api_transaction_uuids)
+
+    def test_sync_no_content_no_cart(self):
+        data = {"transactions": []}
+        with self._create_test_client(router=cart_router) as test_client:
+            response: Response = test_client.post("/sync", content=json.dumps(data))
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_transaction_product_not_existing(self) -> None:
         so = self.env["sale.order"]._create_empty_cart(


### PR DESCRIPTION
This is required to avoid to try to convert a null body value into json on client side. If we return nothing, we must explicitly set the right response code

This change is required for and works with https://github.com/shopinvader/shopinvader-js-cart/pull/11

It will avoid to get the cart set into the 'sync error' status if the call the the 'sync' endpoint return an empty response. 