### PR TITLE
[16.0] shopinvader_api_sale_loyalty: do not update rewards when reading a sale

### DIFF
--- a/shopinvader_api_sale_loyalty/schemas/sale.py
+++ b/shopinvader_api_sale_loyalty/schemas/sale.py
@@ -35,7 +35,6 @@ class Sale(BaseSale, extends=True):
             for card in odoo_rec.generated_coupon_ids
         ]
         # Get claimable rewards
-        odoo_rec._update_programs_and_rewards()
         claimable_rewards = odoo_rec._get_claimable_rewards()
         obj.claimable_rewards = []
         for _, rewards in claimable_rewards.items():


### PR DESCRIPTION
After reading the issue and the https://github.com/shopinvader/odoo-shopinvader/issues/1538 and the PR https://github.com/shopinvader/odoo-shopinvader/pull/1543

I do not think it's necessary to update the reward everytime we call the information on sale object. The method is already call when updating the cart : https://github.com/shopinvader/odoo-shopinvader/blob/16.0/shopinvader_api_sale_loyalty/routers/cart.py#L203 

I just do that PR to show that the test are still working even if we remove it.




