### PR TITLE
[16.0][FIX] shopinvader_anonymous_partner: auth cookie reseted

### DIFF
--- a/shopinvader_anonymous_partner/models/res_partner.py
+++ b/shopinvader_anonymous_partner/models/res_partner.py
@@ -80,11 +80,6 @@ class ResPartner(models.Model):
         Delete anonymous partner and cookie
         """
         self._get_anonymous_partner__cookie(cookies).unlink()
-        response.set_cookie(
-            key=COOKIE_NAME,
-            max_age=0,
-            expires=0,
-        )
 
     @api.model
     def _get_anonymous_partner__token(self, token: str):


### PR DESCRIPTION
When reseting shopinvader-anonymous-partner cookie, a new set-cookie option is set inside the headers of the response. However, it seems that only the last operation is received by the client so the auth cookie is lost so the user is no longer authentiticated for the next operation. As the auth cookie has already been set earlier, we can avoid reseting shopinvader-anonymous-partner-cookie.

This can be tested simply by setting a cookie at the end of the /signin operation from a jwt token.

I think this PR should not be merged as this might not be the right fix.

cc @lmignon 