### PR TITLE
[16.0] [FIX] `shopinvader_api_cart`: fix the empty cart creation upon update

### DIFF
--- a/shopinvader_api_cart/routers/cart.py
+++ b/shopinvader_api_cart/routers/cart.py
@@ -236,6 +236,6 @@ class ShopinvaderApiCartRouterHelper(models.AbstractModel):
     def _update(self, partner, data, uuid):
         cart = self.env["sale.order"]._find_open_cart(partner.id, uuid)
         if not cart:
-            cart = self.env["sale.order"]._create_empty_cart()
+            cart = self.env["sale.order"]._create_empty_cart(partner.id)
         cart.write(data.convert_to_sale_write())
         return cart

--- a/shopinvader_api_cart/tests/test_shopinvader_api_cart.py
+++ b/shopinvader_api_cart/tests/test_shopinvader_api_cart.py
@@ -500,3 +500,20 @@ class TestSaleCart(CommonSaleCart):
                 f"/update/{so.uuid}", content=json.dumps(data)
             )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_update_new_cart(self) -> None:
+        """Test that an empty cart is created when no cart exists."""
+        partner = self.default_fastapi_authenticated_partner
+        address = self.env["res.partner"].create(
+            {
+                "name": "Delivery",
+                "parent_id": partner.id,
+                "type": "delivery",
+            }
+        )
+        data = {"delivery": {"address_id": address.id}}
+        with self._create_test_client(router=cart_router) as test_client:
+            response: Response = test_client.post("/update", content=json.dumps(data))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        info = response.json()
+        self.assertTrue(self.env["sale.order"].browse(info["id"]).exists())


### PR DESCRIPTION
**Steps to reproduce:**

- Perform an update without any existing cart

**Exception:**

```
TypeError: SaleOrder._create_empty_cart() missing 1 required positional
argument: 'partner_id'
```