### PR TITLE
[16.0] [FIX] shopinvader_api_address: Missing rights on address update

### DIFF
--- a/shopinvader_api_address/routers/address_service.py
+++ b/shopinvader_api_address/routers/address_service.py
@@ -231,14 +231,17 @@ class ShopinvaderApiAddressRouterHelper(models.AbstractModel):
         # the enspoint's user
         # (e.g. snailmail/models/res_partner.py)
         partner_sudo = self.partner.sudo()
+        address.check_access_rights("write")
+        address.check_access_rule("write")
+        address_sudo = address.sudo()
         updated_address = False
         if address_type == "invoicing":
             updated_address = partner_sudo._update_shopinvader_invoicing_address(
-                vals, address
+                vals, address_sudo
             )
         elif address_type == "delivery":
             updated_address = partner_sudo._update_shopinvader_delivery_address(
-                vals, address
+                vals, address_sudo
             )
         else:
             raise ValueError(f"Unknown address type: {address_type}")


### PR DESCRIPTION
Same reason as for partner_sudo, on update write is done on address so we may need sudo too.