### PR TITLE
[16.0] shopinvader_api_sale: fix access

### DIFF
--- a/shopinvader_api_sale/routers/sales.py
+++ b/shopinvader_api_sale/routers/sales.py
@@ -43,7 +43,7 @@ def search(
     )
     return PagedCollection[Sale](
         count=count,
-        items=[Sale.from_sale_order(order) for order in orders],
+        items=[Sale.from_sale_order(order) for order in orders.sudo()],
     )
 
 
@@ -60,6 +60,7 @@ def get(
         env["shopinvader_api_sale.sales_router.helper"]
         .new({"partner": partner})
         ._get(sale_id)
+        .sudo()
     )
 
 

--- a/shopinvader_sale_cart/models/sale_order.py
+++ b/shopinvader_sale_cart/models/sale_order.py
@@ -37,7 +37,7 @@ class SaleOrder(models.Model):
             # maybe a current cart exists with another uuid
             domain = self._get_open_cart_domain(partner_id, uuid=None)
             cart = self.search(domain, limit=1)
-        return cart
+        return cart.sudo()
 
     @api.model
     def _get_default_pricelist_id(self):
@@ -73,7 +73,7 @@ class SaleOrder(models.Model):
     def _create_empty_cart(self, partner_id):
         """Create a new empty cart for a given partner"""
         vals = self._prepare_cart(partner_id)
-        return self.create(vals)
+        return self.sudo().create(vals)
 
     def _get_cart_line(self, product_id):
         """


### PR DESCRIPTION
ATM You are forced to add a record rule for _every_ single record involved in the call. Every. Including nested relations. Making that work might be very complicated, especially when those records have nothing to deal w/ partners, meaning that it would be hard to discriminate if the current partner should be allowed to see it.

For instance, the product.pricelist. This model has no default record rule, hence the /sales api is broken OOTB and unfortunately you cannot control the pricelist in the schema because is used down the stack to compute prices.

Of course this might be the best solution but at least it makes the api work OOTB.

In any case, for now this change is only temporary fix for me and a way to raise the problem. As I understand ppl might want to still rely fully on RR, probably we should make this configurable somehow. Maybe via config param? Not sure what's the best w/ the new implementation since there's no s.backend anymore.