### PR TITLE
[16.0] shopinvader_anonymous_partner: make deletation asynchronious

### DIFF
--- a/shopinvader_anonymous_partner/__manifest__.py
+++ b/shopinvader_anonymous_partner/__manifest__.py
@@ -10,7 +10,7 @@
     "author": "ACSONE SA/NV",
     "maintainers": [],
     "website": "https://github.com/shopinvader/odoo-shopinvader",
-    "depends": [],
+    "depends": ["queue_job"],
     "data": [],
     "demo": [],
 }

--- a/shopinvader_anonymous_partner/models/cookie_helper.py
+++ b/shopinvader_anonymous_partner/models/cookie_helper.py
@@ -54,7 +54,11 @@ class ShopinvaderAnonymousCookieHelper(models.AbstractModel):
         Delete anonymous partner and cookie
         """
         self._get_anonymous_partner__cookie(cookies).with_delay().unlink()
-        response.delete_cookie(key=COOKIE_NAME)
+        response.set_cookie(
+            key=COOKIE_NAME,
+            max_age=0,
+            expires=0,
+        )
 
     @api.model
     def _get_anonymous_partner__cookie(self, cookies: Cookies):

--- a/shopinvader_anonymous_partner/models/cookie_helper.py
+++ b/shopinvader_anonymous_partner/models/cookie_helper.py
@@ -53,12 +53,8 @@ class ShopinvaderAnonymousCookieHelper(models.AbstractModel):
         """
         Delete anonymous partner and cookie
         """
-        self._get_anonymous_partner__cookie(cookies).unlink()
-        response.set_cookie(
-            key=COOKIE_NAME,
-            max_age=0,
-            expires=0,
-        )
+        self._get_anonymous_partner__cookie(cookies).with_delay().unlink()
+        response.delete_cookie(key=COOKIE_NAME)
 
     @api.model
     def _get_anonymous_partner__cookie(self, cookies: Cookies):

--- a/shopinvader_anonymous_partner/tests/test_anonymous_partner.py
+++ b/shopinvader_anonymous_partner/tests/test_anonymous_partner.py
@@ -40,6 +40,17 @@ class TestController(Controller):
 
 
 class TestShopinvaderAnonymousPartner(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+                queue_job__no_delay=True,
+            )
+        )
+
     def test_create(self):
         cookie_helper = self.env["shopinvader_anonymous_partner.cookie.helper"]
         partner = cookie_helper._create_anonymous_partner__cookie(mock.MagicMock())
@@ -104,6 +115,17 @@ class TestShopinvaderAnonymousPartner(TransactionCase):
 
 
 class TestShopinvaderAnonymousPartnerEndToEnd(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+                queue_job__no_delay=True,
+            )
+        )
+
     def test_create_and_get_and_delete(self):
         resp = self.url_open("/test/anonymous_partner_create")
         resp.raise_for_status()

--- a/shopinvader_api_signin_jwt/tests/test_signin.py
+++ b/shopinvader_api_signin_jwt/tests/test_signin.py
@@ -16,6 +16,14 @@ class SigninCase(FastAPITransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.default_fastapi_odoo_env = cls.env(
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+                queue_job__no_delay=True,
+            )
+        )
+
         api_signin_jwt_group = cls.env.ref(
             "shopinvader_api_signin_jwt.shopinvader_signin_user_group"
         )

--- a/shopinvader_sale_cart_anonymous_partner/models/res_partner.py
+++ b/shopinvader_sale_cart_anonymous_partner/models/res_partner.py
@@ -19,6 +19,6 @@ class ResPartner(models.Model):
         )
         if anonymous_cart:
             anonymous_cart._transfer_cart(self.id)
-            anonymous_cart.unlink()
+            anonymous_cart.with_delay().unlink()
 
         return rv

--- a/shopinvader_sale_cart_anonymous_partner/tests/test_promotion.py
+++ b/shopinvader_sale_cart_anonymous_partner/tests/test_promotion.py
@@ -9,6 +9,17 @@ from odoo.addons.shopinvader_anonymous_partner.models.cookie_helper import COOKI
 
 
 class PartnerPromotionCase(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+                queue_job__no_delay=True,
+            )
+        )
+
     def test_cart_transfer_at_promotion(self):
         cookie_helper = self.env["shopinvader_anonymous_partner.cookie.helper"]
         anonymous_partner = cookie_helper._create_anonymous_partner__cookie(


### PR DESCRIPTION
By default there is too many missing index in Odoo core (also in OCA module) and on big database deleting a partner is super slow (1/2s). And it's not a common user action, so most of the time we do not care.

For sure we always have to optimize request, but I fear that new comer that test Shopinvader will just have a super bad experience. If they test it on an existing database it will be slow in 99% of case if there have a big db =W so their will just intepret that shopinvader is slow.

As we always have queue job installed, maybe it can be an acceptable dependency and solution to delete this record in background.

@lmignon @paradoxxxzero @sbidoul need your feedback (I do not have a strong opinion on this one)