### PR TITLE
shopinvader_v2_app_demo: remove useless tag.

### DIFF
--- a/shopinvader_v2_app_demo/models/fastapi_endpoint.py
+++ b/shopinvader_v2_app_demo/models/fastapi_endpoint.py
@@ -49,8 +49,6 @@ class FastapiEndpoint(models.Model):
 
     @api.model
     def _get_shopinvader_demo_fastapi_routers(self) -> List[APIRouter]:
-        if "address" not in address_router.tags:
-            address_router.tags.append("address")
         return [
             address_router,
             customer_router,


### PR DESCRIPTION
Since this commit : https://github.com/shopinvader/odoo-shopinvader/commit/3afc2fe7327e7cd1b54a1684713f2b1a0162c929

The tag is not needed anymore. Correct me if I am wrong
@AnizR  @marielejeune @lmignon 
