### PR TITLE
[16.0] [IMP] shopinvader_api_cart_options: Handle unhashable types

### DIFF
--- a/shopinvader_api_cart_options/helper.py
+++ b/shopinvader_api_cart_options/helper.py
@@ -19,10 +19,21 @@ class ShopinvaderApiCartRouterHelper(models.AbstractModel):
         """
         key = super()._get_transaction_key(transaction)
         options = tuple(SaleLineOptions._get_assembled_cls().model_fields.keys())
+
+        def freeze(value):
+            """Freeze the value to make it hashable"""
+            if isinstance(value, list):
+                return tuple(freeze(item) for item in value)
+            elif isinstance(value, dict):
+                return {k: freeze(v) for k, v in value.items()}
+            return value
+
         return namedtuple(key.__class__.__name__, key._fields + options)(
             *key,
             *tuple(
-                getattr(transaction.options, key) if transaction.options else None
+                freeze(getattr(transaction.options, key))
+                if transaction.options
+                else None
                 for key in options
             ),
         )


### PR DESCRIPTION
This prevents unashable type error when some options are of list type.