### PR TITLE
[14.0][FIX] shopinvader track_external_mixin

### DIFF
--- a/shopinvader/models/track_external_mixin.py
+++ b/shopinvader/models/track_external_mixin.py
@@ -9,6 +9,7 @@ class TrackExternalMixin(models.AbstractModel):
 
     last_external_update_date = fields.Datetime()
 
+    @api.model
     def is_rest_request(self):
         return self.env.context.get("shopinvader_request", False)
 
@@ -28,4 +29,4 @@ class TrackExternalMixin(models.AbstractModel):
         new_vals = []
         for vals in values_list:
             new_vals.append(self._fill_last_external_update_date(vals))
-        return super().create(values_list)
+        return super().create(new_vals)

--- a/shopinvader_cart_expiry/__manifest__.py
+++ b/shopinvader_cart_expiry/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "ACSONE SA/NV",
     "website": "https://github.com/shopinvader/odoo-shopinvader",
     "category": "e-commerce",
-    "version": "14.0.1.0.2",
+    "version": "14.0.1.0.3",
     "license": "AGPL-3",
     "depends": ["shopinvader"],
     "data": [

--- a/shopinvader_cart_expiry/migrations/14.0.1.0.3/post-migrate.py
+++ b/shopinvader_cart_expiry/migrations/14.0.1.0.3/post-migrate.py
@@ -1,0 +1,36 @@
+# Copyright 2024 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+from datetime import timedelta
+
+from odoo import SUPERUSER_ID, api, fields
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info("Upgrade shopinvader_cart_expiry: delete old carts")
+    if not version:
+        return
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        domain = [("cart_expiry_delay", ">", 0)]
+        for backend in env["shopinvader.backend"].search(domain):
+            backend = backend.with_company(backend.company_id.id).sudo_tech()
+            expiry_date = fields.Datetime.from_string(fields.Datetime.now())
+            delta_arg = {backend.cart_expiry_delay_unit: backend.cart_expiry_delay}
+            expiry_date -= timedelta(**delta_arg)
+            domain = [
+                ("shopinvader_backend_id", "=", backend.id),
+                ("typology", "=", "cart"),
+                ("state", "=", "draft"),
+                ("last_external_update_date", "=", False),
+            ]
+            cart_expired = backend.env["sale.order"].search(domain)
+            if cart_expired:
+                if backend.cart_expiry_policy == "cancel":
+                    cart_expired.action_cancel()
+                else:
+                    cart_expired.unlink()
+    return

--- a/shopinvader_cart_expiry/models/shopinvader_backend.py
+++ b/shopinvader_cart_expiry/models/shopinvader_backend.py
@@ -35,7 +35,10 @@ class ShopinvaderBackend(models.Model):
         domain = expression.AND([domain, [("cart_expiry_delay", ">", 0)]])
         for backend in self.search(domain):
             description = _("Manage cart expired for backend %s") % backend.name
-            backend.with_delay(description=description).manage_cart_expiry()
+            backend.with_delay(
+                description=description,
+                identity_key="shopinvader_manage_cart_expiry_%s" % (str(backend.id),),
+            ).manage_cart_expiry()
 
     def _get_cart_expiry_delay_domain(self):
         expiry_date = fields.Datetime.from_string(fields.Datetime.now())

--- a/shopinvader_cart_expiry/static/description/index.html
+++ b/shopinvader_cart_expiry/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {


### PR DESCRIPTION
- [FIX] During the creation of a record who inherit `track.external.mixin`, the `last_external_update_date` field was not set.

- [IMP] Improve the job who is cleaning those carts by adding an `identity_key`. That could avoid overloading queue job if something (not related to shopinvader) flood it.

- auto-update of `index.html` (has been done automatically)