### PR TITLE
[16.0] [IMP] sale_cart: Automatically convert cart to sale when a payment is authorized, set as pending, or done.

### DIFF
--- a/sale_cart/README.rst
+++ b/sale_cart/README.rst
@@ -26,6 +26,9 @@ This addon add a typology on sale.order to distinguish the sale orders that are
 in the process of being written (cart) and those that are quotations
 ready to be confirmed.
 
+It also automatically converts the cart into a sale when the payment is
+authorized, set as pending, or done.
+
 **Table of contents**
 
 .. contents::

--- a/sale_cart/models/__init__.py
+++ b/sale_cart/models/__init__.py
@@ -1,1 +1,2 @@
+from . import payment_transaction
 from . import sale_order

--- a/sale_cart/models/payment_transaction.py
+++ b/sale_cart/models/payment_transaction.py
@@ -1,0 +1,33 @@
+# Copyright 2025 Akretion (http://www.akretion.com).
+# @author Florian Mounier <florian.mounier@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class PaymentTransaction(models.Model):
+    _inherit = "payment.transaction"
+
+    def _get_related_carts(self):
+        """Return the carts related to this transaction."""
+        # We only consider sale orders with typology 'cart'
+        return self.sale_order_ids.filtered(lambda so: so.typology == "cart")
+
+    def _confirm_related_carts(self):
+        """Confirm the carts related to this transaction."""
+        self._get_related_carts().action_confirm_cart()
+
+    def _set_authorized(self, state_message=None):
+        """Override to set typology to sale when payment is authorized."""
+        self._confirm_related_carts()
+        return super()._set_authorized(state_message=state_message)
+
+    def _set_pending(self, state_message=None):
+        """Override to set typology to cart when payment is pending."""
+        self._confirm_related_carts()
+        return super()._set_pending(state_message=state_message)
+
+    def _set_done(self, state_message=None):
+        """Override to set typology to sale when payment is done."""
+        self._confirm_related_carts()
+        return super()._set_done(state_message=state_message)

--- a/sale_cart/models/sale_order.py
+++ b/sale_cart/models/sale_order.py
@@ -5,7 +5,6 @@ from odoo import fields, models
 
 
 class SaleOrder(models.Model):
-
     _inherit = "sale.order"
 
     typology = fields.Selection([("sale", "Sale"), ("cart", "Cart")], default="sale")

--- a/sale_cart/readme/DESCRIPTION.rst
+++ b/sale_cart/readme/DESCRIPTION.rst
@@ -1,3 +1,6 @@
 This addon add a typology on sale.order to distinguish the sale orders that are
 in the process of being written (cart) and those that are quotations
 ready to be confirmed.
+
+It also automatically converts the cart into a sale when the payment is
+authorized, set as pending, or done.

--- a/sale_cart/static/description/index.html
+++ b/sale_cart/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -373,6 +373,8 @@ ul.auto-toc {
 <p>This addon add a typology on sale.order to distinguish the sale orders that are
 in the process of being written (cart) and those that are quotations
 ready to be confirmed.</p>
+<p>It also automatically converts the cart into a sale when the payment is
+authorized, set as pending, or done.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/sale_cart/tests/common.py
+++ b/sale_cart/tests/common.py
@@ -1,0 +1,31 @@
+# Copyright 2022 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class SaleCartCommon(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super(SaleCartCommon, cls).setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "product",
+                "uom_id": cls.env.ref("uom.product_uom_unit").id,
+            }
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "partner"})
+        cls.so_cart = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {"product_id": cls.product.id, "product_uom_qty": 1},
+                    )
+                ],
+                "typology": "cart",
+            }
+        )

--- a/sale_cart/tests/test_sale_cart.py
+++ b/sale_cart/tests/test_sale_cart.py
@@ -1,35 +1,11 @@
 # Copyright 2022 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+
+from .common import SaleCartCommon
 
 
-class TestSaleCart(TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super(TestSaleCart, cls).setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.product = cls.env["product.product"].create(
-            {
-                "name": "product",
-                "uom_id": cls.env.ref("uom.product_uom_unit").id,
-            }
-        )
-        cls.partner = cls.env["res.partner"].create({"name": "partner"})
-        cls.so_cart = cls.env["sale.order"].create(
-            {
-                "partner_id": cls.partner.id,
-                "order_line": [
-                    (
-                        0,
-                        0,
-                        {"product_id": cls.product.id, "product_uom_qty": 1},
-                    )
-                ],
-                "typology": "cart",
-            }
-        )
-
+class TestSaleCart(SaleCartCommon):
     def test_action_confirm_cart(self):
         self.assertEqual("draft", self.so_cart.state)
         self.assertEqual("cart", self.so_cart.typology)

--- a/sale_cart/tests/test_sale_cart_payment.py
+++ b/sale_cart/tests/test_sale_cart_payment.py
@@ -1,0 +1,133 @@
+# Copyright 2025 Akretion (http://www.akretion.com).
+# @author Florian Mounier <florian.mounier@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.payment.tests.common import PaymentCommon
+
+from .common import SaleCartCommon
+
+
+class TestSaleCartPayment(SaleCartCommon, PaymentCommon):
+    def test_action_confirm_cart_on_transaction_authorized(self):
+        self.assertEqual("draft", self.so_cart.state)
+        self.assertEqual("cart", self.so_cart.typology)
+        transaction = self.env["payment.transaction"].create(
+            {
+                "amount": self.so_cart.amount_total,
+                "currency_id": self.currency.id,
+                "provider_id": self.provider.id,
+                "reference": self.so_cart.name,
+                "operation": "online_redirect",
+                "partner_id": self.partner.id,
+            }
+        )
+        self.so_cart.transaction_ids |= transaction
+        self.provider.support_manual_capture = True
+        transaction._set_authorized()
+        self.assertEqual("sale", self.so_cart.typology)
+        # The sale order is confirmed since a transaction with the right amount
+        # is authorized
+        self.assertEqual("sale", self.so_cart.state)
+
+    def test_action_confirm_cart_on_transaction_pending(self):
+        self.assertEqual("draft", self.so_cart.state)
+        self.assertEqual("cart", self.so_cart.typology)
+        transaction = self.env["payment.transaction"].create(
+            {
+                "amount": self.so_cart.amount_total,
+                "currency_id": self.currency.id,
+                "provider_id": self.provider.id,
+                "reference": self.so_cart.name,
+                "operation": "online_redirect",
+                "partner_id": self.partner.id,
+            }
+        )
+        self.so_cart.transaction_ids |= transaction
+        transaction._set_pending()
+        self.assertEqual("sale", self.so_cart.typology)
+        # The sale order is set to 'sent' when a transaction is pending
+        self.assertEqual("sent", self.so_cart.state)
+        transaction._reconcile_after_done()
+        self.assertEqual("sent", self.so_cart.state)
+
+    def test_action_confirm_cart_on_transaction_done(self):
+        self.assertEqual("draft", self.so_cart.state)
+        self.assertEqual("cart", self.so_cart.typology)
+        transaction = self.env["payment.transaction"].create(
+            {
+                "amount": self.so_cart.amount_total,
+                "currency_id": self.currency.id,
+                "provider_id": self.provider.id,
+                "reference": self.so_cart.name,
+                "operation": "online_redirect",
+                "partner_id": self.partner.id,
+            }
+        )
+        self.so_cart.transaction_ids |= transaction
+        transaction._set_done()
+        self.assertEqual("sale", self.so_cart.typology)
+        # The sale order is not confirmed instantly on done
+        self.assertEqual("draft", self.so_cart.state)
+        # The sale order is confirmed after the post-processing
+        transaction._reconcile_after_done()
+        self.assertEqual("sale", self.so_cart.state)
+
+    def test_action_confirm_cart_on_transaction_error(self):
+        self.assertEqual("draft", self.so_cart.state)
+        self.assertEqual("cart", self.so_cart.typology)
+        transaction = self.env["payment.transaction"].create(
+            {
+                "amount": self.so_cart.amount_total,
+                "currency_id": self.currency.id,
+                "provider_id": self.provider.id,
+                "reference": self.so_cart.name,
+                "operation": "online_redirect",
+                "partner_id": self.partner.id,
+            }
+        )
+        self.so_cart.transaction_ids |= transaction
+        transaction._set_error(state_message="Test error")
+        # The sale order stays as a cart on error
+        self.assertEqual("cart", self.so_cart.typology)
+        # The sale order is not confirmed on error
+        self.assertEqual("draft", self.so_cart.state)
+
+    def test_action_confirm_cart_on_transaction_cancel(self):
+        self.assertEqual("draft", self.so_cart.state)
+        self.assertEqual("cart", self.so_cart.typology)
+        transaction = self.env["payment.transaction"].create(
+            {
+                "amount": self.so_cart.amount_total,
+                "currency_id": self.currency.id,
+                "provider_id": self.provider.id,
+                "reference": self.so_cart.name,
+                "operation": "online_redirect",
+                "partner_id": self.partner.id,
+            }
+        )
+        self.so_cart.transaction_ids |= transaction
+        transaction._set_canceled()
+        # The sale order stays as a cart on cancel
+        self.assertEqual("cart", self.so_cart.typology)
+        # The sale order is not confirmed on cancel
+        self.assertEqual("draft", self.so_cart.state)
+
+    def test_action_confirm_cart_on_transaction_authorize_wrong_amount(self):
+        self.assertEqual("draft", self.so_cart.state)
+        self.assertEqual("cart", self.so_cart.typology)
+        transaction = self.env["payment.transaction"].create(
+            {
+                "amount": self.so_cart.amount_total + 100,  # Wrong amount
+                "currency_id": self.currency.id,
+                "provider_id": self.provider.id,
+                "reference": self.so_cart.name,
+                "operation": "online_redirect",
+                "partner_id": self.partner.id,
+            }
+        )
+        self.so_cart.transaction_ids |= transaction
+        self.provider.support_manual_capture = True
+        transaction._set_authorized()
+        self.assertEqual("sale", self.so_cart.typology)
+        # The sale order is not confirmed since the transaction amount is wrong
+        self.assertEqual("draft", self.so_cart.state)


### PR DESCRIPTION
From https://github.com/shopinvader/odoo-shopinvader-payment/issues/99

Automatically converts the cart into a sale when the payment is authorized, set as pending, or done instead of relying on callback, see https://github.com/shopinvader/odoo-shopinvader-payment/pull/101