### PR TITLE
[16.0][FIX] shopinvader_search_engine_update: Archived product update must not mark binding to be updated

### DIFF
--- a/shopinvader_search_engine_update/models/se_indexable_record.py
+++ b/shopinvader_search_engine_update/models/se_indexable_record.py
@@ -12,4 +12,4 @@ class SeIndexableRecord(models.AbstractModel):
         linked to this record to be updated in the search engine.
 
         """
-        self.sudo()._se_mark_to_update()
+        self.sudo().filtered("active")._se_mark_to_update()

--- a/shopinvader_search_engine_update/tests/test_update.py
+++ b/shopinvader_search_engine_update/tests/test_update.py
@@ -12,3 +12,13 @@ class TestUpdate(TestProductBindingUpdateBase):
     def test_update_template(self):
         self.product.product_tmpl_id.name = "new name"
         self.assertEqual(self.product_binding.state, "to_recompute")
+
+    def test_update_on_an_archived_product(self):
+        self.product.active = False
+        self.product_binding.state = "to_delete"
+        self.product.name = "new name"
+        self.assertEqual(
+            self.product_binding.state,
+            "to_delete",
+            "The product binding should not be updated if an archived product is updated",
+        )


### PR DESCRIPTION
The companion of https://github.com/OCA/search-engine/pull/187