### PR TITLE
[16.0] shopinvader_schema_sale: allow to hide some line in the schema (like delivery...)

### DIFF
--- a/shopinvader_schema_sale/__init__.py
+++ b/shopinvader_schema_sale/__init__.py
@@ -1,1 +1,2 @@
 from . import schemas
+from . import models

--- a/shopinvader_schema_sale/models/__init__.py
+++ b/shopinvader_schema_sale/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_line

--- a/shopinvader_schema_sale/models/sale_order_line.py
+++ b/shopinvader_schema_sale/models/sale_order_line.py
@@ -1,0 +1,21 @@
+# Copyright 2024 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    visible_in_shopinvader_api = fields.Boolean(
+        compute="_compute_visible_in_shopinvader_api", store=True
+    )
+
+    def _is_visible_in_shopinvader_api(self):
+        self.ensure_one()
+        return True
+
+    def _compute_visible_in_shopinvader_api(self):
+        for record in self:
+            record.visible_in_shopinvader_api = record._is_visible_in_shopinvader_api()

--- a/shopinvader_schema_sale/models/sale_order_line.py
+++ b/shopinvader_schema_sale/models/sale_order_line.py
@@ -2,7 +2,7 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class SaleOrderLine(models.Model):
@@ -16,6 +16,7 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         return True
 
+    @api.depends("product_id")
     def _compute_visible_in_shopinvader_api(self):
         for record in self:
             record.visible_in_shopinvader_api = record._is_visible_in_shopinvader_api()

--- a/shopinvader_schema_sale/schemas/sale.py
+++ b/shopinvader_schema_sale/schemas/sale.py
@@ -40,7 +40,11 @@ class Sale(StrictExtendableBaseModel):
             client_order_ref=odoo_rec.client_order_ref or None,
             date_order=odoo_rec.date_order,
             date_commitment=odoo_rec.commitment_date or None,
-            lines=[SaleLine.from_sale_order_line(line) for line in odoo_rec.order_line],
+            lines=[
+                SaleLine.from_sale_order_line(line)
+                for line in odoo_rec.order_line
+                if line.visible_in_shopinvader_api
+            ],
             amount=SaleAmount.from_sale_order(odoo_rec),
             delivery=DeliveryInfo.from_sale_order(odoo_rec),
             invoicing=InvoicingInfo.from_sale_order(odoo_rec),


### PR DESCRIPTION
Add hook to be able to hide "technical" product in the api

See use case here: https://github.com/shopinvader/odoo-shopinvader-carrier/pull/11