### PR TITLE
[18.0] [MIG] shopinvader_sale_cart

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,6 @@ exclude: |
   ^shopinvader_api_wishlist/|
   ^shopinvader_fastapi_auth_jwt/|
   ^shopinvader_fastapi_auth_partner/|
-  ^shopinvader_sale_cart/|
   ^shopinvader_sale_cart_anonymous_partner/|
   ^shopinvader_schema_address/|
   ^shopinvader_schema_sale/|

--- a/shopinvader_sale_cart/README.rst
+++ b/shopinvader_sale_cart/README.rst
@@ -17,13 +17,13 @@ Shopinvader Cart
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader-lightgray.png?logo=github
-    :target: https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_sale_cart
+    :target: https://github.com/shopinvader/odoo-shopinvader/tree/18.0/shopinvader_sale_cart
     :alt: shopinvader/odoo-shopinvader
 
 |badge1| |badge2| |badge3|
 
-This addon adds helper methods on the sale.older model that ease the management
-and the creation of cart from within odoo code.
+This addon adds helper methods on the sale.older model that ease the
+management and the creation of cart from within odoo code.
 
 **Table of contents**
 
@@ -36,7 +36,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/shopinvader/odoo-shopinvader/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/shopinvader/odoo-shopinvader/issues/new?body=module:%20shopinvader_sale_cart%0Aversion:%2016.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/shopinvader/odoo-shopinvader/issues/new?body=module:%20shopinvader_sale_cart%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -44,18 +44,18 @@ Credits
 =======
 
 Authors
-~~~~~~~
+-------
 
 * ACSONE SA/NV
 
 Contributors
-~~~~~~~~~~~~
+------------
 
-* Marie Lejeune <marie.lejeune@acsone.eu>
+- Marie Lejeune <marie.lejeune@acsone.eu>
 
 Maintainers
-~~~~~~~~~~~
+-----------
 
-This module is part of the `shopinvader/odoo-shopinvader <https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_sale_cart>`_ project on GitHub.
+This module is part of the `shopinvader/odoo-shopinvader <https://github.com/shopinvader/odoo-shopinvader/tree/18.0/shopinvader_sale_cart>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/shopinvader_sale_cart/__manifest__.py
+++ b/shopinvader_sale_cart/__manifest__.py
@@ -3,19 +3,17 @@
 
 {
     "name": "Shopinvader Cart",
-    "summary": """
-        ShopInvader logic for sale carts.""",
-    "version": "16.0.1.2.0",
+    "summary": "ShopInvader logic for sale carts.",
+    "version": "18.0.1.0.0",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/shopinvader/odoo-shopinvader",
     "depends": [
         "sale",
         "sale_cart",
-        "onchange_helper",
     ],
     "data": [
         "views/sale_order.xml",
     ],
-    'installable': False,
+    "installable": True,
 }

--- a/shopinvader_sale_cart/models/sale_order.py
+++ b/shopinvader_sale_cart/models/sale_order.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import uuid
 
-from odoo import api, fields, models
+from odoo import Command, api, fields, models
 
 
 class SaleOrder(models.Model):
@@ -45,16 +45,10 @@ class SaleOrder(models.Model):
         """
         return (
             self.env.ref("base.public_user")
+            .sudo()
             .partner_id.with_context(active_test=False)
             .property_product_pricelist.id
         )
-
-    @api.model
-    def _play_onchanges_cart(self, vals):
-        """
-        Play all onchanges bypassing the rules
-        """
-        return self.sudo().play_onchanges(vals, vals.keys())
 
     @api.model
     def _prepare_cart(self, partner_id):
@@ -63,7 +57,6 @@ class SaleOrder(models.Model):
             "typology": "cart",
             "partner_id": partner_id,
         }
-        vals.update(self._play_onchanges_cart(vals))
         if not vals.get("pricelist_id"):
             vals["pricelist_id"] = self._get_default_pricelist_id()
         return vals
@@ -89,13 +82,11 @@ class SaleOrder(models.Model):
             if line:
                 new_qty = line.product_uom_qty + cart_line.product_uom_qty
                 vals = {"product_uom_qty": new_qty}
-                vals.update(line._play_onchanges_cart_line(vals))
-                cmd = (1, line.id, vals)
+                cmd = (Command.UPDATE, line.id, vals)
             else:
                 vals = cart_line._prepare_cart_line_transfer_values()
                 vals["order_id"] = self.id
-                vals.update(self.env["sale.order.line"]._play_onchanges_cart_line(vals))
-                cmd = (0, None, vals)
+                cmd = (Command.CREATE, None, vals)
             update_cmds.append(cmd)
         self.write({"order_line": update_cmds})
 

--- a/shopinvader_sale_cart/models/sale_order_line.py
+++ b/shopinvader_sale_cart/models/sale_order_line.py
@@ -1,15 +1,11 @@
 # Copyright 2023 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import models
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
-
-    @api.model
-    def _play_onchanges_cart_line(self, vals):
-        return self.sudo().play_onchanges(vals, vals.keys())
 
     def _prepare_cart_line_transfer_values(self):
         """

--- a/shopinvader_sale_cart/pyproject.toml
+++ b/shopinvader_sale_cart/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/shopinvader_sale_cart/readme/CONTRIBUTORS.md
+++ b/shopinvader_sale_cart/readme/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+- Marie Lejeune \<marie.lejeune@acsone.eu\>

--- a/shopinvader_sale_cart/readme/CONTRIBUTORS.rst
+++ b/shopinvader_sale_cart/readme/CONTRIBUTORS.rst
@@ -1,1 +1,0 @@
-* Marie Lejeune <marie.lejeune@acsone.eu>

--- a/shopinvader_sale_cart/readme/DESCRIPTION.md
+++ b/shopinvader_sale_cart/readme/DESCRIPTION.md
@@ -1,0 +1,2 @@
+This addon adds helper methods on the sale.older model that ease the
+management and the creation of cart from within odoo code.

--- a/shopinvader_sale_cart/readme/DESCRIPTION.rst
+++ b/shopinvader_sale_cart/readme/DESCRIPTION.rst
@@ -1,2 +1,0 @@
-This addon adds helper methods on the sale.older model that ease the management
-and the creation of cart from within odoo code.

--- a/shopinvader_sale_cart/static/description/index.html
+++ b/shopinvader_sale_cart/static/description/index.html
@@ -369,9 +369,9 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:15278093ab897beb9fa86a670655f38c860baecc6a9c1fdc912b2cfd7ca4b1aa
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_sale_cart"><img alt="shopinvader/odoo-shopinvader" src="https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader-lightgray.png?logo=github" /></a></p>
-<p>This addon adds helper methods on the sale.older model that ease the management
-and the creation of cart from within odoo code.</p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/shopinvader/odoo-shopinvader/tree/18.0/shopinvader_sale_cart"><img alt="shopinvader/odoo-shopinvader" src="https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader-lightgray.png?logo=github" /></a></p>
+<p>This addon adds helper methods on the sale.older model that ease the
+management and the creation of cart from within odoo code.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -389,7 +389,7 @@ and the creation of cart from within odoo code.</p>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/issues/new?body=module:%20shopinvader_sale_cart%0Aversion:%2016.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/issues/new?body=module:%20shopinvader_sale_cart%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -408,7 +408,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_sale_cart">shopinvader/odoo-shopinvader</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/tree/18.0/shopinvader_sale_cart">shopinvader/odoo-shopinvader</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/shopinvader_sale_cart/tests/test_sale_cart.py
+++ b/shopinvader_sale_cart/tests/test_sale_cart.py
@@ -25,13 +25,13 @@ class TestSaleCart(TestSaleCartBase):
         self.assertEqual(len(merged_cart.order_line), 2)
         self.assertEqual(
             merged_cart.order_line.filtered(
-                lambda l, product=self.product: l.product_id.id == product.id
+                lambda sol, product=self.product: sol.product_id.id == product.id
             ).product_uom_qty,
             2,
         )
         self.assertEqual(
             merged_cart.order_line.filtered(
-                lambda l, product=product_2: l.product_id.id == product.id
+                lambda sol, product=product_2: sol.product_id.id == product.id
             ).product_uom_qty,
             1,
         )

--- a/shopinvader_sale_cart/views/sale_order.xml
+++ b/shopinvader_sale_cart/views/sale_order.xml
@@ -2,7 +2,6 @@
 <!-- Copyright 2022 ACSONE SA/NV
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
-
     <record model="ir.ui.view" id="sale_order_form_view">
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form" />
@@ -12,7 +11,4 @@
             </group>
         </field>
     </record>
-
-
-
 </odoo>


### PR DESCRIPTION
**This migration has an important change** : 
`onchange_helper` has been removed since there's no important onchange in sales in odoo core.

Depends on 
  - #1618 