### PR TITLE
[16.0][ADD] sale_quotation_customer_quotation_workflow_notifications: notifications handeling for "CQ" workflow.

### DIFF
--- a/sale_quotation_customer_quotation_workflow_notifications/__init__.py
+++ b/sale_quotation_customer_quotation_workflow_notifications/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_quotation_customer_quotation_workflow_notifications/__manifest__.py
+++ b/sale_quotation_customer_quotation_workflow_notifications/__manifest__.py
@@ -1,0 +1,23 @@
+# Copyright 2025 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Odoo/addons/Sale Quotation Customer Quotation Workflow Notifications",
+    "summary": """Custom notifications handeling for "customer quotation" workflow on sale orders""",
+    "version": "16.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "ACSONE SA/NV",
+    "website": "https://github.com/shopinvader/odoo-shopinvader",
+    "depends": [
+        # Third-party
+        "sale_quotation",
+    ],
+    "data": ["data/mail_message_subtype.xml"],
+    "assets": {
+        "web.assets_backend": [
+            "sale_quotation_customer_quotation_workflow_notifications/static/src/components/follower_subtype_list/follower_subtype_list.js",
+            "sale_quotation_customer_quotation_workflow_notifications/static/src/components/follower_subtype_list/follower_subtype_list.xml",
+        ],
+    },
+    "demo": [],
+}

--- a/sale_quotation_customer_quotation_workflow_notifications/data/mail_message_subtype.xml
+++ b/sale_quotation_customer_quotation_workflow_notifications/data/mail_message_subtype.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="mt_customer_quotation" model="mail.message.subtype">
+        <field name="name">Customer Quotation Workflow</field>
+        <field name="res_model">sale.order</field>
+        <field name="hidden">1</field>
+        <field name="internal">1</field>
+        <field name="default">0</field>
+        <field
+            name="description"
+        >Parent notification type for "Customer Quotation" workflow actions associated to sale orders.</field>
+    </record>
+    <record id="mt_quotation_request" model="mail.message.subtype">
+        <field name="name">Customer Quotation Request</field>
+        <field name="res_model">sale.order</field>
+        <field name="parent_id" ref="mt_customer_quotation" />
+        <field name="hidden">0</field>
+        <field name="internal">1</field>
+        <field name="default">1</field>
+        <field
+            name="description"
+        >Triggered when a customer requests a quotation on a sale order using "Customer Quotation" workflow.</field>
+    </record>
+    <record id="mt_customer_accept_quotation" model="mail.message.subtype">
+        <field name="name">Customer Quotation Accepted</field>
+        <field name="res_model">sale.order</field>
+        <field name="parent_id" ref="mt_customer_quotation" />
+        <field name="hidden">0</field>
+        <field name="internal">1</field>
+        <field name="default">1</field>
+        <field
+            name="description"
+        >Triggered when a customer accepts a quotation on a sale order using "Customer Quotation" workflow.</field>
+    </record>
+    <record id="mt_customer_reset_quotation_to_draft" model="mail.message.subtype">
+        <field name="name">Customer Quotation to Draft</field>
+        <field name="res_model">sale.order</field>
+        <field name="parent_id" ref="mt_customer_quotation" />
+        <field name="hidden">0</field>
+        <field name="internal">1</field>
+        <field name="default">1</field>
+        <field
+            name="description"
+        >Triggered when a customer resets a quotation to draft on a sale order using "Customer Quotation" workflow.</field>
+    </record>
+    <record id="mt_customer_cancel_quotation" model="mail.message.subtype">
+        <field name="name">Customer Quotation Cancel</field>
+        <field name="res_model">sale.order</field>
+        <field name="parent_id" ref="mt_customer_quotation" />
+        <field name="hidden">0</field>
+        <field name="internal">1</field>
+        <field name="default">1</field>
+        <field
+            name="description"
+        >Triggered when a customer cancels a quotation on a sale order using "Customer Quotation" workflow.</field>
+    </record>
+</odoo>

--- a/sale_quotation_customer_quotation_workflow_notifications/i18n/fr.po
+++ b/sale_quotation_customer_quotation_workflow_notifications/i18n/fr.po
@@ -1,0 +1,147 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_quotation_customer_quotation_workflow_notifications
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-09-08 08:10+0000\n"
+"PO-Revision-Date: 2025-09-08 08:10+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#: model:mail.message.subtype,name:sale_quotation_customer_quotation_workflow_notifications.mt_customer_accept_quotation
+#, python-format
+msgid "Customer Quotation Accepted"
+msgstr "Devis Client Accepté"
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,name:sale_quotation_customer_quotation_workflow_notifications.mt_customer_cancel_quotation
+msgid "Customer Quotation Cancel"
+msgstr "Devis Client Annulé"
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid "Customer Quotation Cancelled"
+msgstr "Devis Client Annulé"
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#: model:mail.message.subtype,name:sale_quotation_customer_quotation_workflow_notifications.mt_quotation_request
+#, python-format
+msgid "Customer Quotation Request"
+msgstr "Devis Client Demande"
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid "Customer Quotation Reset to Draft"
+msgstr "Devis Client Remis en Brouillon"
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,name:sale_quotation_customer_quotation_workflow_notifications.mt_customer_quotation
+msgid "Customer Quotation Workflow"
+msgstr "Flux Devis Client"
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,name:sale_quotation_customer_quotation_workflow_notifications.mt_customer_reset_quotation_to_draft
+msgid "Customer Quotation to Draft"
+msgstr "Devis Client en Brouillon"
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,description:sale_quotation_customer_quotation_workflow_notifications.mt_customer_quotation
+msgid ""
+"Parent notification type for \"Customer Quotation\" workflow actions "
+"associated to sale orders."
+msgstr "Type de notifications parent pour les actions du flux \"Devis Client\" associées aux bons de commande."
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid "Quotation Request Confirmation"
+msgstr "Confirmation de Demande de Devis"
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:ir.model,name:sale_quotation_customer_quotation_workflow_notifications.model_sale_order
+msgid "Sales Order"
+msgstr "Bon de Commande"
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid "The quotation \"%(name)s\" has been accepted by the client \"%(client)s\"."
+msgstr "Le devis \"%(name)s\" a été accepté par le client \"%(client)s\"."
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid "The quotation \"%(name)s\" has been cancelled by the client \"%(client)s\"."
+msgstr "Le devis \"%(name)s\" a été annulé par le client \"%(client)s\"."
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid ""
+"The quotation \"%(name)s\" has been reset to draft by the client "
+"\"%(client)s\"."
+msgstr "Le devis \"%(name)s\" a été remis en brouillon par le client \"%(client)s\"."
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid ""
+"The quotation \"%(quotation_name)s\" has been requested by the client "
+"\"%(client)s\"."
+msgstr "Le devis \"%(quotation_name)s\" a été demandé par le client \"%(client)s\"."
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,description:sale_quotation_customer_quotation_workflow_notifications.mt_customer_accept_quotation
+msgid ""
+"Triggered when a customer accepts a quotation on a sale order using "
+"\"Customer Quotation\" workflow."
+msgstr "Déclenché lorsqu'un client accepte un devis sur un bon de commande via le flux \"Devis Client\"."
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,description:sale_quotation_customer_quotation_workflow_notifications.mt_customer_cancel_quotation
+msgid ""
+"Triggered when a customer cancels a quotation on a sale order using "
+"\"Customer Quotation\" workflow."
+msgstr "Déclenché lorsqu'un client annule un devis sur un bon de commande via le flux \"Devis Client\"."
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,description:sale_quotation_customer_quotation_workflow_notifications.mt_quotation_request
+msgid ""
+"Triggered when a customer requests a quotation on a sale order using "
+"\"Customer Quotation\" workflow."
+msgstr "Déclenché lorsqu'un client demande un devis sur un bon de commande via le flux \"Devis Client\"."
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,description:sale_quotation_customer_quotation_workflow_notifications.mt_customer_reset_quotation_to_draft
+msgid ""
+"Triggered when a customer resets a quotation to draft on a sale order using "
+"\"Customer Quotation\" workflow."
+msgstr "Déclenché lorsqu'un client remet un devis en brouillon sur un bon de commande via le flux \"Devis Client\"."
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid "Your quote request \"%(quotation_name)s\" has been successfully submitted."
+msgstr "Votre demande de devis \"%(quotation_name)s\" a été soumise avec succès."

--- a/sale_quotation_customer_quotation_workflow_notifications/i18n/sale_quotation_customer_quotation_workflow_notifications.pot
+++ b/sale_quotation_customer_quotation_workflow_notifications/i18n/sale_quotation_customer_quotation_workflow_notifications.pot
@@ -1,0 +1,147 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_quotation_customer_quotation_workflow_notifications
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-09-08 08:10+0000\n"
+"PO-Revision-Date: 2025-09-08 08:10+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#: model:mail.message.subtype,name:sale_quotation_customer_quotation_workflow_notifications.mt_customer_accept_quotation
+#, python-format
+msgid "Customer Quotation Accepted"
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,name:sale_quotation_customer_quotation_workflow_notifications.mt_customer_cancel_quotation
+msgid "Customer Quotation Cancel"
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid "Customer Quotation Cancelled"
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#: model:mail.message.subtype,name:sale_quotation_customer_quotation_workflow_notifications.mt_quotation_request
+#, python-format
+msgid "Customer Quotation Request"
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid "Customer Quotation Reset to Draft"
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,name:sale_quotation_customer_quotation_workflow_notifications.mt_customer_quotation
+msgid "Customer Quotation Workflow"
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,name:sale_quotation_customer_quotation_workflow_notifications.mt_customer_reset_quotation_to_draft
+msgid "Customer Quotation to Draft"
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,description:sale_quotation_customer_quotation_workflow_notifications.mt_customer_quotation
+msgid ""
+"Parent notification type for \"Customer Quotation\" workflow actions "
+"associated to sale orders."
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid "Quotation Request Confirmation"
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:ir.model,name:sale_quotation_customer_quotation_workflow_notifications.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid "The quotation \"%(name)s\" has been accepted by the client \"%(client)s\"."
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid "The quotation \"%(name)s\" has been cancelled by the client \"%(client)s\"."
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid ""
+"The quotation \"%(name)s\" has been reset to draft by the client "
+"\"%(client)s\"."
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid ""
+"The quotation \"%(quotation_name)s\" has been requested by the client "
+"\"%(client)s\"."
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,description:sale_quotation_customer_quotation_workflow_notifications.mt_customer_accept_quotation
+msgid ""
+"Triggered when a customer accepts a quotation on a sale order using "
+"\"Customer Quotation\" workflow."
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,description:sale_quotation_customer_quotation_workflow_notifications.mt_customer_cancel_quotation
+msgid ""
+"Triggered when a customer cancels a quotation on a sale order using "
+"\"Customer Quotation\" workflow."
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,description:sale_quotation_customer_quotation_workflow_notifications.mt_quotation_request
+msgid ""
+"Triggered when a customer requests a quotation on a sale order using "
+"\"Customer Quotation\" workflow."
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#: model:mail.message.subtype,description:sale_quotation_customer_quotation_workflow_notifications.mt_customer_reset_quotation_to_draft
+msgid ""
+"Triggered when a customer resets a quotation to draft on a sale order using "
+"\"Customer Quotation\" workflow."
+msgstr ""
+
+#. module: sale_quotation_customer_quotation_workflow_notifications
+#. odoo-python
+#: code:addons/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py:0
+#, python-format
+msgid "Your quote request \"%(quotation_name)s\" has been successfully submitted."
+msgstr ""

--- a/sale_quotation_customer_quotation_workflow_notifications/models/__init__.py
+++ b/sale_quotation_customer_quotation_workflow_notifications/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py
+++ b/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py
@@ -1,0 +1,142 @@
+# Copyright 2025 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def action_customer_request_quotation(self):
+        res = super().action_customer_request_quotation()
+        for so in self:
+            so.message_post(
+                subject=_("Customer Quotation Request"),
+                body=_(
+                    'The quotation "%(quotation_name)s" has been requested by the client "%(client)s".',
+                    quotation_name=self.name,
+                    client=self.partner_id.name,
+                ),
+                subtype_xmlid="sale_quotation_customer_quotation_workflow_notifications.mt_quotation_request",
+            )
+            self.env["mail.thread"].message_notify(
+                partner_ids=self.partner_id.ids,
+                subject=_("Quotation Request Confirmation"),
+                body=_(
+                    'Your quote request "%(quotation_name)s" has been successfully submitted.',
+                    quotation_name=so.name,
+                ),
+                is_internal=False,
+                email_add_signature=False,
+                subtype_id=self.env.ref("mail.mt_comment").id,
+            )
+
+        return res
+
+    def action_customer_accept_quotation(self):
+        res = super().action_customer_accept_quotation()
+        for so in self:
+            so.message_post(
+                subject=_("Customer Quotation Accepted"),
+                body=_(
+                    'The quotation "%(name)s" has been accepted by the client "%(client)s".',
+                    name=self.name,
+                    client=self.partner_id.name,
+                ),
+                subtype_xmlid="sale_quotation_customer_quotation_workflow_notifications.mt_customer_accept_quotation",
+            )
+        return res
+
+    def action_customer_reset_quotation_to_draft(self):
+        res = super().action_customer_reset_quotation_to_draft()
+        for so in self:
+            so.message_post(
+                subject=_("Customer Quotation Reset to Draft"),
+                body=_(
+                    'The quotation "%(name)s" has been reset to draft by the client "%(client)s".',
+                    name=self.name,
+                    client=self.partner_id.name,
+                ),
+                subtype_xmlid="sale_quotation_customer_quotation_workflow_notifications.mt_customer_reset_quotation_to_draft",
+            )
+        return res
+
+    def action_customer_cancel_quotation(self):
+        res = super().action_customer_cancel_quotation()
+        for so in self:
+            so.message_post(
+                subject=_("Customer Quotation Cancelled"),
+                body=_(
+                    'The quotation "%(name)s" has been cancelled by the client "%(client)s".',
+                    name=self.name,
+                    client=self.partner_id.name,
+                ),
+                subtype_xmlid="sale_quotation_customer_quotation_workflow_notifications.mt_customer_cancel_quotation",
+            )
+        return res
+
+    def _get_default_and_custom_subtype_ids(self):
+        """Helper method to get the IDs of default messages subtypes depending.
+
+        on the workflow of the given SO.
+        """
+        self.ensure_one()
+
+        custom_quotation_subtype = self.env.ref(
+            "sale_quotation_customer_quotation_workflow_notifications.mt_customer_quotation",
+        )
+        if self.use_customer_quotation_workflow:
+            return (
+                self.env["mail.message.subtype"]
+                .search(
+                    [
+                        ("res_model", "=", "sale.order"),
+                        ("parent_id", "=", custom_quotation_subtype.id),
+                    ]
+                )
+                .filtered("default")
+                .ids
+            )
+        return (
+            self.env["mail.message.subtype"]
+            .search(
+                [
+                    ("res_model", "in", [False, "sale.order"]),
+                    ("parent_id", "!=", custom_quotation_subtype.id),
+                ]
+            )
+            .filtered("default")
+            .ids
+        )
+
+    def _update_subscriptions(self):
+        """Helper method to handle subscription/unsubscription logic."""
+        for so in self:
+            follower_partner_ids = so.message_follower_ids.mapped("partner_id").ids
+
+            if not follower_partner_ids:
+                continue
+
+            if so.use_customer_quotation_workflow:
+                so.message_subscribe(
+                    partner_ids=follower_partner_ids,
+                    subtype_ids=so._get_default_and_custom_subtype_ids(),
+                )
+
+            else:
+                so.message_subscribe(
+                    partner_ids=follower_partner_ids,
+                    subtype_ids=so._get_default_and_custom_subtype_ids(),
+                )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        res._update_subscriptions()
+        return res
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "use_customer_quotation_workflow" in vals or "user_id" in vals:
+            self._update_subscriptions()
+        return res

--- a/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py
+++ b/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py
@@ -124,17 +124,10 @@ class SaleOrder(models.Model):
             if not follower_partner_ids:
                 continue
 
-            if so.use_customer_quotation_workflow:
-                so.message_subscribe(
-                    partner_ids=follower_partner_ids,
-                    subtype_ids=so._get_default_and_custom_subtype_ids(),
-                )
-
-            else:
-                so.message_subscribe(
-                    partner_ids=follower_partner_ids,
-                    subtype_ids=so._get_default_and_custom_subtype_ids(),
-                )
+            so.message_subscribe(
+                partner_ids=follower_partner_ids,
+                subtype_ids=so._get_default_and_custom_subtype_ids(),
+            )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py
+++ b/sale_quotation_customer_quotation_workflow_notifications/models/sale_order.py
@@ -13,11 +13,13 @@ class SaleOrder(models.Model):
             so.message_post(
                 subject=_("Customer Quotation Request"),
                 body=_(
-                    'The quotation "%(quotation_name)s" has been requested by the client "%(client)s".',
+                    'The quotation "%(quotation_name)s" has been requested '
+                    'by the client "%(client)s".',
                     quotation_name=self.name,
                     client=self.partner_id.name,
                 ),
-                subtype_xmlid="sale_quotation_customer_quotation_workflow_notifications.mt_quotation_request",
+                subtype_xmlid="sale_quotation_customer_quotation_workflow_notifications"
+                ".mt_quotation_request",
             )
             self.env["mail.thread"].message_notify(
                 partner_ids=self.partner_id.ids,
@@ -43,7 +45,8 @@ class SaleOrder(models.Model):
                     name=self.name,
                     client=self.partner_id.name,
                 ),
-                subtype_xmlid="sale_quotation_customer_quotation_workflow_notifications.mt_customer_accept_quotation",
+                subtype_xmlid="sale_quotation_customer_quotation_workflow_notifications"
+                ".mt_customer_accept_quotation",
             )
         return res
 
@@ -53,11 +56,13 @@ class SaleOrder(models.Model):
             so.message_post(
                 subject=_("Customer Quotation Reset to Draft"),
                 body=_(
-                    'The quotation "%(name)s" has been reset to draft by the client "%(client)s".',
+                    'The quotation "%(name)s" has been reset to draft by the '
+                    'client "%(client)s".',
                     name=self.name,
                     client=self.partner_id.name,
                 ),
-                subtype_xmlid="sale_quotation_customer_quotation_workflow_notifications.mt_customer_reset_quotation_to_draft",
+                subtype_xmlid="sale_quotation_customer_quotation_workflow_notifications"
+                ".mt_customer_reset_quotation_to_draft",
             )
         return res
 
@@ -71,7 +76,8 @@ class SaleOrder(models.Model):
                     name=self.name,
                     client=self.partner_id.name,
                 ),
-                subtype_xmlid="sale_quotation_customer_quotation_workflow_notifications.mt_customer_cancel_quotation",
+                subtype_xmlid="sale_quotation_customer_quotation_workflow_notifications"
+                ".mt_customer_cancel_quotation",
             )
         return res
 
@@ -83,7 +89,8 @@ class SaleOrder(models.Model):
         self.ensure_one()
 
         custom_quotation_subtype = self.env.ref(
-            "sale_quotation_customer_quotation_workflow_notifications.mt_customer_quotation",
+            "sale_quotation_customer_quotation_workflow_notifications"
+            ".mt_customer_quotation",
         )
         if self.use_customer_quotation_workflow:
             return (

--- a/sale_quotation_customer_quotation_workflow_notifications/static/src/components/follower_subtype_list/follower_subtype_list.js
+++ b/sale_quotation_customer_quotation_workflow_notifications/static/src/components/follower_subtype_list/follower_subtype_list.js
@@ -1,0 +1,57 @@
+/** @odoo-module **/
+
+import {FollowerSubtypeList} from "@mail/components/follower_subtype_list/follower_subtype_list";
+import {patch} from "@web/core/utils/patch";
+
+import {useState} from "@odoo/owl";
+
+function getUrlSearchParams() {
+    return new URLSearchParams(location.hash.substring(1));
+}
+patch(
+    FollowerSubtypeList.prototype,
+    "Add a filter on message subtypes for customer quotation sale orders",
+    {
+        async setup() {
+            this._super();
+
+            this.state = useState({
+                filteredSubtypeViews: this.followerSubtypeList.followerSubtypeViews,
+            });
+
+            this.state.filteredSubtypeViews = await this.filteredFollowerSubtypeViews();
+        },
+
+        async filteredFollowerSubtypeViews() {
+            const urlSearchParams = getUrlSearchParams();
+            if (
+                urlSearchParams.get("model") != "sale.order" ||
+                urlSearchParams.get("view_type") != "form"
+            ) {
+                return this.followerSubtypeList.followerSubtypeViews;
+            }
+
+            const records = await this.env.services.orm.searchRead(
+                "sale.order",
+                [["id", "=", urlSearchParams.get("id")]],
+                ["use_customer_quotation_workflow"]
+            );
+            const record = records.length ? records[0] : null;
+
+            if (!record || !record.use_customer_quotation_workflow) {
+                return this.followerSubtypeList.followerSubtypeViews.filter(
+                    (x) =>
+                        x.subtype.resModel === false || x.subtype.parentModel === false
+                );
+            }
+            return this.followerSubtypeList.followerSubtypeViews.filter(
+                (x) => x.subtype.resModel !== false && x.subtype.parentModel !== false
+            );
+        },
+    }
+);
+
+patch(FollowerSubtypeList, "Filter subtypes on sale orders", {
+    template:
+        "sale_quotation_customer_quotation_workflow_notifications.FilteredFollowerSubtypeList",
+});

--- a/sale_quotation_customer_quotation_workflow_notifications/static/src/components/follower_subtype_list/follower_subtype_list.xml
+++ b/sale_quotation_customer_quotation_workflow_notifications/static/src/components/follower_subtype_list/follower_subtype_list.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t
+        t-name="sale_quotation_customer_quotation_workflow_notifications.FilteredFollowerSubtypeList"
+        t-inherit="mail.FollowerSubtypeList"
+        owl="1"
+        t-inherit-mode="primary"
+    >
+
+        <xpath
+            expr="//t[@t-foreach='followerSubtypeList.followerSubtypeViews']"
+            position="replace"
+        >
+            <t
+                t-foreach="state.filteredSubtypeViews"
+                t-as="followerSubtypeView"
+                t-key="followerSubtypeView.localId"
+            >
+                <FollowerSubtype
+                    className="'o_FollowerSubtypeList_subtype'"
+                    record="followerSubtypeView"
+                />
+
+            </t>
+        </xpath>
+
+    </t>
+</templates>

--- a/sale_quotation_customer_quotation_workflow_notifications/tests/__init__.py
+++ b/sale_quotation_customer_quotation_workflow_notifications/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import test_customer_quotation_workflow_notifications
+from . import test_customer_quotation_workflow_subscriptions

--- a/sale_quotation_customer_quotation_workflow_notifications/tests/test_customer_quotation_workflow_notifications.py
+++ b/sale_quotation_customer_quotation_workflow_notifications/tests/test_customer_quotation_workflow_notifications.py
@@ -1,0 +1,154 @@
+# Copyright 2025 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import Command
+from odoo.tests.common import TransactionCase
+
+
+class TestCustomerQuotationWorkflowNotifications(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.salesman = cls.env["res.users"].create(
+            {
+                "name": "Test Sales Man",
+                "login": "test_user",
+                "email": "test_user@example.com",
+                "groups_id": [
+                    Command.set([cls.env.ref("sales_team.group_sale_salesman").id])
+                ],
+            }
+        )
+
+        cls.customer = cls.env["res.partner"].create(
+            {
+                "name": "Test Customer",
+                "email": "test_customer@example.com",
+            }
+        )
+
+        cls.mt_quotation_request = cls.env.ref(
+            "sale_quotation_customer_quotation_workflow_notifications.mt_quotation_request"
+        )
+        cls.mt_customer_accept_quotation = cls.env.ref(
+            "sale_quotation_customer_quotation_workflow_notifications.mt_customer_accept_quotation"
+        )
+        cls.mt_customer_reset_quotation_to_draft = cls.env.ref(
+            "sale_quotation_customer_quotation_workflow_notifications.mt_customer_reset_quotation_to_draft"
+        )
+        cls.mt_customer_cancel_quotation = cls.env.ref(
+            "sale_quotation_customer_quotation_workflow_notifications.mt_customer_cancel_quotation"
+        )
+
+        # Ensure all custom notifications types are assigned to the salesman
+        # when creating an SO
+        (
+            cls.mt_quotation_request
+            | cls.mt_customer_accept_quotation
+            | cls.mt_customer_reset_quotation_to_draft
+            | cls.mt_customer_cancel_quotation
+        ).default = True
+
+        cls.sale_order = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.customer.id,
+                "use_customer_quotation_workflow": True,
+                "user_id": cls.salesman.id,
+            }
+        )
+
+    def _get_notifications(self, partner):
+        """Helper to return the `mail.notification`'s associated to a given partner."""
+        return self.env["mail.notification"].search(
+            [("res_partner_id", "=", partner.id)]
+        )
+
+    def _get_notified_messages(self, sale_order, partner):
+        """
+        Helper to return the messages of the SO that notified the given partner.
+
+        This method is necessary since the subscription mechanism does not necessarily
+        create a `mail.notification` record though partners are still notified.
+        """
+        return sale_order.message_ids.filtered(
+            lambda m: partner in m.notified_partner_ids
+        )
+
+    def test_quotation_request_notifications(self):
+        """
+        Test that when a user requests a quotation:
+
+            - the salesperson gets notified of the quotation request
+            - the customer receives a confirmation of the quotation request
+        """
+        sale_order = self.sale_order
+        sale_order.action_customer_request_quotation()
+
+        customer_notifications = self._get_notifications(sale_order.partner_id)
+        self.assertEqual(
+            len(customer_notifications),
+            1,
+            "Customer should be notified of successful request",
+        )
+        self.assertEqual(
+            "Quotation Request Confirmation",
+            customer_notifications.mail_message_id.subject,
+        )
+
+        # Check that a notification was posted for the salesperson
+        salesman_messages = self._get_notified_messages(
+            sale_order, sale_order.user_id.partner_id
+        )
+        self.assertEqual(
+            len(salesman_messages),
+            1,
+            "Salesperson should be notified of quotation requests",
+        )
+        self.assertEqual("Customer Quotation Request", salesman_messages.subject)
+
+    def test_customer_quotation_actions_notify_salesman(self):
+        """Test that the different customer actions notify the salesman."""
+        sale_order = self.sale_order
+        sale_order.action_customer_request_quotation()
+        sale_order.action_customer_reset_quotation_to_draft()
+
+        salesman_messages = self._get_notified_messages(
+            sale_order, sale_order.user_id.partner_id
+        )
+        self.assertEqual(
+            len(salesman_messages),
+            2,
+        )
+        self.assertIn(
+            "Customer Quotation Reset to Draft", salesman_messages.mapped("subject")
+        )
+
+        sale_order.action_customer_request_quotation()
+        sale_order.action_customer_cancel_quotation()
+
+        salesman_messages = self._get_notified_messages(
+            sale_order, sale_order.user_id.partner_id
+        )
+        self.assertEqual(
+            len(salesman_messages),
+            4,
+        )
+        self.assertIn(
+            "Customer Quotation Cancelled", salesman_messages.mapped("subject")
+        )
+
+        sale_order.action_customer_reset_quotation_to_draft()
+        sale_order.action_customer_request_quotation()
+        sale_order.action_quotation_sent()
+        sale_order.action_customer_accept_quotation()
+        salesman_messages = self._get_notified_messages(
+            sale_order, sale_order.user_id.partner_id
+        )
+        self.assertEqual(
+            len(salesman_messages),
+            7,
+        )
+        self.assertIn(
+            "Customer Quotation Accepted", salesman_messages.mapped("subject")
+        )

--- a/sale_quotation_customer_quotation_workflow_notifications/tests/test_customer_quotation_workflow_subscriptions.py
+++ b/sale_quotation_customer_quotation_workflow_notifications/tests/test_customer_quotation_workflow_subscriptions.py
@@ -1,0 +1,126 @@
+# Copyright 2025 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import Command
+from odoo.tests.common import TransactionCase
+
+
+class TestCustomerQuotationWorkflowSubscriptions(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.salesman = cls.env["res.users"].create(
+            {
+                "name": "Test Sales Man",
+                "login": "test_user",
+                "email": "test_user@example.com",
+                "groups_id": [
+                    Command.set([cls.env.ref("sales_team.group_sale_salesman").id])
+                ],
+            }
+        )
+
+        cls.customer = cls.env["res.partner"].create(
+            {
+                "name": "Test Customer",
+                "email": "test_customer@example.com",
+            }
+        )
+
+        custom_quotation_subtype = cls.env.ref(
+            "sale_quotation_customer_quotation_workflow_notifications.mt_customer_quotation",
+        )
+        cls.customer_quotation_default_message_types = (
+            cls.env["mail.message.subtype"]
+            .search(
+                [
+                    ("res_model", "=", "sale.order"),
+                    ("parent_id", "=", custom_quotation_subtype.id),
+                ]
+            )
+            .filtered("default")
+        )
+
+        cls.base_default_message_types = (
+            cls.env["mail.message.subtype"]
+            .search(
+                [
+                    ("res_model", "in", [False, "sale.order"]),
+                    ("parent_id", "!=", custom_quotation_subtype.id),
+                ]
+            )
+            .filtered("default")
+        )
+
+    def _get_salesman_notification_types(self, so):
+        """Helper to retrieve the notifications subtypes of the salesman for.
+
+        a given SO.
+        """
+        salesperson_follower = so.message_follower_ids.filtered(
+            lambda f: f.partner_id == so.user_id.partner_id
+        )
+        return salesperson_follower.subtype_ids
+
+    def test_create_base_worflow_subscriptions(self):
+        """Test that the salesman is subscribed to default normal subtypes.
+
+        when creating an SO using normal workflow.
+        """
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "use_customer_quotation_workflow": False,
+                "user_id": self.salesman.id,
+            }
+        )
+        self.assertEqual(
+            self._get_salesman_notification_types(sale_order),
+            self.base_default_message_types,
+        )
+
+    def test_create_customer_quotation_worflow_subscriptions(self):
+        """Test that the salesman is subscribed to custom default subtypes.
+
+        when creating an SO using normal workflow.
+        """
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "use_customer_quotation_workflow": True,
+                "user_id": self.salesman.id,
+            }
+        )
+
+        self.assertEqual(
+            self._get_salesman_notification_types(sale_order),
+            self.customer_quotation_default_message_types,
+        )
+
+    def test_toggle_customer_quotation_workflow_subscriptions(self):
+        """Test that the salesman is subscribed to the default message types.
+
+        from the corresponding workfow when toggling the "Customer Quotation" workflow.
+        """
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "use_customer_quotation_workflow": False,
+                "user_id": self.salesman.id,
+            }
+        )
+        self.assertEqual(
+            self._get_salesman_notification_types(sale_order),
+            self.base_default_message_types,
+        )
+
+        sale_order.use_customer_quotation_workflow = True
+        self.assertEqual(
+            self._get_salesman_notification_types(sale_order),
+            self.customer_quotation_default_message_types,
+        )
+        sale_order.use_customer_quotation_workflow = False
+        self.assertEqual(
+            self._get_salesman_notification_types(sale_order),
+            self.base_default_message_types,
+        )

--- a/setup/sale_quotation_customer_quotation_workflow_notifications/odoo/addons/sale_quotation_customer_quotation_workflow_notifications
+++ b/setup/sale_quotation_customer_quotation_workflow_notifications/odoo/addons/sale_quotation_customer_quotation_workflow_notifications
@@ -1,0 +1,1 @@
+../../../../sale_quotation_customer_quotation_workflow_notifications

--- a/setup/sale_quotation_customer_quotation_workflow_notifications/setup.py
+++ b/setup/sale_quotation_customer_quotation_workflow_notifications/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,13 @@ vcrpy-unittest
 unittest2 # For shopinvader test_controller, which inherits component
 odoo-test-helper
 httpx  # For FastAPI tests
+
+# References PR: [16.0] refactor quotations rest api #1597
+odoo-addon-sale-cart @ git+ssh://git@github.com/acsone/odoo-shopinvader.git@16.0-refactor-quotations-rest-api#subdirectory=setup/sale_cart
+odoo-addon-sale-cart-quotation @ git+ssh://git@github.com/acsone/odoo-shopinvader.git@16.0-refactor-quotations-rest-api#subdirectory=setup/sale_cart_quotation
+odoo-addon-sale-quotation @ git+ssh://git@github.com/acsone/odoo-shopinvader.git@16.0-refactor-quotations-rest-api#subdirectory=setup/sale_quotation
+odoo-addon-sale-typology @ git+ssh://git@github.com/acsone/odoo-shopinvader.git@16.0-refactor-quotations-rest-api#subdirectory=setup/sale_typology
+odoo-addon-shopinvader-api-cart-quotation @ git+ssh://git@github.com/acsone/odoo-shopinvader.git@16.0-refactor-quotations-rest-api#subdirectory=setup/shopinvader_api_cart_quotation
+odoo-addon-shopinvader-api-quotation @ git+ssh://git@github.com/acsone/odoo-shopinvader.git@16.0-refactor-quotations-rest-api#subdirectory=setup/shopinvader_api_quotation
+odoo-addon-shopinvader-product-order-mode @ git+ssh://git@github.com/acsone/odoo-shopinvader.git@16.0-refactor-quotations-rest-api#subdirectory=setup/shopinvader_product_order_mode
+odoo-addon-shopinvader-product-order-mode-on-request @ git+ssh://git@github.com/acsone/odoo-shopinvader.git@16.0-refactor-quotations-rest-api#subdirectory=setup/shopinvader_product_order_mode_on_request


### PR DESCRIPTION
This PR is based on #1597

* New "Customer Quotation" message subtypes that we can subscribe partners to
* Ensures salesman receives a notification for customer quotation actions
* Returns a confirmation notification to  a customer requesting a quotation
* Notifies salesman when a user requests a quotation
* Toggles between "CQ" workflow default message types and base default message types when toggling the `use_customer_quotation_workflow` variable.

<img width="1189" height="469" alt="image" src="https://github.com/user-attachments/assets/aa615c70-9a6d-49bc-b4f0-960324c7c63e" />
<img width="1189" height="469" alt="image" src="https://github.com/user-attachments/assets/48ea12bb-75f0-4dd7-9a04-d0ebea625995" />
