### PR TITLE
[16.0][IMP] shopinvader_product: Avoid translated attribute name

### DIFF
--- a/shopinvader_product/models/tools.py
+++ b/shopinvader_product/models/tools.py
@@ -13,5 +13,5 @@ except ImportError:
 
 
 def sanitize_attr_name(attribute):
-    key = attribute.name
+    key = attribute.with_context(lang="en_US").name
     return unidecode(key.replace(" ", "_").lower())


### PR DESCRIPTION
Product attribute names are translatable but they serve as keys in the shopinvader bindings.
We typically have several bindings, one per lang, but we want to keep the same keys among all the bindings.
Thus, always translate attribute names to "en_US", the default Odoo language.