### PR TITLE
[14][IMP] shopinvader_sale_coupon : cast bool skip_coupon_recompute

### DIFF
--- a/shopinvader_sale_coupon/services/cart.py
+++ b/shopinvader_sale_coupon/services/cart.py
@@ -5,6 +5,7 @@
 from odoo import _
 from odoo.exceptions import UserError
 
+from odoo.addons.base_rest.components.service import to_bool
 from odoo.addons.component.core import Component
 
 
@@ -121,6 +122,7 @@ class CartService(Component):
             "skip_coupon_recompute": {
                 "type": "boolean",
                 "required": False,
+                "coerce": to_bool,
             }
         }
 


### PR DESCRIPTION
problem from our client

_the cart update_item methods requires skip_coupon_recompute to be a boolean while the rest (item_id, item_qty) can be string. We are facing troubles due to this constraint, it will be better to accept string for the skip_coupon_recompute as well. So we won’t need to cast the value every where we use the method_


@acsonefho 