### PR TITLE
[18.0] [UPD] test_requirements.txt: Use httpx2

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,4 +4,4 @@ vcrpy
 vcrpy-unittest
 unittest2 # For shopinvader test_controller, which inherits component
 odoo-test-helper
-httpx  # For FastAPI tests
+httpx2  # For FastAPI tests


### PR DESCRIPTION
With recent starlette version, httpx emit a deprecation warning.