### PR TITLE
[16.0][ADD] shopinvader_api_cart: cart helper: Add hooks

### DIFF
--- a/shopinvader_api_cart/routers/cart.py
+++ b/shopinvader_api_cart/routers/cart.py
@@ -124,8 +124,24 @@ class ShopinvaderApiCartRouterHelper(models.AbstractModel):
         ):
             return (2, cart_line.id, None)
         vals = {"product_uom_qty": new_qty}
+        vals = self._apply_transactions_on_existing_cart_line__post(
+            cart_line, transactions, vals
+        )
         vals.update(cart_line._play_onchanges_cart_line(vals))
         return (1, cart_line.id, vals)
+
+    @api.model
+    def _apply_transactions_on_existing_cart_line__post(
+        self,
+        line: SaleOrderLine,
+        transactions: list[CartTransaction],
+        values: dict,
+    ):
+        """Post hook allowing to add custom values in cart lines to be updated.
+
+        Meant to be overridden
+        """
+        return values
 
     @api.model
     def _apply_transactions_creating_new_cart_line(
@@ -138,9 +154,22 @@ class ShopinvaderApiCartRouterHelper(models.AbstractModel):
             cart=cart, transactions=transactions
         )
         if vals:
+            vals = self._apply_transactions_creating_new_cart_line__post(
+                cart, transactions, vals
+            )
             vals.update(self.env["sale.order.line"]._play_onchanges_cart_line(vals))
             return (0, None, vals)
         return None
+
+    @api.model
+    def _apply_transactions_creating_new_cart_line__post(
+        self, cart: SaleOrder, transactions: list[CartTransaction], values: dict
+    ):
+        """Post hook allowing to add custom values in cart lines to be created.
+
+        Meant to be overridden
+        """
+        return values
 
     @api.model
     def _get_sale_order_line_name(self, product_id):


### PR DESCRIPTION
Add hooks in cart helper in order to ease override when modifying transaction schema