### PR TITLE
[16.0][IMP] shopinvader_search_engine_product_{,multi_}price: support batch _get_price

### DIFF
--- a/shopinvader_search_engine_product_multi_price/models/product_product.py
+++ b/shopinvader_search_engine_product_multi_price/models/product_product.py
@@ -15,10 +15,17 @@ class ProductProduct(models.Model):
     def _compute_shopinvader_price_by_pricelist(self):
         index_id = self.env.context.get("index_id", False)
         index = self.env["se.index"].browse(index_id)
+        prices = {}
+        if index_id:
+            for pricelist in index._get_pricelists():
+                price_unit_list = self._get_price(pricelist=pricelist)
+                prices[pricelist.id] = price_unit_list
         for product in self:
-            prices = {}
+            price_by_pricelist = {}
             if index_id:
                 for pricelist in index._get_pricelists():
-                    price = product._get_price(pricelist=pricelist)
-                    prices.update({pricelist.id: price})
-            product.shopinvader_price_by_pricelist = prices
+                    if product.id in prices[pricelist.id]:
+                        price_by_pricelist.update(
+                            {pricelist.id: prices[pricelist.id][product.id]}
+                        )
+            product.shopinvader_price_by_pricelist = price_by_pricelist

--- a/shopinvader_search_engine_product_price/models/product_product.py
+++ b/shopinvader_search_engine_product_price/models/product_product.py
@@ -14,8 +14,9 @@ class ProductProduct(models.Model):
     def _compute_shopinvader_price(self):
         index_id = self.env.context.get("index_id", False)
         index = self.env["se.index"].browse(index_id)
+        pricelist = None
+        if index_id:
+            pricelist = index._get_pricelist()
+        price_unit_list = self._get_price(pricelist=pricelist)
         for record in self:
-            pricelist = None
-            if index_id:
-                pricelist = index._get_pricelist()
-            record.shopinvader_price = record._get_price(pricelist=pricelist)
+            record.shopinvader_price = price_unit_list[record.id]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,3 +8,4 @@ httpx  # For FastAPI tests
 
 odoo-addon-shopinvader_api_customer @ git+https://github.com/shopinvader/odoo-shopinvader@refs/pull/1551/head#subdirectory=setup/shopinvader_api_customer
 odoo-addon-shopinvader_api_settings @ git+https://github.com/shopinvader/odoo-shopinvader@refs/pull/1555/head#subdirectory=setup/shopinvader_api_settings
+odoo-addon-product_get_price_helper @ git+https://github.com/OCA/product-attribute@refs/pull/1954/head#subdirectory=setup/product_get_price_helper


### PR DESCRIPTION
This PR updates the `shopinvader_search_engine_product_price` and `shopinvader_search_engine_product_multi_price` module to support the new batch computation logic introduced in `_get_price`.

### Depends on:
- https://github.com/OCA/product-attribute/pull/1954