### PR TITLE
[16.0] shopinvader_api_cart: improve convert_to_sale_write

### DIFF
--- a/shopinvader_api_cart/routers/cart.py
+++ b/shopinvader_api_cart/routers/cart.py
@@ -236,5 +236,5 @@ class ShopinvaderApiCartRouterHelper(models.AbstractModel):
         cart = self.env["sale.order"]._find_open_cart(partner.id, uuid)
         if not cart:
             cart = self.env["sale.order"]._create_empty_cart(partner.id)
-        cart.write(data.convert_to_sale_write())
+        cart.write(data.convert_to_sale_write(cart))
         return cart

--- a/shopinvader_api_cart/schemas/cart.py
+++ b/shopinvader_api_cart/schemas/cart.py
@@ -31,7 +31,7 @@ class CartUpdateInput(StrictExtendableBaseModel, extra="ignore"):
     invoicing: InvoicingUpdateInfo | None = None
     note: str | None = None
 
-    def convert_to_sale_write(self):
+    def convert_to_sale_write(self, cart):
         vals = {}
         data = self.model_dump(exclude_unset=True)
         if "client_order_ref" in data:


### PR DESCRIPTION
Pass the current cart because:

* you might need an env
* you might need to determine a value based on the current record

This way we don't need any other hook on the helpers.


Split from #1521 