### PR TITLE
[16.0] [IMP] shopinvader_api_cart: don't use `self.env.norecompute`

### DIFF
--- a/shopinvader_api_cart/routers/cart.py
+++ b/shopinvader_api_cart/routers/cart.py
@@ -188,20 +188,19 @@ class ShopinvaderApiCartRouterHelper(models.AbstractModel):
             transactions=transactions
         )
         update_cmds = []
-        with self.env.norecompute():
-            # prefetch all products
-            self.env["product.product"].browse(transactions_by_product_id.keys())
-            # here we avoid that each on change on a line trigger all the
-            # recompute methods on the SO. These methods will be triggered
-            # by the orm into the 'write' process
-            for product_id, trxs in transactions_by_product_id.items():
-                line = cart._get_cart_line(product_id)
-                if line:
-                    cmd = self._apply_transactions_on_existing_cart_line(line, trxs)
-                else:
-                    cmd = self._apply_transactions_creating_new_cart_line(cart, trxs)
-                if cmd:
-                    update_cmds.append(cmd)
+        # prefetch all products
+        self.env["product.product"].browse(transactions_by_product_id.keys())
+        # here we avoid that each on change on a line trigger all the
+        # recompute methods on the SO. These methods will be triggered
+        # by the orm into the 'write' process
+        for product_id, trxs in transactions_by_product_id.items():
+            line = cart._get_cart_line(product_id)
+            if line:
+                cmd = self._apply_transactions_on_existing_cart_line(line, trxs)
+            else:
+                cmd = self._apply_transactions_creating_new_cart_line(cart, trxs)
+            if cmd:
+                update_cmds.append(cmd)
         all_transaction_uuids = transaction_uuids = [
             str(t.uuid) for t in transactions if t.uuid
         ]


### PR DESCRIPTION
This context manager has been deprecated since many versions now, and it's not doing absolutely anything.

It was originally used to prevent computed fields to be recomputed when their dependencies are updated, but that's not the case anymore since the apparition of `flush`, where the recomputation is delayed.

See: https://github.com/odoo/odoo/blob/be4c1502/odoo/api.py#L823-L826
Also: https://github.com/odoo/odoo/commit/9920f20e


