### PR TITLE
[16.0][IMP] shopinvader_api_sale_loyalty: do not update rewards when reading a sale

### DIFF
--- a/shopinvader_api_sale_loyalty/schemas/sale.py
+++ b/shopinvader_api_sale_loyalty/schemas/sale.py
@@ -35,7 +35,6 @@ class Sale(BaseSale, extends=True):
             for card in odoo_rec.generated_coupon_ids
         ]
         # Get claimable rewards
-        odoo_rec._update_programs_and_rewards()
         claimable_rewards = odoo_rec._get_claimable_rewards()
         obj.claimable_rewards = []
         for _, rewards in claimable_rewards.items():


### PR DESCRIPTION
The issue:
- https://github.com/shopinvader/odoo-shopinvader/issues/1538

Context:

 - `sale.order:_update_programs_and_rewards()` must be called at least once to create reward lines
 
- In odoo native, it is done when clicking on button `PROMOTIONS` and on `sale.order:action_confirm()`

- In oca, we have module `sale_loyalty_auto_refresh` (https://github.com/OCA/sale-promotion/pull/208) to do it whenever the sale order is updated

- So in `shopinvader_api_sale_loyalty`, `sale.order:_update_programs_and_rewards()` was explicitly called on GET /sales to make sure reward lines are created before returning the requested sale orders data

- But `sale.order:_update_programs_and_rewards()` implementation calls write() through [_reset_loyalty()](https://github.com/odoo/odoo/blob/accc6148834853993707d02a106f8e5ac4ded27a/addons/sale_loyalty/models/sale_order.py#L770) which is not what we expect from a GET endpoint (should be read-only); one direct consequence is that GET /sales endpoint can fail when called for _locked_ orders

- This PR fixes it by calling `sale.order:_update_programs_and_rewards()` only when strictly needed (when no reward line exists), and of course only if not locked.

Improvements:
- it's not necessary to update the reward every time we call the information on sale object. The method is already called when updating the cart: https://github.com/shopinvader/odoo-shopinvader/blob/16.0/shopinvader_api_sale_loyalty/routers/cart.py#L203
