### PR TITLE
[14.0][IMP] shopinvader_locomotive: avoid unnecessary partner exports

### DIFF
--- a/shopinvader_locomotive/component/event_listeners.py
+++ b/shopinvader_locomotive/component/event_listeners.py
@@ -16,8 +16,17 @@ class ShopinvaderBindingListener(Component):
     def on_record_create(self, record, fields=None):
         record.with_delay().export_record(_fields=fields)
 
+    def _get_export_not_triggered_fields(self):
+        return ["external_id", "last_login_time"]
+
     @skip_if(lambda self, record, **kwargs: self.no_connector_export(record))
     def on_record_write(self, record, fields=None):
+        if not fields:
+            return
+        # skip export if updating only fields that are not relevant
+        filtered_fields = self._get_export_not_triggered_fields()
+        if filtered_fields and set(fields).issubset(filtered_fields):
+            return
         record.with_delay().export_record(_fields=fields)
 
     def on_record_unlink(self, record):

--- a/shopinvader_locomotive/tests/test_shopinvader_partner.py
+++ b/shopinvader_locomotive/tests/test_shopinvader_partner.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
+from unittest.mock import patch
 
 from odoo import fields
 from odoo.exceptions import AccessError
@@ -104,6 +105,55 @@ class TestShopinvaderPartner(CommonShopinvaderPartner):
         partner.write({"city": "TEST"})
         # As we did not updated a field to export, no job should be created
         self._check_nbr_job_created(0)
+
+    def test_no_update_on_shopinvader_partner_external_id(self):
+        shop_partner, params = self._create_shopinvader_partner(
+            self.data, "5a953d6aae1c744cfcfb3cd3"
+        )
+        self._init_job_counter()
+        shop_partner.write({"external_id": "TEST"})
+        # should not create export job
+        self._check_nbr_job_created(0)
+
+    def test_update_on_shopinvader_partner_with_mixed_fields(self):
+        shop_partner, params = self._create_shopinvader_partner(
+            self.data, "5a953d6aae1c744cfcfb3cd3"
+        )
+        self._init_job_counter()
+        shop_partner.write(
+            {
+                "partner_email": "TEST",
+                "external_id": "TEST",
+            }
+        )
+        # should create export job as it contains non-filtered partner field
+        self._check_nbr_job_created(1)
+
+    def test_update_on_shopinvader_partner_without_fields_set(self):
+        shop_partner, params = self._create_shopinvader_partner(
+            self.data, "5a953d6aae1c744cfcfb3cd3"
+        )
+        self._init_job_counter()
+        shop_partner.write({})
+        # no jobs should be created
+        self._check_nbr_job_created(0)
+
+    def test_get_export_not_triggered_fields_override(self):
+        def mock_get_export_not_triggered_fields(self):
+            return False
+
+        shop_partner, params = self._create_shopinvader_partner(
+            self.data, "5a953d6aae1c744cfcfb3cd3"
+        )
+        self._init_job_counter()
+        with patch(
+            "odoo.addons.shopinvader_locomotive.component.event_listeners."
+            "ShopinvaderBindingListener._get_export_not_triggered_fields",
+            mock_get_export_not_triggered_fields,
+        ):
+            shop_partner.write({"external_id": "TEST"})
+        # job should be created normally
+        self._check_nbr_job_created(1)
 
     def test_binding_access_rights(self):
         shop_partner, params = self._create_shopinvader_partner(


### PR DESCRIPTION
shopinvader_locomotive: avoid unnecessary partner exports by not executing the export if the updated fields contain only:
- `external_id`
- `last_login_time`