### PR TITLE
[16.0] shopinvader_product_attribute_set: fix float handling + unwanted data conversion

### DIFF
--- a/shopinvader_product_attribute_set/schemas/product.py
+++ b/shopinvader_product_attribute_set/schemas/product.py
@@ -12,7 +12,7 @@ from .product_attribute_group import ProductAttributeGroup
 
 class ProductProduct(product.ProductProduct, extends=True):
     attribute_set: ProductAttributeSet | None = None
-    attributes: dict[str, str | bool | int | list[str]] = {}
+    attributes: dict[str, str | bool | int | float | list[str]] = {}
     structured_attributes: list[ProductAttributeGroup] = []
 
     @classmethod
@@ -32,7 +32,7 @@ class ProductProduct(product.ProductProduct, extends=True):
     @classmethod
     def _compute_attributes(
         cls, record: product_product.ProductProduct
-    ) -> dict[str, str | bool | int | list[str]]:
+    ) -> dict[str, str | bool | int | float | list[str]]:
         attributes = {}
         for attr in record.attribute_set_id.attribute_ids:
             # all attr start with "x_" we remove it for the export

--- a/shopinvader_product_attribute_set/schemas/product_attribute.py
+++ b/shopinvader_product_attribute_set/schemas/product_attribute.py
@@ -29,7 +29,7 @@ class ProductAttributeType(Enum):
 class ProductAttribute(StrictExtendableBaseModel):
     name: str
     key: str
-    value: str | bool | int | list[str]
+    value: str | bool | int | float | list[str]
     type: ProductAttributeType
 
     @classmethod
@@ -38,7 +38,7 @@ class ProductAttribute(StrictExtendableBaseModel):
         product: ProductProduct,
         attr: AttributeAttribute,
         string_mode: bool = False,
-    ) -> str | bool | int | list[str]:
+    ) -> str | bool | int | float | list[str]:
         if attr.attribute_type == "select":
             return product[attr.name].display_name or ""
         elif attr.attribute_type == "multiselect":
@@ -47,8 +47,7 @@ class ProductAttribute(StrictExtendableBaseModel):
             return product[attr.name] and "true" or "false"
         elif string_mode or attr.attribute_type in ("char", "text"):
             return "%s" % (product[attr.name] or "")
-        else:
-            return product[attr.name] or ""
+        return product[attr.name] or ""
 
     @classmethod
     def from_product_attribute(

--- a/shopinvader_product_attribute_set/schemas/product_attribute.py
+++ b/shopinvader_product_attribute_set/schemas/product_attribute.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from enum import Enum
 
+import pydantic
 from extendable_pydantic import StrictExtendableBaseModel
 
 from odoo.addons.product.models.product_product import ProductProduct
@@ -29,7 +30,10 @@ class ProductAttributeType(Enum):
 class ProductAttribute(StrictExtendableBaseModel):
     name: str
     key: str
-    value: str | bool | int | float | list[str]
+    # Use strict types to avoid opinionated conversion of original values
+    value: pydantic.StrictInt | pydantic.StrictStr | pydantic.StrictFloat | bool | list[
+        str
+    ]
     type: ProductAttributeType
 
     @classmethod

--- a/shopinvader_product_attribute_set/schemas/product_attribute.py
+++ b/shopinvader_product_attribute_set/schemas/product_attribute.py
@@ -24,6 +24,8 @@ class ProductAttributeType(Enum):
     float = "float"
     date = "date"
     datetime = "datetime"
+    # TODO: I'm not sure this value is handled properly
+    # as product[attr.name] will return a b64 string, not a binary.
     binary = "binary"
 
 

--- a/shopinvader_product_attribute_set/tests/test_product.py
+++ b/shopinvader_product_attribute_set/tests/test_product.py
@@ -224,3 +224,52 @@ class ProductCase(TransactionCase, ExtendableMixin):
                 }
             ],
         )
+
+    def test_product_data_numbers(self):
+        attribute_int = self._create_attribute(
+            {
+                "attribute_type": "integer",
+            }
+        )
+        attribute_float = self._create_attribute(
+            {
+                "attribute_type": "float",
+            }
+        )
+        self.attr_set.attribute_ids = attribute_int | attribute_float
+        self.product.write(
+            {
+                "attribute_set_id": self.attr_set.id,
+                "x_integer": 10,
+                "x_float": 20.0,
+            }
+        )
+        self.reset_extendable_registry()
+        self.init_extendable_registry()
+        res = ProductProduct.from_product_product(self.product).model_dump()
+        self.assertEqual(
+            res.get("attributes"),
+            {"integer": 10, "float": 20.0},
+        )
+        self.assertListEqual(
+            res.get("structured_attributes"),
+            [
+                {
+                    "group_name": "My Group",
+                    "fields": [
+                        {
+                            "value": "10",
+                            "name": "Attribute integer",
+                            "key": "integer",
+                            "type": ProductAttributeType.integer,
+                        },
+                        {
+                            "value": "20.0",
+                            "name": "Attribute float",
+                            "key": "float",
+                            "type": ProductAttributeType.float,
+                        },
+                    ],
+                }
+            ],
+        )


### PR DESCRIPTION
See atomic commits for details.

Before this change it was impossible to have a float attribute successfully validated for search engine binding data.

@lmignon I'd love to have your feedback here.