### PR TITLE
[14.0] shopinvader: store last_login_time 

### DIFF
--- a/shopinvader/__manifest__.py
+++ b/shopinvader/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Shopinvader",
     "summary": "Shopinvader",
-    "version": "14.0.5.24.13",
+    "version": "14.0.5.25.0",
     "category": "e-commerce",
     "website": "https://github.com/shopinvader/odoo-shopinvader",
     "author": "Akretion",

--- a/shopinvader/migrations/14.0.5.25.0/pre-migrate.py
+++ b/shopinvader/migrations/14.0.5.25.0/pre-migrate.py
@@ -1,0 +1,11 @@
+# Copyright 2022 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tools import sql
+
+
+def migrate(cr, version):
+    if not version or sql.column_exists(cr, "shopinvader_partner", "last_login_time"):
+        return
+    # Pre-create new column
+    sql.create_column(cr, "shopinvader_partner", "last_login_time", "timestamp")

--- a/shopinvader/models/shopinvader_partner.py
+++ b/shopinvader/models/shopinvader_partner.py
@@ -36,6 +36,7 @@ class ShopinvaderPartner(models.Model):
     # Having the same field on both models allows to use simple conditions to check.
     # The compute methods offers a hook to modify the behavior.
     is_shopinvader_active = fields.Boolean(compute="_compute_is_shopinvader_active")
+    last_login_time = fields.Datetime(readonly=True)
 
     def _compute_is_shopinvader_active_depends(self):
         return ()

--- a/shopinvader/services/customer.py
+++ b/shopinvader/services/customer.py
@@ -4,7 +4,7 @@
 # Simone Orsi <simone.orsi@camptocamp.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 # pylint: disable=consider-merging-classes-inherited,method-required-super
-from odoo import _
+from odoo import _, fields
 from odoo.exceptions import UserError
 
 from odoo.addons.component.core import Component
@@ -56,6 +56,7 @@ class CustomerService(Component):
         return self.get()
 
     def sign_in(self, **params):
+        self.invader_partner.last_login_time = fields.Datetime.now()
         return self._assign_cart_and_get_store_cache()
 
     # The following method are 'private' and should be never never NEVER call

--- a/shopinvader/tests/test_customer.py
+++ b/shopinvader/tests/test_customer.py
@@ -110,8 +110,10 @@ class TestCustomer(TestCustomerCommon):
         SaleOrder.search(sale_domain).unlink()
 
         invader_partner = partner._get_invader_partner(self.backend)
+        self.assertFalse(invader_partner.last_login_time)
         self.service._load_partner_work_context(invader_partner)
         self.service.sign_in()
+        self.assertTrue(invader_partner.last_login_time)
         self.assertFalse(SaleOrder.search(sale_domain))
 
     def test_update_customer(self):

--- a/shopinvader/views/shopinvader_partner_view.xml
+++ b/shopinvader/views/shopinvader_partner_view.xml
@@ -20,6 +20,7 @@
                                 groups="base.group_multi_company"
                             />
                             <field name="create_date" readonly="1" />
+                            <field name="last_login_time" />
                             <field name="sync_date" />
                         </group>
                         <group name="record">
@@ -50,6 +51,7 @@
                 <field name="backend_id" />
                 <field name="external_id" />
                 <field name="create_date" readonly="1" />
+                <field name="last_login_time" />
                 <field
                     name="company_id"
                     widget="selection"
@@ -82,6 +84,18 @@
                         string="Parent"
                         domain="[]"
                         context="{'group_by':'parent_id'}"
+                    />
+                </group>
+                <group string="Login time">
+                    <filter
+                        name="filter_login_never"
+                        string="Never logged-in"
+                        domain="[('last_login_time', '=', False)]"
+                    />
+                    <filter
+                        name="filter_login_last_month"
+                        string="No login in a month"
+                        domain="[('last_login_time', '&lt;=', (context_today() + relativedelta(months=-1)).strftime('%Y-%m-%d'))]"
                     />
                 </group>
             </search>


### PR DESCRIPTION
Simply store the last login timestamp when /sign_in is called.

Includes #1532 