### PR TITLE
[16.0][FIX] shopincader_api_cart: Fix idempotency of cart transaction sync

### DIFF
--- a/shopinvader_api_cart/routers/cart.py
+++ b/shopinvader_api_cart/routers/cart.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Response
 
 from odoo import _, api, models
-from odoo.exceptions import MissingError
+from odoo.exceptions import MissingError, UserError
 from odoo.tools import float_compare
 
 from odoo.addons.base.models.res_partner import Partner as ResPartner
@@ -243,11 +243,58 @@ class ShopinvaderApiCartRouterHelper(models.AbstractModel):
         return vals
 
     @api.model
+    def _get_applied_transaction_uuids(self, cart: SaleOrder) -> set:
+        """Return the set of transaction uuids already applied on the cart."""
+        if not cart.applied_cart_api_transaction_uuids:
+            return set()
+        return set(cart.applied_cart_api_transaction_uuids.split(","))
+
+    @api.model
+    def _filter_new_transactions(
+        self, cart: SaleOrder, transactions: list[CartTransaction]
+    ) -> list[CartTransaction]:
+        """Drop the transactions already applied on the cart and check that
+        the remaining ones were never applied either.
+
+        Transactions are expected in the order they occurred. A client may
+        resend a batch that overlaps with what was already synced (for
+        example after a lost response), so we skip the leading transactions
+        already known and keep everything from the first unknown one on. If
+        an already applied transaction appears after that point, the received
+        order is inconsistent with what the cart knows: applying it again
+        would add the same quantity delta a second time, so we raise a
+        UserError.
+        """
+        applied = self._get_applied_transaction_uuids(cart)
+        if not applied:
+            return transactions
+        boundary = 0
+        for index, transaction in enumerate(transactions):
+            if transaction.uuid and str(transaction.uuid) in applied:
+                boundary = index + 1
+            else:
+                break
+        residual = transactions[boundary:]
+        for transaction in residual:
+            if transaction.uuid and str(transaction.uuid) in applied:
+                raise UserError(
+                    _(
+                        "Transaction %(uuid)s was already applied to this "
+                        "cart but is received out of order."
+                    )
+                    % {"uuid": transaction.uuid}
+                )
+        return residual
+
+    @api.model
     def _apply_transactions(self, cart, transactions: list[CartTransaction]):
         """Apply transactions to the given cart."""
         if not transactions:
             return
         cart.ensure_one()
+        transactions = self._filter_new_transactions(cart, transactions)
+        if not transactions:
+            return
         self._check_transactions(transactions=transactions)
         # prefetch all products
         self.env["product.product"].browse({tx.product_id for tx in transactions})
@@ -269,13 +316,12 @@ class ShopinvaderApiCartRouterHelper(models.AbstractModel):
             if cmd:
                 update_cmds.append(cmd)
 
-        all_transaction_uuids = transaction_uuids = [
-            str(t.uuid) for t in transactions if t.uuid
-        ]
+        new_transaction_uuids = [str(t.uuid) for t in transactions if t.uuid]
+        all_transaction_uuids = new_transaction_uuids
         if cart.applied_cart_api_transaction_uuids:
             all_transaction_uuids = [
                 cart.applied_cart_api_transaction_uuids
-            ] + transaction_uuids
+            ] + new_transaction_uuids
         vals = {"applied_cart_api_transaction_uuids": ",".join(all_transaction_uuids)}
         if update_cmds:
             vals["order_line"] = update_cmds

--- a/shopinvader_api_cart/tests/test_shopinvader_api_cart.py
+++ b/shopinvader_api_cart/tests/test_shopinvader_api_cart.py
@@ -7,7 +7,7 @@
 from fastapi import status
 from requests import Response
 
-from odoo.exceptions import AccessError, MissingError
+from odoo.exceptions import AccessError, MissingError, UserError
 from odoo.tests.common import RecordCapturer
 
 from ..routers.cart import cart_router
@@ -277,6 +277,74 @@ class TestSaleCart(CommonSaleCart):
             test_client.post(f"/{so.uuid}/sync", json=data)
         line = so.order_line
         self.assertEqual(0, len(line))
+
+    def test_sync_retry_skips_already_applied_leading_transactions(self) -> None:
+        """
+        A client retrying a batch after a lost response may resend
+        transactions that were already applied, followed by new
+        ones. The already applied ones must be skipped, not re-applied.
+        """
+        so = self.env["sale.order"]._create_empty_cart(
+            self.default_fastapi_authenticated_partner.id
+        )
+        data = {
+            "transactions": [
+                {"uuid": self.trans_uuid_1, "product_id": self.product_1.id, "qty": 1},
+                {"uuid": self.trans_uuid_2, "product_id": self.product_1.id, "qty": 3},
+            ]
+        }
+        with self._create_test_client(router=cart_router) as test_client:
+            test_client.post(f"/{so.uuid}/sync", json=data)
+        line = so.order_line
+        self.assertEqual(4, line.product_uom_qty)
+
+        # Retry with the same 2 already applied transactions, plus one new
+        data = {
+            "transactions": [
+                {"uuid": self.trans_uuid_1, "product_id": self.product_1.id, "qty": 1},
+                {"uuid": self.trans_uuid_2, "product_id": self.product_1.id, "qty": 3},
+                {"uuid": self.trans_uuid_3, "product_id": self.product_1.id, "qty": 2},
+            ]
+        }
+        with self._create_test_client(router=cart_router) as test_client:
+            test_client.post(f"/{so.uuid}/sync", json=data)
+        line = so.order_line
+        # Only trans_uuid_3's delta (+2) should have been applied, not a
+        # second time trans_uuid_1/2's deltas (+1/+3).
+        self.assertEqual(6, line.product_uom_qty)
+        self.assertEqual(
+            so.applied_cart_api_transaction_uuids,
+            f"{self.trans_uuid_1},{self.trans_uuid_2},{self.trans_uuid_3}",
+        )
+
+    def test_sync_out_of_order_already_applied_transaction_raises(self) -> None:
+        """
+        An already applied transaction showing up after an unknown one in
+        the received list is an inconsistent replay: order matters, so we
+        must not silently skip or re-apply it.
+        """
+        so = self.env["sale.order"]._create_empty_cart(
+            self.default_fastapi_authenticated_partner.id
+        )
+        data = {
+            "transactions": [
+                {"uuid": self.trans_uuid_1, "product_id": self.product_1.id, "qty": 1},
+            ]
+        }
+        with self._create_test_client(router=cart_router) as test_client:
+            test_client.post(f"/{so.uuid}/sync", json=data)
+
+        data = {
+            "transactions": [
+                {"uuid": self.trans_uuid_2, "product_id": self.product_1.id, "qty": 3},
+                {"uuid": self.trans_uuid_1, "product_id": self.product_1.id, "qty": 1},
+            ]
+        }
+        with (
+            self._create_test_client(router=cart_router) as test_client,
+            self.assertRaises(UserError),
+        ):
+            test_client.post(f"/{so.uuid}/sync", json=data)
 
     def test_multi_transactions_same_product(self) -> None:
         so = self.env["sale.order"]._create_empty_cart(

--- a/shopinvader_api_sale_loyalty/tests/test_apply_coupon_or_reward.py
+++ b/shopinvader_api_sale_loyalty/tests/test_apply_coupon_or_reward.py
@@ -36,7 +36,6 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         cls.cart = cls.env["sale.order"]._create_empty_cart(
             cls.default_fastapi_authenticated_partner.id
         )
-        cls.dummy_uuid = str(uuid.uuid4())
 
     def _create_promotion_program_A_B(self):
         # Configure a new promotion program: when 1A and 1B are in the cart,
@@ -97,7 +96,11 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         with self._create_test_client(router=cart_router) as test_client:
             data = {
                 "transactions": [
-                    {"uuid": self.dummy_uuid, "product_id": self.product_A.id, "qty": 1}
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "product_id": self.product_A.id,
+                        "qty": 1,
+                    }
                 ]
             }
             response: Response = test_client.post("/sync", json=data)
@@ -125,7 +128,7 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
             data = {
                 "transactions": [
                     {
-                        "uuid": self.dummy_uuid,
+                        "uuid": str(uuid.uuid4()),
                         "product_id": self.product_A.id,
                         "qty": -1,
                     }
@@ -155,7 +158,11 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         with self._create_test_client(router=cart_router) as test_client:
             data = {
                 "transactions": [
-                    {"uuid": self.dummy_uuid, "product_id": self.product_A.id, "qty": 1}
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "product_id": self.product_A.id,
+                        "qty": 1,
+                    }
                 ]
             }
             response: Response = test_client.post("/sync", json=data)
@@ -178,7 +185,11 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         with self._create_test_client(router=cart_router) as test_client:
             data = {
                 "transactions": [
-                    {"uuid": self.dummy_uuid, "product_id": self.product_B.id, "qty": 1}
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "product_id": self.product_B.id,
+                        "qty": 1,
+                    }
                 ]
             }
             response: Response = test_client.post("/sync", json=data)
@@ -203,7 +214,7 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
             data = {
                 "transactions": [
                     {
-                        "uuid": self.dummy_uuid,
+                        "uuid": str(uuid.uuid4()),
                         "product_id": self.product_A.id,
                         "qty": -1,
                     }
@@ -232,7 +243,11 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         with self._create_test_client(router=cart_router) as test_client:
             data = {
                 "transactions": [
-                    {"uuid": self.dummy_uuid, "product_id": self.product_C.id, "qty": 1}
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "product_id": self.product_C.id,
+                        "qty": 1,
+                    }
                 ]
             }
             response: Response = test_client.post("/sync", json=data)
@@ -283,7 +298,7 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
             data = {
                 "transactions": [
                     {
-                        "uuid": self.dummy_uuid,
+                        "uuid": str(uuid.uuid4()),
                         "product_id": self.product_C.id,
                         "qty": 1,
                     }
@@ -331,7 +346,11 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         with self._create_test_client(router=cart_router) as test_client:
             data = {
                 "transactions": [
-                    {"uuid": self.dummy_uuid, "product_id": self.product_A.id, "qty": 1}
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "product_id": self.product_A.id,
+                        "qty": 1,
+                    }
                 ]
             }
             response: Response = test_client.post("/sync", json=data)
@@ -400,7 +419,11 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         with self._create_test_client(router=cart_router) as test_client:
             data = {
                 "transactions": [
-                    {"uuid": self.dummy_uuid, "product_id": self.product_B.id, "qty": 2}
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "product_id": self.product_B.id,
+                        "qty": 2,
+                    }
                 ]
             }
             response: Response = test_client.post("/sync", json=data)
@@ -419,7 +442,11 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         with self._create_test_client(router=cart_router) as test_client:
             data = {
                 "transactions": [
-                    {"uuid": self.dummy_uuid, "product_id": self.product_A.id, "qty": 1}
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "product_id": self.product_A.id,
+                        "qty": 1,
+                    }
                 ]
             }
             test_client.post("/sync", json=data)
@@ -452,7 +479,11 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         with self._create_test_client(router=cart_router) as test_client:
             data = {
                 "transactions": [
-                    {"uuid": self.dummy_uuid, "product_id": self.product_A.id, "qty": 1}
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "product_id": self.product_A.id,
+                        "qty": 1,
+                    }
                 ]
             }
             response: Response = test_client.post("/sync", json=data)
@@ -488,7 +519,11 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         with self._create_test_client(router=cart_router) as test_client:
             data = {
                 "transactions": [
-                    {"uuid": self.dummy_uuid, "product_id": self.product_A.id, "qty": 1}
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "product_id": self.product_A.id,
+                        "qty": 1,
+                    }
                 ]
             }
             response: Response = test_client.post("/sync", json=data)
@@ -539,7 +574,11 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         with self._create_test_client(router=cart_router) as test_client:
             data = {
                 "transactions": [
-                    {"uuid": self.dummy_uuid, "product_id": self.product_A.id, "qty": 1}
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "product_id": self.product_A.id,
+                        "qty": 1,
+                    }
                 ]
             }
             response: Response = test_client.post("/sync", json=data)
@@ -591,7 +630,11 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         with self._create_test_client(router=cart_router) as test_client:
             data = {
                 "transactions": [
-                    {"uuid": self.dummy_uuid, "product_id": self.product_A.id, "qty": 1}
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "product_id": self.product_A.id,
+                        "qty": 1,
+                    }
                 ]
             }
             test_client.post("/sync", json=data)
@@ -645,7 +688,11 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         with self._create_test_client(router=cart_router) as test_client:
             data = {
                 "transactions": [
-                    {"uuid": self.dummy_uuid, "product_id": self.product_A.id, "qty": 1}
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "product_id": self.product_A.id,
+                        "qty": 1,
+                    }
                 ]
             }
             response: Response = test_client.post("/sync", json=data)
@@ -701,7 +748,11 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         with self._create_test_client(router=cart_router) as test_client:
             data = {
                 "transactions": [
-                    {"uuid": self.dummy_uuid, "product_id": self.product_A.id, "qty": 1}
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "product_id": self.product_A.id,
+                        "qty": 1,
+                    }
                 ]
             }
             response: Response = test_client.post("/sync", json=data)
@@ -733,7 +784,11 @@ class TestLoyaltyCard(TestShopinvaderSaleLoyaltyCommon):
         with self._create_test_client(router=cart_router) as test_client:
             data = {
                 "transactions": [
-                    {"uuid": self.dummy_uuid, "product_id": self.product_A.id, "qty": 1}
+                    {
+                        "uuid": str(uuid.uuid4()),
+                        "product_id": self.product_A.id,
+                        "qty": 1,
+                    }
                 ]
             }
             response: Response = test_client.post("/sync", json=data)


### PR DESCRIPTION
_apply_transactions never filtered incoming transactions against already-applied uuids, so a client retrying a batch after a lost response would re-apply quantity deltas a second time. Skip already known leading transactions and raise if an already-applied uuid reappears out of order in the remaining batch.