### PR TITLE
[FIX][14.0] Shopinvader cart expiry fix expired carts domain

### DIFF
--- a/shopinvader_cart_expiry/__manifest__.py
+++ b/shopinvader_cart_expiry/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "ACSONE SA/NV",
     "website": "https://github.com/shopinvader/odoo-shopinvader",
     "category": "e-commerce",
-    "version": "14.0.1.0.2",
+    "version": "14.0.1.0.3",
     "license": "AGPL-3",
     "depends": ["shopinvader"],
     "data": [

--- a/shopinvader_cart_expiry/models/shopinvader_backend.py
+++ b/shopinvader_cart_expiry/models/shopinvader_backend.py
@@ -45,7 +45,7 @@ class ShopinvaderBackend(models.Model):
             ("shopinvader_backend_id", "=", self.id),
             ("typology", "=", "cart"),
             ("state", "=", "draft"),
-            ("last_external_update_date", "<=", expiry_date),
+            ("write_date", "<=", expiry_date),
         ]
         return domain
 

--- a/shopinvader_cart_expiry/static/description/index.html
+++ b/shopinvader_cart_expiry/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {


### PR DESCRIPTION
For some reason on v14.0, `last_external_update_date` is almost never set.
Therefore carts aren't correctly dropped.
The commit I'm kinda "reverting" was never ported to 16.0.