### PR TITLE
[16.0] shopinvader_product_sale_packaging: fix empty barcode

### DIFF
--- a/shopinvader_product_sale_packaging/schemas/product_packaging.py
+++ b/shopinvader_product_sale_packaging/schemas/product_packaging.py
@@ -1,6 +1,8 @@
 # Copyright 2023 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from typing import Any
+
 from odoo.addons.extendable_fastapi import StrictExtendableBaseModel
 from odoo.addons.stock_packaging_calculator.models.product import Packaging
 
@@ -12,6 +14,12 @@ class SimpleProductPackaging(StrictExtendableBaseModel):
     barcode: str | None = None
     is_unit: bool
     can_be_sold: bool
+
+    def __init__(self, /, **data: Any) -> None:  # type: ignore
+        # Ensure `barcode` is set to None when empty, no matter if we use `from_packaging`.
+        if "barcode" in data and not data["barcode"]:
+            data["barcode"] = None
+        super().__init__(**data)
 
     @classmethod
     def from_packaging(cls, odoo_product, packaging, packaging_contained_mapping=None):
@@ -50,7 +58,7 @@ class ProductPackaging(SimpleProductPackaging):
                             pkg["id"],
                             pkg["name"],
                             pkg["qty"],
-                            pkg["barcode"] or None,
+                            pkg["barcode"],
                             pkg["is_unit"],
                         ),
                     )

--- a/shopinvader_product_sale_packaging/tests/test_product_data.py
+++ b/shopinvader_product_sale_packaging/tests/test_product_data.py
@@ -104,6 +104,13 @@ class TestProductPackagingData(ExtendableMixin, CommonPackagingCase, TestCommon)
         default_packaging = self._default_packaging()
         self.assertEqual(res.packaging, default_packaging)
 
+    def test_product_schema_no_barcode(self):
+        self.pkg_pallet.barcode = False
+        res = ProductProduct.from_product_product(self.product_a)
+        self.assertEqual(len(res.packaging), 4)
+        default_packaging = self._default_packaging()
+        self.assertEqual(res.packaging, default_packaging)
+
     def test_shopinvader_display(self):
         self.pkg_big_box.shopinvader_display = False
         res = ProductProduct.from_product_product(self.product_a)


### PR DESCRIPTION
Never fail when a packaging has no barcode.
No matter where the data is coming from or how the object is initialized.